### PR TITLE
Stabilize desktop i18n catalog references

### DIFF
--- a/apps/desktop/lingui.config.ts
+++ b/apps/desktop/lingui.config.ts
@@ -1,4 +1,5 @@
 import { defineConfig } from "@lingui/cli";
+import { formatter } from "@lingui/format-po";
 
 export default defineConfig({
   sourceLocale: "en",
@@ -114,6 +115,7 @@ export default defineConfig({
     "zu",
   ],
   compileNamespace: "ts",
+  format: formatter({ lineNumbers: false }),
   fallbackLocales: {
     default: "en",
   },

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -123,6 +123,7 @@
     "@dotenvx/dotenvx": "^1.61.0",
     "@lingui/babel-plugin-lingui-macro": "^6.0.1",
     "@lingui/cli": "^6.0.1",
+    "@lingui/format-po": "^6.0.1",
     "@lingui/vite-plugin": "^6.0.1",
     "@rolldown/plugin-babel": "^0.2.3",
     "@tanstack/react-router-devtools": "^1.166.13",

--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Voeg taal by"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Voeg gesproke taal by"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Bykomende gesproke tale"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Altyd gereed sonder om handmatig te begin."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Toepassing"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Begin outomaties luister wanneer 'n gebeurtenis-gesteunde noot sy geskeduleerde begintyd bereik."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Hou outomaties op om te luister wanneer die vergaderingprogram die mikrofoon vrystel."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Taal en streek"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Taal vir opsommings, kletse en KI-gegenereerde antwoorde"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hooftaal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Vergaderings"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Geen passende tale gevind nie"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Kennisgewings"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Soek taal..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Kies taal"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Stuur anonieme gebruikontledings om Anarlog te help verbeter."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Deel gebruiksdata"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Wys die kompakte drywende beheer terwyl jy luister."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Begin Anarlog by aanmelding"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Begin wanneer vergadering begin"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stop wanneer vergadering eindig"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Die hooftaal is altyd ingesluit vir transkripsie"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ቋንቋ አክል"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "የሚነገር ቋንቋ ያክሉ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ተጨማሪ የሚነገሩ ቋንቋዎች"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "እራስዎ ሳይጀመር ሁልጊዜ ዝግጁ።"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "መተግበሪያ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "በክስተት የተደገፈ ማስታወሻ የተያዘለት የመጀመሪያ ሰዓቱ ሲደርስ በራስ-ሰር ማዳመጥ ይጀምሩ።"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "የስብሰባው መተግበሪያ ማይክሮፎኑን ሲለቅ በራስ-ሰር ማዳመጥ ያቁሙ።"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ቋንቋ እና ክልል"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ቋንቋ ለማጠቃለያዎች፣ ውይይቶች እና በAI-የተፈጠሩ ምላሾች"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ዋና ቋንቋ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ስብሰባዎች"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ምንም ተዛማጅ ቋንቋዎች አልተገኙም"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "ማሳወቂያዎች"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ቋንቋ ፈልግ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ቋንቋ ምረጥ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "አናሎግ ለማሻሻል ለማገዝ ስም-አልባ የአጠቃቀም ትንታኔዎችን ይላኩ።"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "የአጠቃቀም ውሂብ አጋራ"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "በማዳመጥ ጊዜ የታመቀ ተንሳፋፊ መቆጣጠሪያውን አሳይ።"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "በመግቢያው ላይ አናርሎግ ይጀምሩ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ስብሰባ ሲጀምር ጀምር"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ስብሰባው ሲያልቅ ያቁሙ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ዋናው ቋንቋ ሁል ጊዜ ለጽሑፍ ግልባጭ ተካቷል"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "إضافة لغة"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "إضافة لغة منطوقة"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "اللغات المنطوقة الإضافية"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "جاهز دائمًا بدون التشغيل يدويًا."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "التطبيق"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ابدأ الاستماع تلقائيًا عندما تصل ملاحظة مدعومة بالحدث إلى وقت البدء المحدد لها."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "إيقاف الاستماع تلقائيًا عندما يقوم تطبيق الاجتماع بتحرير الميكروفون."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "اللغة والمنطقة"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "لغة الملخصات والمحادثات والاستجابات التي ينشئها الذكاء الاصطناعي"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "اللغة الرئيسية"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "الاجتماعات"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "لم يتم العثور على لغات مطابقة"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "الإشعارات"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "لغة البحث..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "حدد اللغة"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "أرسل تحليلات استخدام مجهولة المصدر للمساعدة في تحسين Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "مشاركة بيانات الاستخدام"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "إظهار عنصر التحكم العائم المدمج أثناء الاستماع."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ابدأ Anarlog عند تسجيل الدخول"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ابدأ عندما يبدأ الاجتماع"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "توقف عند انتهاء الاجتماع"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "يتم تضمين اللغة الرئيسية دائمًا في عملية النسخ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ভাষা যোগ কৰক"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "কথিত ভাষা যোগ কৰক"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "অতিৰিক্ত কথিত ভাষা"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "হস্তচালিতভাৱে আৰম্ভ নকৰাকৈ সদায় সাজু।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "এপ্প"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "স্বয়ংক্ৰিয়ভাৱে শুনা আৰম্ভ কৰক যেতিয়া এটা ইভেন্ট-সমৰ্থিত টোকা ইয়াৰ নিৰ্ধাৰিত আৰম্ভণি সময় পোৱা যায়।"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "মিটিং এপে মাইক্ৰ'ফোন মুকলি কৰাৰ সময়ত স্বয়ংক্ৰিয়ভাৱে শুনা বন্ধ কৰক।"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ভাষা আৰু অঞ্চল"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "সাৰাংশ, আড্ডা, আৰু AI-উৎপন্ন সঁহাৰিৰ বাবে ভাষা"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "মূল ভাষা"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "সভাসমূহ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "কোনো মিল থকা ভাষা পোৱা নগ'ল"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "জাননীসমূহ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "অন্বেষণ ভাষা..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ভাষা নিৰ্বাচন কৰক"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog উন্নত কৰাত সহায় কৰিবলে বেনামী ব্যৱহাৰ বিশ্লেষণ পঠাওক।"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ব্যৱহাৰৰ তথ্য অংশীদাৰী কৰক"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "শুনি থকাৰ সময়ত কমপেক্ট ভাসমান নিয়ন্ত্ৰণ দেখুৱাওক।"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "প্ৰৱেশৰ সময়ত Anarlog আৰম্ভ কৰক"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "মিটিং আৰম্ভ হ'লে আৰম্ভ কৰক"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "মিটিং শেষ হ'লে বন্ধ কৰক"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "প্ৰধান ভাষাটো সদায় লিপিবদ্ধ কৰাৰ বাবে অন্তৰ্ভুক্ত কৰা হয়"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dil əlavə edin"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Danışıq dili əlavə edin"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Əlavə danışıq dilləri"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Əl ilə işə salmadan həmişə hazırdır."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Tətbiq"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Tədbirlə dəstəklənən qeyd planlaşdırılan başlama vaxtına çatdıqda avtomatik olaraq dinləməyə başlayın."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Görüş proqramı mikrofonu buraxdıqda avtomatik olaraq dinləməni dayandırın."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Dil və Region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Xülasələr, söhbətlər və AI tərəfindən yaradılan cavablar üçün dil"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Əsas dil"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Görüşlər"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Uyğun dil tapılmadı"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Bildirişlər"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Dil axtarın..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Dil seçin"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarloqu təkmilləşdirməyə kömək etmək üçün anonim istifadə analitikasını göndərin."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "İstifadə datasını paylaşın"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Qulaq asarkən kompakt üzən idarəetməni göstərin."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Giriş zamanı Analoqu başladın"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Görüş başlayanda başlayın"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Görüş bitəndə dayandırın"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Əsas dil həmişə transkripsiya üçün daxil edilir"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Тел өҫтәү"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Һөйләү телен өҫтәү"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Өҫтәмә һөйләү телдәре"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ҡул менән эшләтеп ебәрмәйенсә һәр ваҡыт әҙер."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ҡушымта"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Ваҡиғалар менән нығытылған иҫкәрмә планлаштырылған башланғыс ваҡытҡа еткәс, автоматик рәүештә тыңлауҙы башлай."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Осрашыу ҡушымтаһы микрофонды бушатҡас, тыңлауҙы автоматик рәүештә туҡтата."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Тел һәм төбәк"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Йомғаҡлау, чаттар һәм ЯИ-генерацияланған яуаптар өсөн тел"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Төп тел"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Осрашыуҙар"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Тап килгән телдәр табылмаған"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Хәбәр итеүҙәр"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Эҙләү теле..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Телде һайлау"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Анарлогты яҡшыртыу өсөн аноним ҡулланыу аналитикаһын ебәрегеҙ."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Ҡулланыу мәғлүмәттәре менән уртаҡлашыу"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Тыңлағанда компактлы йөҙөүсе идара итеү ҡоролмаһын күрһәтегеҙ."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Логин ваҡытында Анарлогты башлағыҙ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Осрашыу башланғас башла"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Осрашыу тамамланғас туҡта"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Төп тел транскрипция өсөн һәр ваҡыт индерелә"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Дадаць мову"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Дадаць гутарковую мову"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Дадатковыя размоўныя мовы"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Заўсёды гатовы без ручнога запуску."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Прыкладанне"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Аўтаматычны пачатак праслухоўвання, калі нататка, якая падтрымліваецца падзеяй, надыходзіць запланаваны час пачатку."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Аўтаматычна спыняць праслухоўванне, калі праграма сустрэчы адпускае мікрафон."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Мова і рэгіён"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Мова для зводак, чатаў і адказаў, згенераваных штучным інтэлектам"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Асноўная мова"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Сустрэчы"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Не знойдзена адпаведных моў"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Апавяшчэнні"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Мова пошуку..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Выбраць мову"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Адпраўляць ананімную аналітыку выкарыстання, каб дапамагчы палепшыць Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Абагульваць дадзеныя аб выкарыстанні"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Паказваць кампактны плаваючы элемент кіравання падчас праслухоўвання."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Запусціць Anarlog пры ўваходзе ў сістэму"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Пачаць, калі пачынаецца сустрэча"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Спыніцца, калі сустрэча скончыцца"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Асноўная мова заўсёды ўключаецца ў транскрыпцыю"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Добавяне на език"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Добавяне на говорим език"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Допълнителни говорими езици"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Винаги готов без ръчно стартиране."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Приложение"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Автоматично започване на прослушване, когато подкрепена от събитие бележка достигне планирания си начален час."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Автоматично спиране на слушането, когато приложението за срещи освободи микрофона."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Език и регион"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Език за резюмета, чатове и генерирани от AI отговори"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Основен език"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Срещи"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Няма намерени съответстващи езици"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Известия"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Език за търсене..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Избор на език"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Изпращайте анонимни анализи на използването, за да помогнете за подобряването на Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Споделяне на данни за използване"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Показване на компактния плаващ контрол, докато слушате."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Стартирайте Anarlog при влизане"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Започнете, когато срещата започне"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Спрете, когато срещата приключи"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Основният език винаги е включен за транскрипция"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ভাষা যোগ করুন"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "কথ্য ভাষা যোগ করুন"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "অতিরিক্ত কথ্য ভাষা"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ম্যানুয়ালি লঞ্চ না করে সর্বদা প্রস্তুত।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "অ্যাপ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "একটি ইভেন্ট-ব্যাকড নোট তার নির্ধারিত শুরুর সময়ে পৌঁছে গেলে স্বয়ংক্রিয়ভাবে শোনা শুরু করুন।"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "মিটিং অ্যাপ মাইক্রোফোন প্রকাশ করলে স্বয়ংক্রিয়ভাবে শোনা বন্ধ করুন।"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ভাষা ও অঞ্চল"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "সারাংশ, চ্যাট এবং এআই-উত্পন্ন প্রতিক্রিয়াগুলির জন্য ভাষা"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "প্রধান ভাষা"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "মিটিং"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "কোন মিলিত ভাষা পাওয়া যায়নি"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "বিজ্ঞপ্তি"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ভাষা খুঁজুন..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ভাষা নির্বাচন করুন"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "অ্যানারলগ উন্নত করতে সাহায্য করার জন্য বেনামী ব্যবহার বিশ্লেষণ পাঠান।"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ব্যবহারের ডেটা শেয়ার করুন"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "শোনার সময় কমপ্যাক্ট ফ্লোটিং কন্ট্রোল দেখান।"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "লগইনে অ্যানারলগ শুরু করুন"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "মিটিং শুরু হলে শুরু করুন"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "মিটিং শেষ হলে থামুন"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "প্রধান ভাষা সর্বদা ট্রান্সক্রিপশনের জন্য অন্তর্ভুক্ত করা হয়"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "སྐད་ཡིག་ཁ་སྣོན"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "སྐད་ཆའི་སྐད་ཡིག་ཁ་སྣོན"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ཁ་སྣོན་གྱི་སྐད་ཆ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ལག་ཐོག་ནས་འགོ་མ་བཙུགས་པར་ག་དུས་ཡིན་ཡང་གྲ་སྒྲིག་ཡོད།"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "མཉེན་ཆས།"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "བྱུང་རིམ་རྒྱབ་སྐྱོར་བྱས་པའི་དྲན་ཐོ་ཞིག་དུས་ཚོད་གཏན་འཁེལ་བྱས་པའི་འགོ་འཛུགས་དུས་ཚོད་ལ་སླེབས་སྐབས་རང་འགུལ་གྱིས་ཉན་འགོ་ཚུགས།"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "ཚོགས་འདུའི་མཉེན་ཆས་ཀྱིས་སྐད་འཕྲིན་གློད་དུས་རང་འགུལ་གྱིས་ཉན་མཚམས་འཇོག་གི་ཡོད།"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "སྐད་ཡིག་དང་ས་ཁུལ།"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "སྙིང་བསྡུས་དང་། ཁ་བརྡ། AI ཡིས་བཟོས་པའི་ལན་འདེབས་ཀྱི་སྐད་ཡིག"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "སྐད་ཡིག་གཙོ་བོ།"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ཚོགས་འདུ།"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "མཐུན་པའི་སྐད་ཡིག་མ་རྙེད།"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "བརྡ་ཐོ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "འཚོལ་ཞིབ་སྐད་ཡིག..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "སྐད་ཡིག་འདེམས།"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "མིང་མེད་པའི་བེད་སྤྱོད་དབྱེ་ཞིབ་གཏོང་ནས་ཨ་ནར་ལོག་ཡར་རྒྱས་གཏོང་བར་ཕན་ཐོགས།"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "བེད་སྤྱོད་ཀྱི་གཞི་གྲངས་མཉམ་སྤྱོད།"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ཉན་པའི་སྐབས་སུ་འཕྱོ་བའི་ཚོད་འཛིན་ཆུང་ཆུང་དེ་སྟོན།"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ནང་འཇུག་བྱེད་སྐབས་ཨ་ནར་ལོག་འགོ་འཛུགས།"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ཚོགས་འདུ་འགོ་འཛུགས་སྐབས་འགོ་འཛུགས།"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ཚོགས་འདུ་གྲོལ་རྗེས་མཚམས་འཇོག་དགོས།"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ཡིག་བསྒྱུར་གྱི་ཆེད་དུ་སྐད་ཡིག་གཙོ་བོ་ནི་རྟག་ཏུ་ཚུད་ཡོད།"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ouzhpennañ ur yezh"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ouzhpennañ ar yezh komzet"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Yezhoù komzet ouzhpenn"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Prest atav hep loc'hañ dre zorn."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Arload"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Kregiñ a ra ar selaou ent emgefre pa erru un notenn skoret gant un darvoud d'an eur loc'hañ rakwelet."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Paouez da selaou ent emgefre pa vo laosket ar mikro gant an arload emvod."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Yezh & Rannvro"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Yezh evit an diverrañ, ar flapañ hag ar respontoù krouet gant IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Yezh pennañ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Emvodoù"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "N'eus bet kavet yezh ebet a glot"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Kemennadennoù"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Klask yezh..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Dibab yezh"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Kas dielfennadurioù implij dizanv evit sikour da wellaat Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Rannañ roadennoù implij"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Diskouez ar c'hontroll neuial bihan e-pad ma selaouer."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Kregiñ gant an Anarlog pa vez kevreet"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Kregiñ pa grogo an emvod"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Paouez pa vo echu an emvod"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Lakaet e vez atav ar yezh pennañ evit an treuzskrivadur"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dodaj jezik"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Dodaj govorni jezik"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Dodatni govorni jezici"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Uvijek spreman bez ručnog pokretanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikacija"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatski počnite slušati kada bilješka podržana događajem dostigne zakazano vrijeme početka."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatski zaustavi slušanje kada aplikacija za sastanak pusti mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Jezik i regija"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Jezik za sažetke, razgovore i odgovore generirane umjetnom inteligencijom"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Glavni jezik"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Sastanci"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nije pronađen nijedan odgovarajući jezik"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Obaveštenja"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Pretraži jezik..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Odaberite jezik"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Pošaljite anonimnu analitiku korištenja da pomognete poboljšanju Anarloga."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Dijelite podatke o korištenju"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Prikaži kompaktnu plutajuću kontrolu dok slušate."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Pokreni Anarlog pri prijavi"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Započni kada sastanak počne"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Zaustavi kada sastanak završi"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Glavni jezik je uvijek uključen za transkripciju"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Afegeix un idioma"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Afegeix un idioma parlat"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Idiomes parlats addicionals"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Sempre a punt sense iniciar-lo manualment."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplicació"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Comença a escoltar automàticament quan una nota amb el suport d'un esdeveniment arriba a l'hora d'inici programada."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Deixa d'escoltar automàticament quan l'aplicació de reunió alliberi el micròfon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Idioma i regió"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Idioma per a resums, xats i respostes generades per IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Idioma principal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Reunions"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "No s'han trobat idiomes coincidents"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Cerca l'idioma..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Seleccioneu l'idioma"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Envieu analítiques d'ús anònimes per ajudar a millorar Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Comparteix les dades d'ús"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Mostra el control flotant compacte mentre escoltes."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Inicieu Anarlog en iniciar sessió"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Comenceu quan comenci la reunió"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Atura't quan acabi la reunió"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "L'idioma principal sempre s'inclou per a la transcripció"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Přidat jazyk"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Přidat mluvený jazyk"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Další mluvené jazyky"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Vždy připraven bez ručního spouštění."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikace"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automaticky začít poslouchat, když poznámka podporovaná událostí dosáhne svého plánovaného času zahájení."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automaticky přestat poslouchat, když schůzková aplikace uvolní mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Jazyk a oblast"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Jazyk pro shrnutí, chaty a odpovědi generované umělou inteligencí"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hlavní jazyk"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Schůzky"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nebyly nalezeny žádné odpovídající jazyky"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Oznámení"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Jazyk vyhledávání..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Vyberte jazyk"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Posílejte anonymní analýzy využití, které pomohou zlepšit Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Sdílet údaje o využití"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Při poslechu ukažte kompaktní plovoucí ovládání."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Spustit Anarlog při přihlášení"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Začít při zahájení schůzky"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Zastavit, když schůzka skončí"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Pro přepis je vždy zahrnut hlavní jazyk"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ychwanegu iaith"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ychwanegu iaith lafar"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ieithoedd llafar ychwanegol"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Bob amser yn barod heb ei lansio â llaw."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ap"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Dechrau gwrando'n awtomatig pan fydd nodyn a gefnogir gan ddigwyddiad yn cyrraedd ei amser cychwyn a drefnwyd."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Rhowch y gorau i wrando'n awtomatig pan fydd ap y cyfarfod yn rhyddhau'r meicroffon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Iaith a Rhanbarth"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Iaith ar gyfer crynodebau, sgyrsiau, ac ymatebion a gynhyrchir gan AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Prif iaith"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Cyfarfodydd"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ni chanfuwyd ieithoedd sy'n cyfateb"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Hysbysiadau"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Iaith chwilio..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Dewiswch iaith"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anfon dadansoddeg defnydd dienw i helpu i wella Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Rhannu data defnydd"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Dangos y rheolydd arnofio cryno wrth wrando."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Dechrau Anarlog wrth fewngofnodi"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Dechrau pan fydd y cyfarfod yn dechrau"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stopiwch pan ddaw'r cyfarfod i ben"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Mae'r brif iaith bob amser yn cael ei chynnwys ar gyfer trawsgrifio"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tilføj sprog"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Tilføj talesprog"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Yderligere talte sprog"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Altid klar uden manuel lancering."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Begynd automatisk at lytte, når en begivenhedsstøttet note når sit planlagte starttidspunkt."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Stop automatisk med at lytte, når mødeappen slipper mikrofonen."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Sprog og region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Sprog til resuméer, chats og AI-genererede svar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hovedsprog"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Møder"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Der blev ikke fundet nogen matchende sprog"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Underretninger"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Søgesprog..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Vælg sprog"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Send anonym brugsanalyse for at hjælpe med at forbedre Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Del brugsdata"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Vis den kompakte flydende kontrol, mens du lytter."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Start Anarlog ved login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Start, når mødet begynder"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stop, når mødet slutter"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Hovedsproget er altid inkluderet til transskription"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Sprache hinzufügen"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Gesprochene Sprache hinzufügen"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Weitere gesprochene Sprachen"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Immer bereit, ohne manuelles Starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatisch mit dem Zuhören beginnen, wenn eine kalenderbasierte Notiz ihre geplante Startzeit erreicht."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatisch aufhören zuzuhören, wenn die Meeting-App das Mikrofon freigibt."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Sprache & Region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Sprache für Zusammenfassungen, Chats und KI-generierte Antworten"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hauptsprache"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Treffen"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Keine passenden Sprachen gefunden"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Benachrichtigungen"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Sprache suchen..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Sprache auswählen"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anonyme Nutzungsanalysen senden, um Anarlog zu verbessern."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Nutzungsdaten teilen"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Die kompakte schwebende Steuerung beim Zuhören anzeigen."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Anarlog beim Anmelden starten"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Beim Beginn des Meetings starten"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stoppen, wenn das Meeting endet"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Die Hauptsprache wird für die Transkription immer eingeschlossen"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Προσθήκη γλώσσας"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Προσθήκη προφορικής γλώσσας"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Πρόσθετες ομιλούμενες γλώσσες"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Πάντα έτοιμο χωρίς μη αυτόματη εκκίνηση."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Εφαρμογή"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Αυτόματη έναρξη ακρόασης όταν μια σημείωση που υποστηρίζεται από συμβάν φτάσει στην προγραμματισμένη ώρα έναρξης."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Διακόψτε αυτόματα την ακρόαση όταν η εφαρμογή σύσκεψης απελευθερώσει το μικρόφωνο."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Γλώσσα και περιοχή"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Γλώσσα για περιλήψεις, συνομιλίες και απαντήσεις που δημιουργούνται από AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Κύρια γλώσσα"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Συναντήσεις"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Δεν βρέθηκαν γλώσσες που να ταιριάζουν"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Ειδοποιήσεις"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Αναζήτηση γλώσσας..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Επιλογή γλώσσας"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Στείλτε ανώνυμα αναλυτικά στοιχεία χρήσης για να συμβάλετε στη βελτίωση του Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Κοινή χρήση δεδομένων χρήσης"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Εμφάνιση του συμπαγούς αιωρούμενου χειριστηρίου κατά την ακρόαση."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Ξεκινήστε το Anarlog κατά τη σύνδεση"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Ξεκινήστε όταν ξεκινά η σύσκεψη"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Διακοπή όταν τελειώσει η σύσκεψη"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Η κύρια γλώσσα περιλαμβάνεται πάντα για μεταγραφή"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr "(default)"
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr "{0} opened on"
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr "{trialDaysRemaining} day left"
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr "{trialDaysRemaining} days left"
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr "1 day"
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr "1 month"
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr "1 week"
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr "3 days"
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr "A to Z"
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr "Accessibility"
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr "Account"
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr "Add"
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr "Add \"{0}\""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr "Add {0} account"
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Add language"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr "Add names, jargon, or product terms to prefer"
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr "Add notes about this contact..."
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr "Add organization"
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr "Add person"
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr "Add repository"
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Add spoken language"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Additional spoken languages"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr "Advanced"
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr "After recording"
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr "All Notes"
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr "Allow access"
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr "Allow microphone access"
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr "Allow system audio access"
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Always ready without manually launching."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr "Analyzing structure..."
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr "Anarlog can hear others"
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr "Anarlog can hear your voice"
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr "Anarlog will sync your calendar to get meeting reminders"
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr "API Key"
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr "Appearance"
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr "Apply and Restart"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr "Apply to all"
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr "Applying..."
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr "Ask & search about anything, or be creative!"
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr "Ask Anarlog anything"
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr "Ask anything"
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr "Assignees:"
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr "Audio"
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr "Authorize access in your browser, then return to Anarlog."
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr "Automatically detect when a meeting starts based on microphone activity."
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatically start listening when an event-backed note reaches its scheduled start time."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatically stop listening when the meeting app releases the microphone."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr "Back"
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr "Base URL"
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr "Browse"
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr "Browser handoff not working? Paste the callback link instead"
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr "Calendar"
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr "Calendar connected"
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr "Can transcribe while the meeting is happening."
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr "Cancel"
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr "Cancel date edit"
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr "Change"
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr "Change content location"
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr "Chat history"
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr "Checking folder..."
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr "Checking trial eligibility..."
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr "Choose a file format and what to include."
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr "Choose light, dark, or match your system setting."
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr "Choose storage location"
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr "Choose where Anarlog should store data. (notes, settings, etc)"
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr "Clear search"
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr "Clone"
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr "Close"
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr "Close changelog"
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr "Close chat"
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr "Closed"
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr "comment"
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr "commented on"
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr "comments"
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr "Company"
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr "Compare Free, Lite, and Pro before you sign in."
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr "Complete sign-in in your browser, then return to Anarlog."
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr "Complete your purchase"
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr "Configure"
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr "Configure Providers"
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr "Configure this provider to use it."
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr "Confirm"
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr "Connect {0}"
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr "Connect calendar"
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr "Connect GitHub for private repos."
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr "Connect Google Calendar"
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr "Connect Outlook"
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr "Connect your integration"
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr "Contacts"
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr "Content"
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr "Context"
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr "Continue"
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr "Continuing without trial"
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr "Copy message"
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr "Could not start trial"
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr "Create account"
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr "Create template"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr "Created"
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr "Customize"
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr "Dark"
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr "Date and time are required"
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr "Delete"
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr "Delete All Recurring Events"
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr "Delete Event"
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr "Delete model"
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr "Delete Note"
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr "Delete recording"
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr "Delete Selected ({sessionCount})"
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr "Delete This Event"
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr "Deleting..."
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr "Describe the template purpose..."
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr "Detection delay"
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr "Dictionary"
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr "Disconnect"
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr "Disconnect private repo access."
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr "Do not keep recordings after processing"
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr "Don't save"
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr "Don't show notifications when Do-Not-Disturb is enabled on your system"
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr "Download"
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr "Duplicate"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr "Duration"
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr "Edit date"
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr "Eligible for free trial"
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr "Email"
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr "Enable {0}"
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr "Enhance contact"
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr "Enhance contact {label}"
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr "Enter a model identifier"
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr "Enter a valid date and time"
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr "Enter template title"
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr "Enter your API key"
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr "Enter your API key (optional)"
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr "Event notifications"
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr "Examples"
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr "Exclude apps from detection"
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr "existing data to new location"
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr "Expire recordings after one day"
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr "Expire recordings after one month"
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr "Expire recordings after one week"
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr "Expire recordings after three days"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr "Export"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr "Exporting..."
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr "Failed to load Google Calendar"
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr "Failed to load integration status"
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr "Failed to load issue"
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr "Failed to load Outlook Calendar"
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr "Failed to load pull request"
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr "Favorite template"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr "File format"
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr "Filter synced items by {0}."
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr "Find a note..."
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr "Finish checkout in your browser, then return to Anarlog."
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr "Finish sign-in"
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr "First day of the week in the calendar view"
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr "Float chat"
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr "For enabled notifications"
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr "Forever"
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr "Free"
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr "General"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr "Generating title..."
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr "Get notified 5 minutes before calendar events start"
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr "Get started"
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr "Get started for free"
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr "Go back to now"
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr "Go home"
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr "Go to next section"
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr "Go to previous section"
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr "Go to recent"
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr "Having trouble?"
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr "Help Anarlog listen to others"
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr "Help Anarlog listen to you"
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr "Hide Deleted Events"
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr "How long the mic must be active before triggering"
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr "Human"
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr "In {minutes} minute"
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr "In {minutes} minutes"
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr "In {totalSeconds} second"
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr "In {totalSeconds} seconds"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr "Include"
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr "Insert above"
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr "Insert below"
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr "Insights"
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr "Intelligence"
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr "Job Title"
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr "Join"
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr "Join {name}"
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr "Join our community and stay updated:"
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr "Keep Anarlog available from the menu bar."
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr "Keep recordings until manually deleted"
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Language & Region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Language for summaries, chats, and AI-generated responses"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr "Learn how to fix this"
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr "Light"
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr "LinkedIn"
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr "Live"
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr "Loading calendars..."
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr "Loading models..."
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr "Loading..."
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr "Login with existing account"
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Main language"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr "Manage"
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr "Manage billing"
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr "Match case"
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr "Match whole word"
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr "Meeting"
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Meetings"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr "member"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr "members"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr "Memo"
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr "Memos"
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr "Merged"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr "Metadata"
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr "Microphone"
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr "Microphone access turned on"
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr "Microphone detection"
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr "Model being used"
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr "Monday"
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr "More options"
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr "Move"
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr "Move down"
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr "Move up"
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr "Name"
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr "New chat"
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr "New Note"
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr "Newest"
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr "Next match"
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr "No apps found."
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr "No calendars found"
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr "No changelog available for this version."
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr "No community templates available"
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr "No content."
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr "No description provided."
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr "No items today"
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "No matching languages found"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr "No matching people"
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr "No models available."
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr "No models ready to use."
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr "No notes found."
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr "No people"
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr "No people in this organization"
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr "No recent chats"
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr "No related notes found"
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr "No results found."
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr "No templates yet"
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr "Note breadcrumb"
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr "Notes"
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr "Now"
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr "Oldest"
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr "Only public repositories are supported."
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr "Open"
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr "Open {0} settings"
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr "Open Anarlog"
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr "Open calendar"
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr "Open calendar account actions"
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr "Open floating panel"
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr "Open in New Tab"
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr "Open in New Window"
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr "Open in right panel"
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr "Open on GitHub"
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr "Open repository on GitHub"
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr "Open settings"
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr "or"
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr "Organization"
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr "Organization name"
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr "Others"
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr "Override the timezone used for the sidebar timeline"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr "Participants"
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr "Paste the browser URL here if the browser button did not reopen Anarlog."
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr "People"
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr "permission panel."
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr "Permissions"
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr "Permissions granted"
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr "Personalization"
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr "Phone"
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr "Plan & Billing"
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr "Plans"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr "Preparing transcript..."
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr "Previous match"
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr "Pro"
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr "Pro trial"
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr "Ready to go"
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr "Recent"
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr "Reconnect required"
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr "Refresh billing status"
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr "Refresh calendars"
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr "Regenerate insights"
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr "Regenerate message"
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr "Regenerating insights"
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr "Related Notes"
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr "Reminders"
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr "Remove {term}"
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr "Remove repository"
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr "Reopen checkout page"
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr "Reopen in browser"
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr "Reopen sign-in page"
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr "Replace"
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr "Replace all"
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr "Replace repository"
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr "Replace with..."
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr "Request"
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr "Request {0}"
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr "Request {0} permission"
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr "Request,"
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr "Required to capture other participants' voices in meetings"
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr "Required to detect meeting apps and sync mute status"
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr "Required to record your voice during meetings and calls"
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr "Required to sync Apple Calendar events into Anarlog"
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr "Reset"
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr "Respect Do-Not-Disturb mode"
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr "Resume"
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr "Retry"
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr "Runs after the recording finishes, not during the meeting."
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr "Save audio after meeting"
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr "Save date"
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr "Search contacts..."
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr "Search installed apps to exclude them. Click an excluded app to include it again."
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr "Search installed apps..."
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Search language..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr "Search or add company"
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr "Search or create new"
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr "Search or type owner/repo"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr "Search people"
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr "Search templates..."
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr "Search timezone..."
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr "Search..."
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr "Section actions"
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr "See all templates"
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr "Select a different folder"
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr "Select a model"
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr "Select a person to view details"
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr "Select a provider"
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr "Select an organization to view details"
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr "Select appearance"
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr "Select day"
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Select language"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr "Select timezone"
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr "Select..."
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Send anonymous usage analytics to help improve Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr "Send email"
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr "Send message"
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr "Session note tabs"
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr "Session title"
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr "Set as default"
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr "Settings"
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Share usage data"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr "Show All Recurring Events"
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr "Show Anarlog in the Dock and app switcher."
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr "Show app in Dock"
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr "Show Deleted Events"
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr "Show Event"
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr "Show floating bar"
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr "Show in Finder"
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Show the compact floating control while listening."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr "Show This Event"
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr "Show tray icon"
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr "Sign in"
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr "Sign in for Lite"
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr "Sign in for private repo access."
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr "Sign in for Pro"
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr "Sign in to Anarlog"
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr "Sign in to connect"
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr "Sign in to connect {0}"
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr "Sign in to unlock powerful AI models, sync across devices, and personalization."
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr "Sign in to your account"
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr "Sign out"
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr "Signed in"
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr "Signing out..."
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr "Skip"
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr "Skipped"
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr "Software Engineer"
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr "Something went wrong while generating the summary."
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr "Sort options"
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Start Anarlog at login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr "Start Recording"
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Start when meeting begins"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr "Start with permissions"
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr "Starting your trial..."
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr "Stop"
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr "Stop listening"
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr "Stop response"
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stop when meeting ends"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr "Storage"
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr "Storage configured"
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr "Storage Updated"
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr "Stores app-wide settings and configurations"
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr "Stores your notes, recordings, and session data"
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr "Submit callback URL"
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr "Summary"
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr "Sunday"
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr "System"
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr "System audio"
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr "System audio enabled"
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr "Template actions"
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr "Template content with Jinja2: {{ variable }}, {% if condition %}"
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr "Templates"
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr "The app will restart after onboarding to apply your storage changes"
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "The main language is always included for transcription"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr "Thinking..."
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr "Ticket"
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr "Timezone"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr "Tip: The Anarlog team loves our users!"
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr "Transcript"
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr "Transcription"
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr "Trial"
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr "Trial activated - 14 days of Pro"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr "Unknown"
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr "Unknown date"
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr "Unnamed"
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr "Untitled"
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr "Untitled Note"
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr "Upgrade for private repos."
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr "Upgrade to connect"
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr "Upgrade to Pro"
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr "Upgrade to Pro for {0}"
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr "Upgrade to Pro to use this provider."
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr "Upgrade to use"
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr "Upload audio"
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr "Upload transcript"
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr "View LinkedIn profile"
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr "Want to use with your vault?"
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr "Week starts on"
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr "Welcome to Anarlog"
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr "What's new in {version}?"
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr "Where your notes and recordings are stored"
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr "Work on this task"
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr "You can"
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr "You have an active plan"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr "You need to configure a language model to summarize this meeting"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr "You need to configure the API key and base URL for your language model provider"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr "You need to configure the API key for your language model provider"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr "You need to configure the base URL for your language model provider"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr "You need to select a model to summarize this meeting"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr "You need to sign in to use Anarlog's language model"
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr "You're on a Pro trial"
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr "You're on the <0>{planLabel}</0> plan"
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr "Your Account"
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr "Your Anarlog plan has expired. Configure another language model or renew your plan"
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr "Z to A"

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Añadir idioma"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Añadir idioma hablado"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Idiomas hablados adicionales"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Siempre listo sin iniciarlo manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplicación"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Comenzar a escuchar automáticamente cuando una nota vinculada a un evento llegue a su hora de inicio programada."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Dejar de escuchar automáticamente cuando la app de reuniones libere el micrófono."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Idioma y región"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Idioma para resúmenes, chats y respuestas generadas por IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Idioma principal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Reuniones"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "No se encontraron idiomas coincidentes"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificaciones"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Buscar idioma..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Seleccionar idioma"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Enviar análisis de uso anónimos para ayudar a mejorar Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Compartir datos de uso"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Mostrar el control flotante compacto mientras escucha."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Iniciar Anarlog al iniciar sesión"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Iniciar cuando comience la reunión"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Detener cuando termine la reunión"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "El idioma principal siempre se incluye para la transcripción"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Lisage keel"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Lisage kõnekeel"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Täiendavad kõnekeeled"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Alati valmis ilma käsitsi käivitamata."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Rakendus"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Alustage automaatselt kuulamist, kui sündmusega tagatud noot jõuab oma kavandatud algusaega."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Lõpetage kuulamine automaatselt, kui koosolekurakendus mikrofoni vabastab."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Keel ja piirkond"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Kokkuvõtete, vestluste ja tehisintellekti loodud vastuste keel"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Põhikeel"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Koosolekud"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Sobivaid keeli ei leitud"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Märguanded"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Otsingukeel..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Valige keel"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Saatke anonüümseid kasutusanalüüse, et aidata Anarlogi täiustada."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Kasutusandmete jagamine"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Kuulamise ajal kompaktse ujuva juhtelemendi kuvamine."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Käivitage sisselogimisel Anarlog"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Alusta koosoleku alguses"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Peatage koosoleku lõppedes"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Põhikeel on alati transkriptsiooni jaoks kaasas"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Gehitu hizkuntza"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Gehitu ahozko hizkuntza"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ahozko hizkuntza gehigarriak"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Beti prest eskuz abiarazi gabe."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikazioa"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Hasi automatikoki entzuten gertaerak babestutako ohar bat programatutako hasiera-orura iristen denean."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Utzi automatikoki entzuteari bilera-aplikazioak mikrofonoa askatzen duenean."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Hizkuntza eta eskualdea"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Laburpenetarako, txatetarako eta AI bidez sortutako erantzunetarako hizkuntza"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hizkuntza nagusia"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Bilkurak"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ez da bat datorren hizkuntzarik aurkitu"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Jakinarazpenak"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Bilatu hizkuntza..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Hautatu hizkuntza"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Bidali erabilera-analisi anonimoak Anarlog hobetzen laguntzeko."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Partekatu erabilera datuak"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Erakutsi kontrol mugikor trinkoa entzuten duzun bitartean."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Hasi Anarlog saioa hasten denean"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Hasi bilera hasten denean"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Gelditu bilera amaitzen denean"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Hizkuntza nagusia beti sartzen da transkripzioa egiteko"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "افزودن زبان"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "افزودن زبان گفتاری"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "زبان‌های گفتاری دیگر"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "همیشه بدون راه‌اندازی دستی آماده است."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "برنامه"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "وقتی یادداشت دارای پشتوانه رویداد به زمان شروع برنامه‌ریزی‌شده خود رسید، به‌طور خودکار گوش دادن را شروع کنید."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "وقتی برنامه جلسه میکروفون را آزاد می‌کند، به‌طور خودکار گوش دادن را متوقف کنید."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "زبان و منطقه"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "زبان خلاصه‌ها، چت‌ها و پاسخ‌های ایجاد شده توسط هوش مصنوعی"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "زبان اصلی"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "جلسات"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "هیچ زبان منطبقی یافت نشد"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "اعلان‌ها"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "زبان جستجو..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "زبان را انتخاب کنید"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "تحلیل استفاده ناشناس را برای کمک به بهبود Anarlog ارسال کنید."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "به اشتراک گذاری داده های استفاده"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "کنترل شناور فشرده را هنگام گوش دادن نشان دهید."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Anarlog را با ورود شروع کنید"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "با شروع جلسه شروع شود"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "وقتی جلسه تمام شد متوقف شود"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "زبان اصلی همیشه برای رونویسی گنجانده شده است"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ɓeydu ɗemngal"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ɓeydu ɗemngal haalteengal"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ɗemɗe kaaleteeɗe ɓeydaaɗe"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ko hesɗi sahaa kala tawa aɗa uddita e junngo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Kuutorgal"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Fuɗɗoo heɗaade otomatik so winndannde ballitoore kewu yettiima waktu mum puɗɗorɗo."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Woppu heɗtaade otomatik so app pottital ngal yaltinii mikroo."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Ɗemngal e Diiwaan"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ɗemngal ngam ciimtol, yeewtere, e jaabawuuli AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Ɗemngal mawngal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Kawrital"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ɗemɗe nannduɗe alaa tawaa"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Noddaango"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Ɗemngal njiylawu..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Suɓo ɗemngal"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Neldu ƴeewndo kuutoragol ngol anndaaka ngam wallitde moƴƴinde Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Renndinde dokke kuutoragol"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Hollit jokkorgal ɓuuɓngal compact nde aɗa nana."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Fuɗɗo Anarlog e naatgol"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Fuɗɗo so batu fuɗɗiima"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Darto so batu nguu gasii"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Ɗemngal mawngal ina heen sahaa kala ngam winndude"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Lisää kieli"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Lisää puhuttu kieli"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Muita puhuttuja kieliä"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Aina valmis ilman manuaalista käynnistämistä."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Sovellus"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Aloita kuuntelu automaattisesti, kun tapahtuman taustalla oleva nuotti saavuttaa ajoitetun alkamisajan."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Lopeta kuuntelu automaattisesti, kun kokoussovellus vapauttaa mikrofonin."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Kieli ja alue"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Kieli yhteenvetoja, keskusteluja ja tekoälyn luomia vastauksia varten"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Pääkieli"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Kokoukset"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Vastaavia kieliä ei löytynyt"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Ilmoitukset"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Hakukieli..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Valitse kieli"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Lähetä anonyymi käyttöanalytiikka auttaaksesi parantamaan Anarlogia."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Jaa käyttötiedot"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Näytä kompakti kelluva säädin kuunnellessasi."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Käynnistä Anarlog sisäänkirjautumisen yhteydessä"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Aloita kokouksen alkaessa"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Lopeta, kun kokous päättyy"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Pääkieli on aina mukana transkriptiota varten"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Legg mál til"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Legg talumál til"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Eyka talumál"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Altíð klárur uttan at seta í gongd manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Forrit"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Byrja sjálvvirkandi at lurta, tá ein hendingarstuðlaður notur nær sína ásettu byrjanartíð."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Sjálvvirkandi steðga við at lurta, tá møtiappin sleppur mikrofonini."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Mál og øki"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Mál til samandráttir, kjak og AI-genererað svar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Høvuðsmál"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Fundir"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Einki samsvarandi mál er funnið"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Fráboðanir"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Leitimál..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Vel mál"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Send dulnevndar nýtslugreiningar fyri at hjálpa til við at betra um Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Deil nýtsludátur"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Vís kompaktu flótandi stýringina, meðan tú lurtar."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Byrja Anarlog við innritan"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Byrja tá møtið byrjar"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Steðga á, tá ið fundurin endar"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Høvuðsmálið er altíð við til umskriving"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ajouter une langue"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ajouter une langue parlée"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Langues parlées supplémentaires"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Toujours prêt sans lancement manuel."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Application"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Démarre automatiquement l'écoute lorsqu'une note liée à un événement atteint son heure de début prévue."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Arrête automatiquement l'écoute lorsque l'application de réunion libère le micro."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Langue et région"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Langue des résumés, discussions et réponses générées par l'IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Langue principale"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Réunions"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Aucune langue correspondante trouvée"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notifications"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Rechercher une langue..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Sélectionner une langue"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Envoyer des analyses d'utilisation anonymes pour aider à améliorer Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Partager les données d'utilisation"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Afficher le contrôle flottant compact pendant l'écoute."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Lancer Anarlog à la connexion"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Démarrer au début de la réunion"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Arrêter à la fin de la réunion"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "La langue principale est toujours incluse pour la transcription"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Cuir teanga leis"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Cuir teanga labhartha leis"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Teangacha breise labhartha"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Bí réidh i gcónaí gan é a sheoladh de láimh."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aip"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Cuir tús leis an éisteacht go huathoibríoch nuair a shroicheann nóta le tacaíocht imeachta a am tosaithe sceidealaithe."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Stop go huathoibríoch den éisteacht nuair a scaoileann an aip cruinnithe an micreafón."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Teanga & Réigiún"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Teanga le haghaidh achoimrí, comhráite, agus freagraí a ghintear le AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Príomhtheanga"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Cruinnithe"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Níor aimsíodh aon teanga chomhoiriúnach"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Fógraí"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Teanga chuardaigh..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Roghnaigh teanga"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Seol anailísí úsáide gan ainm chun cabhrú leis an Anarlog a fheabhsú."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Comhroinn sonraí úsáide"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Taispeáin an dlúthrialtán ar snámh agus tú ag éisteacht."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Tosaigh Anarlog ag logáil isteach"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Tosaigh nuair a thosaíonn an cruinniú"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stop nuair a thagann deireadh leis an gcruinniú"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Cuirtear an phríomhtheanga san áireamh le tras-scríobh i gcónaí"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Engadir idioma"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Engadir idioma falado"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Idiomas falados adicionais"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Sempre listo sen iniciar manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplicación"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Comezar a escoitar automaticamente cando unha nota apoiada nun evento alcance a súa hora de inicio programada."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Deixa de escoitar automaticamente cando a aplicación de reunións solte o micrófono."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Idioma e rexión"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Idioma para resumos, chats e respostas xeradas pola intelixencia artificial"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Idioma principal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Reunións"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Non se atoparon idiomas coincidentes"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificacións"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Buscar idioma..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Seleccionar idioma"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Envía análises de uso anónimas para axudar a mellorar Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Compartir datos de uso"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Mostra o control flotante compacto mentres escoitas."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Iniciar Anarlog ao iniciar sesión"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Comezar cando comece a reunión"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Para cando remate a reunión"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "O idioma principal sempre se inclúe para a transcrición"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ભાષા ઉમેરો"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "બોલાતી ભાષા ઉમેરો"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "અતિરિક્ત બોલાતી ભાષાઓ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "મેન્યુઅલી લોન્ચ કર્યા વિના હંમેશા તૈયાર."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "એપ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "જ્યારે ઇવેન્ટ-બેક કરેલ નોંધ તેના નિર્ધારિત પ્રારંભ સમય પર પહોંચે ત્યારે આપમેળે સાંભળવાનું શરૂ કરો."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "જ્યારે મીટિંગ એપ્લિકેશન માઇક્રોફોન રિલીઝ કરે ત્યારે આપમેળે સાંભળવાનું બંધ કરો."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ભાષા અને પ્રદેશ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "સારાંશ, ચેટ્સ અને AI-જનરેટેડ પ્રતિસાદો માટેની ભાષા"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "મુખ્ય ભાષા"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "મીટિંગ્સ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "કોઈ મેળ ખાતી ભાષાઓ મળી નથી"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "સૂચના"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ભાષા શોધો..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ભાષા પસંદ કરો"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "એનારલોગને બહેતર બનાવવામાં મદદ કરવા માટે અનામી વપરાશ વિશ્લેષણ મોકલો."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "વપરાશનો ડેટા શેર કરો"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "સાંભળતી વખતે કોમ્પેક્ટ ફ્લોટિંગ કંટ્રોલ બતાવો."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "લોગિન પર એનાલોગ શરૂ કરો"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "મીટિંગ શરૂ થાય ત્યારે શરૂ કરો"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "મીટિંગ સમાપ્ત થાય ત્યારે રોકો"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "મુખ્ય ભાષા હંમેશા ટ્રાન્સક્રિપ્શન માટે સમાવવામાં આવે છે"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ƙara harshe"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ƙara yaren magana"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ƙarin harsunan magana"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Koyaushe a shirye ba tare da ƙaddamar da hannu ba."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Fara sauraro ta atomatik lokacin da bayanin kula da abin ya faru ya kai lokacin farawa da aka tsara."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Dakatar da saurare ta atomatik lokacin da app ɗin taron ya saki makirufo."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Harshe & Yanki"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Harshe don taƙaitawa, taɗi, da martanin AI da aka samar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Babban harshe"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Taro"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ba a sami yarukan da suka dace ba"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Sanarwa"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Yaren bincike..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Zaɓi harshe"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Aika bayanan amfani da ba a san su ba don taimakawa inganta Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Raba bayanan amfani"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Nuna ƙaramin iko mai iyo yayin sauraro."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Fara Anarlog a login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Fara lokacin da aka fara taro"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Dakata lokacin da taro ya ƙare"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Koyaushe ana haɗa babban harshe don rubutawa"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "הוסף שפה"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "הוסף שפה מדוברת"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "שפות מדוברות נוספות"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "תמיד מוכן ללא הפעלה ידנית."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "אפליקציה"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "התחל להאזין באופן אוטומטי כאשר הערה מגובה אירוע מגיעה לזמן ההתחלה המתוכנן שלה."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "הפסק להאזין באופן אוטומטי כאשר אפליקציית הפגישות משחררת את המיקרופון."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "שפה ואזור"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "שפה לסיכומים, צ'אטים ותגובות שנוצרו על ידי AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "שפה ראשית"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "פגישות"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "לא נמצאו שפות מתאימות"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "התראות"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "שפת חיפוש..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "בחר שפה"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "שלח ניתוח שימוש אנונימי כדי לעזור בשיפור Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "שתף נתוני שימוש"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "הצג את הבקרה הציפה הקומפקטית תוך כדי האזנה."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "התחל אנלוג בכניסה"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "התחל כאשר הפגישה מתחילה"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "עצור כאשר הפגישה מסתיימת"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "השפה הראשית כלולה תמיד לתמלול"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "भाषा जोड़ें"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "बोली जाने वाली भाषा जोड़ें"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "अतिरिक्त बोली जाने वाली भाषाएँ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "मैन्युअल रूप से लॉन्च किए बिना हमेशा तैयार।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ऐप"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "जब कोई ईवेंट-समर्थित नोट अपने निर्धारित प्रारंभ समय पर पहुंचता है तो स्वचालित रूप से सुनना प्रारंभ करें।"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "जब मीटिंग ऐप माइक्रोफ़ोन जारी करता है तो स्वचालित रूप से सुनना बंद कर देता है।"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "भाषा एवं क्षेत्र"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "सारांश, चैट और AI-जनरेटेड प्रतिक्रियाओं के लिए भाषा"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "मुख्य भाषा"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "बैठकें"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "कोई मेल खाती भाषा नहीं मिली"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "सूचनाएँ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "खोज भाषा..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "भाषा चुनें"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "अनारलॉग को बेहतर बनाने में सहायता के लिए अनाम उपयोग विश्लेषण भेजें।"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "उपयोग डेटा साझा करें"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "सुनते समय कॉम्पैक्ट फ़्लोटिंग नियंत्रण दिखाएं।"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "लॉगिन पर अनारलॉग प्रारंभ करें"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "मीटिंग शुरू होने पर प्रारंभ करें"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "मीटिंग ख़त्म होने पर रुकें"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "प्रतिलेखन के लिए मुख्य भाषा हमेशा शामिल होती है"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dodajte jezik"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Dodaj govorni jezik"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Dodatni govorni jezici"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Uvijek spreman bez ručnog pokretanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikacija"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatski počnite sa slušanjem kada bilješka potkrijepljena događajem dosegne zakazano vrijeme početka."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatski prestani slušati kada aplikacija za sastanke otpusti mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Jezik i regija"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Jezik za sažetke, razgovore i odgovore generirane umjetnom inteligencijom"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Glavni jezik"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Sastanci"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nije pronađen nijedan odgovarajući jezik"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Obavijesti"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Traži jezik..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Odaberite jezik"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Šaljite anonimnu analitiku korištenja kako biste poboljšali Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Dijeljenje podataka o korištenju"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Pokažite kompaktnu lebdeću kontrolu dok slušate."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Pokreni Anarlog pri prijavi"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Počni kada sastanak počne"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Zaustavi kada sastanak završi"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Glavni jezik je uvijek uključen za transkripciju"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ajoute lang"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ajoute lang ki pale"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Anplis lang ki pale"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Toujou pare san yo pa lanse manyèlman."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikasyon"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Otomatikman kòmanse koute lè yon nòt ki apiye yon evènman rive nan lè kòmanse pwograme li a."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Otomatikman sispann koute lè aplikasyon reyinyon an lage mikwofòn la."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Lang ak Rejyon"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Lang pou rezime, chat, ak repons AI te pwodwi"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Lang prensipal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Reyinyon"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Okenn lang pa jwenn"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notifikasyon"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Rechèch lang..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Chwazi lang"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Voye analiz itilizasyon anonim pou ede amelyore Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Pataje done itilizasyon"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Montre kontwòl k ap flote kontra a pandan w ap koute."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Kòmanse Anarlog lè w konekte"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Kòmanse lè reyinyon an kòmanse"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Sispann lè reyinyon an fini"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Lang prensipal la toujou enkli pou transkripsyon"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Nyelv hozzáadása"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Beszélt nyelv hozzáadása"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "További beszélt nyelvek"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Mindig készen áll kézi indítás nélkül."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Alkalmazás"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatikusan elkezdheti a hallgatást, ha egy eseményhez kapcsolódó hangjegy eléri az ütemezett kezdési időpontját."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "A hallgatás automatikus leállítása, amikor az értekezlet alkalmazás elengedi a mikrofont."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Nyelv és régió"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Összefoglalók, csevegések és mesterséges intelligencia által generált válaszok nyelve"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Fő nyelv"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Találkozók"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nincs megfelelő nyelv"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Értesítések"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Keresési nyelv..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Nyelv kiválasztása"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anonim használati elemzések küldése az Anarlog fejlesztéséhez."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Használati adatok megosztása"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "A kompakt lebegő vezérlő megjelenítése hallgatás közben."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Indítsa el az Anarlogot bejelentkezéskor"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "A megbeszélés kezdetekor kezdődik"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Leállítás az értekezlet végén"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "A fő nyelv mindig szerepel az átíráshoz"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ավելացնել լեզու"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ավելացնել խոսակցական լեզու"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Լրացուցիչ խոսակցական լեզուներ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Միշտ պատրաստ է առանց ձեռքով գործարկելու:"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Հավելված"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Ավտոմատ կերպով սկսեք լսել, երբ իրադարձություններով ապահովված նշումը հասնում է իր նախատեսված մեկնարկի ժամանակին:"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Ավտոմատ կերպով դադարեցրեք լսելը, երբ հանդիպման հավելվածը թողարկի խոսափողը:"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Լեզուն և տարածաշրջանը"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ամփոփումների, զրույցների և AI-ի կողմից ստեղծված պատասխանների լեզու"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Հիմնական լեզու"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Հանդիպումներ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Համապատասխան լեզուներ չեն գտնվել"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Ծանուցումներ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Որոնման լեզուն..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Ընտրեք լեզուն"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Ուղարկեք անանուն օգտագործման վերլուծություններ՝ օգնելու բարելավել Anarlog-ը:"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Կիսեք օգտագործման տվյալները"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Ցույց տալ կոմպակտ լողացող կառավարը լսելիս:"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Մուտք գործեք Anarlog-ը"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Սկսել, երբ հանդիպումը սկսվի"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Դադարեցնել, երբ հանդիպումն ավարտվի"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Հիմնական լեզուն միշտ ներառված է տառադարձման համար"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tambahkan bahasa"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Tambahkan bahasa lisan"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Bahasa lisan tambahan"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Selalu siap tanpa meluncurkan secara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikasi"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Secara otomatis mulai mendengarkan ketika catatan yang didukung acara mencapai waktu mulai yang dijadwalkan."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Secara otomatis berhenti mendengarkan saat aplikasi rapat melepaskan mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Bahasa & Wilayah"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Bahasa untuk ringkasan, chat, dan respons yang dihasilkan AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Bahasa utama"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Rapat"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Tidak ditemukan bahasa yang cocok"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Bahasa penelusuran..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pilih bahasa"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Kirim analisis penggunaan anonim untuk membantu meningkatkan Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Bagikan data penggunaan"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Tampilkan kontrol mengambang ringkas sambil mendengarkan."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Mulai Anarlog saat login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Mulai saat rapat dimulai"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Berhenti ketika rapat berakhir"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Bahasa utama selalu disertakan untuk transkripsi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tinye asụsụ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Tinye asụsụ asụ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Asụsụ ndị agbakwunyere"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Na-adị njikere mgbe niile na-ejighi aka malite."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ngwa"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Bido ige ntị na akpaghị aka mgbe ndetu akwadoro emume ruru oge mbido ahaziri."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Kwụsị ige ntị na akpaghị aka mgbe ngwa nzụkọ wepụtara igwe okwu."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Asụsụ & Mpaghara"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Asụsụ maka nchịkọta, nkata, na nzaghachi AI mepụtara"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Asụsụ isi"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Nzukọ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ọnweghị asụsụ dabara adaba ahụrụ"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Ọkwa"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Chọọ asụsụ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Họrọ asụsụ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Zipu nyocha ojiji na-amaghị aha iji nyere aka melite Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Kekọrịta data ojiji"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Gosi kọmpat njikwa na-ese n'elu mmiri mgbe ị na-ege ntị."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Bido Anarlog na nbanye"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Malite mgbe nzukọ ga-amalite"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Kwụsị mgbe nzukọ agwụ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "A na-etinyekarị asụsụ isi maka ndegharị"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Bæta við tungumáli"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Bæta við töluðu máli"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Viðbótar töluð tungumál"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Alltaf tilbúinn án þess að ræsa handvirkt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Byrjaðu sjálfkrafa að hlusta þegar viðburðarstudd glósa nær áætluðum upphafstíma."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Hættu sjálfkrafa að hlusta þegar fundarforritið sleppir hljóðnemanum."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Tungumál og svæði"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Tungumál fyrir samantektir, spjall og AI-mynduð svör"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Aðaltungumál"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Fundir"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Engin tungumál sem passa við fundust"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Tilkynningar"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Leita tungumál..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Veldu tungumál"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Sendu nafnlausa notkunargreiningu til að bæta Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Deildu notkunargögnum"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Sýndu fyrirferðarlítið fljótandi stjórn á meðan þú hlustar."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Byrjaðu Anarlog við innskráningu"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Byrjaðu þegar fundur hefst"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Hættu þegar fundi lýkur"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Aðaltungumálið er alltaf innifalið fyrir umritun"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Aggiungi lingua"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Aggiungi lingua parlata"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Lingue parlate aggiuntive"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Sempre disponibile senza avvio manuale."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Avvia automaticamente l'ascolto quando una nota collegata a un evento raggiunge l'orario di inizio programmato."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Interrompi automaticamente l'ascolto quando l'app per riunioni rilascia il microfono."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Lingua e regione"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Lingua per riepiloghi, chat e risposte generate dall'IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Lingua principale"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Riunioni"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nessuna lingua corrispondente trovata"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notifiche"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Cerca lingua..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Seleziona lingua"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Invia analisi anonime sull'utilizzo per aiutare a migliorare Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Condividi dati di utilizzo"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Mostra il controllo flottante compatto durante l'ascolto."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Avvia Anarlog all'accesso"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Avvia all'inizio della riunione"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Interrompi alla fine della riunione"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "La lingua principale è sempre inclusa per la trascrizione"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "言語を追加"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "音声言語を追加"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "追加の音声言語"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "手動で起動しなくても常に準備できます。"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "アプリ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "予定に紐づいたノートが開始時刻になると、自動的にリスニングを開始します。"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "会議アプリがマイクを解放すると、自動的にリスニングを停止します。"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "言語と地域"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "要約、チャット、AI生成応答に使用する言語"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "メイン言語"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "会議"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "一致する言語が見つかりません"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "言語を検索..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "言語を選択"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog の改善に役立てるため、匿名の使用状況データを送信します。"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "使用状況データを共有"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "リスニング中にコンパクトなフローティングコントロールを表示します。"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ログイン時に Anarlog を起動"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "会議開始時に開始"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "会議終了時に停止"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "メイン言語は文字起こしに常に含まれます"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tambah basa"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Tambahake basa lisan"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Basa lisan tambahan"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Tansah siyap tanpa diluncurake kanthi manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikasi"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Miwiti kanthi otomatis ngrungokake nalika cathetan sing didhukung acara tekan wektu wiwitan sing dijadwalake."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Otomatis mandheg ngrungokake nalika aplikasi rapat ngeculake mikropon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Basa & Wilayah"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Basa kanggo ringkesan, obrolan, lan tanggapan sing digawe AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Basa utama"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Patemon"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ora ditemokake basa sing cocog"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Kabar"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Telusuri basa..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pilih basa"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Kirim analisis panggunaan anonim kanggo mbantu nambah Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Nuduhake data panggunaan"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Tampilake kontrol ngambang kompak nalika ngrungokake."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Mulai Anarlog nalika mlebu"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Miwiti nalika rapat diwiwiti"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Mandheg nalika rapat rampung"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Basa utama mesthi kalebu kanggo transkripsi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ენის დამატება"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "სალაპარაკო ენის დამატება"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "დამატებითი სალაპარაკო ენები"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ყოველთვის მზადაა ხელით გაშვების გარეშე."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "აპი"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ავტომატურად დაიწყეთ მოსმენა, როდესაც ღონისძიებაზე მხარდაჭერილი ჩანიშვნა მიაღწევს დაგეგმილ დაწყების დროს."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "ავტომატურად შეწყვიტოს მოსმენა, როდესაც შეხვედრის აპი გამოუშვებს მიკროფონს."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ენა და რეგიონი"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ენა შეჯამებისთვის, ჩეთებისთვის და AI-ით გენერირებული პასუხებისთვის"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "მთავარი ენა"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "შეხვედრები"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "შესაბამისი ენები ვერ მოიძებნა"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "შეტყობინებები"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ენის ძიება..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "აირჩიეთ ენა"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "ანონიმური გამოყენების ანალიტიკის გაგზავნა Anarlog-ის გასაუმჯობესებლად."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "გამოყენების მონაცემების გაზიარება"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "კომპაქტური მცურავი მართვის ჩვენება მოსმენისას."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "დაიწყეთ Anarlog შესვლისას"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "დაიწყეთ შეხვედრის დაწყებისთანავე"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "შეჩერება შეხვედრის დასრულებისას"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "მთავარი ენა ყოველთვის შედის ტრანსკრიფციისთვის"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Тілді қосу"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Сөйлеу тілін қосу"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Қосымша ауызекі тілдер"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Қолмен іске қоспай-ақ әрқашан дайын."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Қолданба"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Оқиғаға негізделген жазба жоспарланған басталу уақытына жеткенде тыңдауды автоматты түрде бастаңыз."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Кездесу қолданбасы микрофонды шығарған кезде тыңдауды автоматты түрде тоқтатыңыз."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Тіл және аймақ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Қорытындыларға, чаттарға және AI жасаған жауаптарға арналған тіл"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Негізгі тіл"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Кездесулер"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Сәйкес тіл табылмады"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Хабарландырулар"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Іздеу тілі..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Тілді таңдаңыз"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog-ті жақсартуға көмектесу үшін анонимді пайдалану аналитикасын жіберіңіз."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Пайдалану деректерін бөлісу"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Тыңдау кезінде ықшам қалқымалы басқару элементін көрсетіңіз."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Кіру кезінде Anarlog іске қосыңыз"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Кездесу басталғанда бастаңыз"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Кездесу аяқталғанда тоқтатыңыз"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Негізгі тіл әрқашан транскрипция үшін қосылады"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "បន្ថែមភាសា"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "បន្ថែមភាសានិយាយ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ភាសានិយាយបន្ថែម"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "រួចរាល់ជានិច្ច ដោយមិនចាំបាច់បើកដំណើរការដោយដៃ។"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "កម្មវិធី"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ចាប់ផ្តើមស្តាប់ដោយស្វ័យប្រវត្តិ នៅពេលដែលកំណត់ចំណាំដែលគាំទ្រព្រឹត្តិការណ៍ឈានដល់ម៉ោងចាប់ផ្តើមដែលបានកំណត់ពេលរបស់វា។"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "បញ្ឈប់ការស្តាប់ដោយស្វ័យប្រវត្តិ នៅពេលដែលកម្មវិធីប្រជុំបញ្ចេញមីក្រូហ្វូន។"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ភាសា និងតំបន់"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ភាសាសម្រាប់ការសង្ខេប ការជជែក និងការឆ្លើយតបដែលបង្កើតឡើងដោយ AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ភាសាចម្បង"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ការប្រជុំ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "រកមិនឃើញភាសាដែលត្រូវគ្នាទេ"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "ការជូនដំណឹង"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ភាសាស្វែងរក..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ជ្រើសរើសភាសា"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "ផ្ញើការវិភាគការប្រើប្រាស់អនាមិក ដើម្បីជួយកែលម្អ Anarlog ។"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ចែករំលែកទិន្នន័យការប្រើប្រាស់"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "បង្ហាញការគ្រប់គ្រងបណ្តែតតូចខណៈពេលកំពុងស្តាប់។"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ចាប់ផ្តើម Anarlog នៅពេលចូល"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ចាប់ផ្តើមនៅពេលការប្រជុំចាប់ផ្តើម"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ឈប់នៅពេលការប្រជុំបញ្ចប់"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ភាសាចម្បងតែងតែត្រូវបានរួមបញ្ចូលសម្រាប់ការចម្លង"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ಭಾಷೆಯನ್ನು ಸೇರಿಸಿ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "ಮಾತನಾಡುವ ಭಾಷೆಯನ್ನು ಸೇರಿಸಿ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ಹೆಚ್ಚುವರಿ ಮಾತನಾಡುವ ಭಾಷೆಗಳು"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ಹಸ್ತಚಾಲಿತವಾಗಿ ಪ್ರಾರಂಭಿಸದೆ ಯಾವಾಗಲೂ ಸಿದ್ಧವಾಗಿದೆ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ಅಪ್ಲಿಕೇಶನ್"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ಈವೆಂಟ್-ಬೆಂಬಲಿತ ಟಿಪ್ಪಣಿಯು ಅದರ ನಿಗದಿತ ಪ್ರಾರಂಭದ ಸಮಯವನ್ನು ತಲುಪಿದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆಲಿಸಲು ಪ್ರಾರಂಭಿಸಿ."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "ಮೀಟಿಂಗ್ ಅಪ್ಲಿಕೇಶನ್ ಮೈಕ್ರೊಫೋನ್ ಅನ್ನು ಬಿಡುಗಡೆ ಮಾಡಿದಾಗ ಸ್ವಯಂಚಾಲಿತವಾಗಿ ಆಲಿಸುವುದನ್ನು ನಿಲ್ಲಿಸಿ."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ಭಾಷೆ ಮತ್ತು ಪ್ರದೇಶ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ಸಾರಾಂಶಗಳು, ಚಾಟ್‌ಗಳು ಮತ್ತು AI-ರಚಿಸಿದ ಪ್ರತಿಕ್ರಿಯೆಗಳಿಗಾಗಿ ಭಾಷೆ"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ಮುಖ್ಯ ಭಾಷೆ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ಸಭೆಗಳು"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ಯಾವುದೇ ಹೊಂದಾಣಿಕೆಯ ಭಾಷೆಗಳು ಕಂಡುಬಂದಿಲ್ಲ"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "ಅಧಿಸೂಚನೆಗಳು"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ಹುಡುಕಾಟ ಭಾಷೆ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ಭಾಷೆಯನ್ನು ಆಯ್ಕೆಮಾಡಿ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog ಸುಧಾರಿಸಲು ಸಹಾಯ ಮಾಡಲು ಅನಾಮಧೇಯ ಬಳಕೆಯ ವಿಶ್ಲೇಷಣೆಗಳನ್ನು ಕಳುಹಿಸಿ."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ಬಳಕೆಯ ಡೇಟಾವನ್ನು ಹಂಚಿಕೊಳ್ಳಿ"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ಕೇಳುತ್ತಿರುವಾಗ ಕಾಂಪ್ಯಾಕ್ಟ್ ಫ್ಲೋಟಿಂಗ್ ನಿಯಂತ್ರಣವನ್ನು ತೋರಿಸಿ."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ಲಾಗಿನ್‌ನಲ್ಲಿ ಅನಾರ್ಲಾಗ್ ಅನ್ನು ಪ್ರಾರಂಭಿಸಿ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ಸಭೆ ಪ್ರಾರಂಭವಾದಾಗ ಪ್ರಾರಂಭಿಸಿ"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ಸಭೆಯು ಕೊನೆಗೊಂಡಾಗ ನಿಲ್ಲಿಸಿ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ಪ್ರತಿಲೇಖನಕ್ಕಾಗಿ ಮುಖ್ಯ ಭಾಷೆಯನ್ನು ಯಾವಾಗಲೂ ಸೇರಿಸಲಾಗುತ್ತದೆ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "언어 추가"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "음성 언어 추가"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "추가 음성 언어"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "수동으로 실행하지 않아도 항상 준비됩니다."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "앱"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "일정에 연결된 노트의 시작 시간이 되면 자동으로 듣기를 시작합니다."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "회의 앱이 마이크를 해제하면 자동으로 듣기를 중지합니다."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "언어 및 지역"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "요약, 채팅, AI 생성 응답에 사용할 언어"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "기본 언어"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "회의"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "일치하는 언어를 찾을 수 없습니다"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "알림"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "언어 검색..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "언어 선택"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog 개선을 위해 익명 사용 분석을 보냅니다."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "사용 데이터 공유"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "듣는 동안 작은 플로팅 컨트롤을 표시합니다."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "로그인 시 Anarlog 시작"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "회의 시작 시 시작"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "회의 종료 시 중지"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "기본 언어는 전사에 항상 포함됩니다"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ziman lê zêde bike"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Zimanê axaftinê lê zêde bike"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Zimanên axaftinê yên zêde"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Bêyî destpêkirina bi destan her dem amade ye."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Dema ku notek bi piştgiriya bûyerê digihîje dema xweya destpêkê ya plansazkirî, bixweber dest bi guhdarkirinê bike."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Dema sepana civînê mîkrofonê berdide, bixweber guhdarîkirinê rawestîne."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Ziman û Herêm"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ziman ji bo kurtasî, sohbet û bersivên ku ji hêla AI-ê ve hatî çêkirin"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Zimanê sereke"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Hevdîtin"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Zimanên lihevhatî nehatin dîtin"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Agahdar"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Zimanê gerînê..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Ziman hilbijêre"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Analîzên karanîna nenas bişîne da ku alîkariya baştirkirina Anarlog bike."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Daneyên bikaranînê parve bikin"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Dema ku guhdarî dike, kontrolê ya kompakt nîşan bide."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Di têketinê de Anarlogê dest pê bike"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Dema civîn dest pê dike"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Dema civîn biqede raweste"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Zimanê sereke her tim ji bo transkripsiyonê tê de"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Тил кошуу"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Оозеки тилди кошуңуз"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Кошумча сүйлөө тилдери"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Кол менен ишке киргизбестен ар дайым даяр."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Колдонмо"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Окуяга негизделген эскертүү пландаштырылган башталуу убактысына жеткенде, автоматтык түрдө угууну баштаңыз."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Жолугушуу колдонмосу микрофонду чыгарганда, угууну автоматтык түрдө токтотот."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Тил жана аймак"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Кыскача баяндамалар, чаттар жана AI тарабынан түзүлгөн жооптор үчүн тил"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Негизги тил"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Жолугушуулар"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Дал келген тилдер табылган жок"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Эскертмелер"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Тилди издөө..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Тилди тандаңыз"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog'ту жакшыртууга жардам берүү үчүн анонимдүү колдонуу аналитикасын жөнөтүңүз."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Колдонуу дайындарын бөлүшүү"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Угуу учурунда чакан калкыма башкарууну көрсөтүңүз."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Кирүү учурунда Anarlogти баштаңыз"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Жолугушуу башталганда баштаңыз"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Жолугушуу аяктаганда токтоңуз"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Негизги тил ар дайым транскрипция үчүн камтылган"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Linguam addere"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Linguam vocalem addere"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Additional linguas vocales"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Semper sine manually deductis."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatarie audire incipit cum res lippus notae attingit ad tempus initium horarium."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatarie auscultare desinunt cum conventus app tortor ligulam remittit."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Lingua & Regio"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Lingua pro summariis, confabulationibus, et responsis generatis AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Lingua principalis"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Placitum"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Non inventae linguae matching"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificationes"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Quaerere linguam..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Linguam selectam"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Analytica usus anonymi mitte ad meliorem Anarlogum adiuvandum."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Phare usus data"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Monstrare pactionem fluitantem imperium audiendo."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Incipit Anarlog in login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Committitur cum conventu incipit"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Desine cum fines conventum"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Praecipua lingua semper includitur in transcriptione"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Sprooch derbäi"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Füügt geschwat Sprooch"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Zousätzlech geschwat Sproochen"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Immer prett ouni manuell ze starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatesch ufänken ze lauschteren wann en Event-gestützten Notiz seng geplangte Startzäit erreecht."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatesch ophalen ze lauschteren wann d'Versammlungsapp de Mikro erausgeet."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Sprooch & Regioun"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Sprooch fir Zesummefaassungen, Chats, an AI-generéiert Äntwerten"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Haaptsprooch"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Versammlungen"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Keng passende Sprooche fonnt"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notifikatiounen"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Sich Sprooch..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Sprooch auswielen"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Send anonym Notzungsanalyse fir Anarlog ze verbesseren."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Verbrauchsdaten deelen"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Weist déi kompakt schwiewend Kontroll beim Nolauschteren."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Start Anarlog beim Login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Start wann d'Versammlung ufänkt"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stopp wann d'Versammlung eriwwer ass"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "D'Haaptsprooch ass ëmmer fir Transkriptioun abegraff"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ongerako olulimi"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ongerako olulimi olwogerwa"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ennimi endala ezoogerwa"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Bulijjo mwetegefu nga totongozza mu ngalo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ekikozesebwa"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Tandika okuwuliriza mu ngeri ey'otoma nga ekiwandiiko ekiwanirirwa ekibaddewo kituuse ku ssaawa yaakyo etegekeddwa okutandika."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Olekera awo okuwuliriza mu ngeri ey'otoma nga app y'olukiiko efulumya akazindaalo."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Olulimi & Ekitundu"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Olulimi lw'ebifunze, okukubaganya ebirowoozo, n'okuddamu okukolebwa AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Olulimi olukulu"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Enkiiko"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Tewali nnimi zikwatagana zizuuliddwa"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Ebimanyisibwa"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Olulimi lw'okunoonya..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Londa olulimi"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Wereza okwekenneenya enkozesa okutali kwa mannya okuyamba okulongoosa Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Gabana data y'enkozesa"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Laga ekifuga ekitengejja ekitono nga owuliriza."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Tandika Anarlog ku kuyingira"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Tandika ng'olukiiko lutandise"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Komya ng'olukiiko luwedde"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Olulimi olukulu bulijjo luteekebwamu okuwandiika"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Bakisa monoko"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Bakisa monoko oyo balobaka"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Minoko ya kobakisa oyo balobaka"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ezali ntango nyonso prêt sans lancement manuellement."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Esaleli"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Banda koyoka na ndenge ya automatique tango note oyo esimbami na likambo ekomi na ngonga na yango ya kobanda oyo esengelaki."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Tika koyoka na ndenge ya automatique tango appli ya likita ebimisaka micro."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Monoko & Etuka"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Monoko mpo na bokuse, masolo, mpe biyano oyo esalemi na AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Monoko ya monene"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Makita"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Minoko oyo ekokani ezwami te"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Mayebisi"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Boluka monoko..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pona monoko"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Tinda ba analyses ya usage anonyme mpo na kosunga kobongisa Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Kabola ba données ya bosaleli"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Lakisa contrôle flottante compact tango ozali koyoka."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Banda Anarlog na bokoti"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Banda tango likita ekobanda"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Tika tango likita ekosila"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Monoko ya monene ekotisami ntango nyonso mpo na bokomi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ເພີ່ມພາສາ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "ເພີ່ມພາສາເວົ້າ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ພາສາເວົ້າເພີ່ມເຕີມ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ພ້ອມສະເໝີໂດຍບໍ່ມີການເປີດດ້ວຍຕົນເອງ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ແອັບ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ເລີ່ມຟັງອັດຕະໂນມັດເມື່ອບັນທຶກເຫດການທີ່ຮອງຮັບຮອດເວລາເລີ່ມຕົ້ນທີ່ກຳນົດໄວ້."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "ຢຸດຟັງອັດຕະໂນມັດເມື່ອແອັບປະຊຸມປ່ອຍໄມໂຄຣໂຟນ."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ພາສາ ແລະພາກພື້ນ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ພາສາສຳລັບບົດສະຫຼຸບ, ການສົນທະນາ ແລະຄຳຕອບທີ່ສ້າງຂຶ້ນໂດຍ AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ພາສາຫຼັກ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ການປະຊຸມ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ບໍ່ພົບພາສາທີ່ກົງກັນ"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "ການແຈ້ງເຕືອນ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ພາສາຄົ້ນຫາ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ເລືອກພາສາ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "ສົ່ງການວິເຄາະການນຳໃຊ້ທີ່ບໍ່ເປີດເຜີຍຊື່ເພື່ອຊ່ວຍປັບປຸງ Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ແບ່ງປັນຂໍ້ມູນການນຳໃຊ້"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ສະແດງການຄວບຄຸມການລອຍຕົວແບບກະທັດຮັດໃນຂະນະທີ່ຟັງ."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ເລີ່ມ​ຕົ້ນ​ອະນາ​ລັອກ​ທີ່​ເຂົ້າ​ສູ່​ລະ​ບົບ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ເລີ່ມເມື່ອການປະຊຸມເລີ່ມຕົ້ນ"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ຢຸດເມື່ອການປະຊຸມຈົບລົງ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ພາສາຫຼັກແມ່ນລວມເຂົ້າກັບການຖອດຂໍ້ຄວາມສະເໝີ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Pridėti kalbą"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Pridėti šnekamąją kalbą"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Papildomos šnekamosios kalbos"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Visada paruoštas nepaleidus rankiniu būdu."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Programa"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatiškai pradėkite klausytis, kai įvykiu paremta pastaba pasiekia suplanuotą pradžios laiką."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatiškai sustabdyti klausymą, kai susitikimo programa atleidžia mikrofoną."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Kalba ir regionas"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Suvestinių, pokalbių ir dirbtinio intelekto sugeneruotų atsakymų kalba"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Pagrindinė kalba"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Susitikimai"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nerasta atitinkančių kalbų"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Pranešimai"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Paieškos kalba..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pasirinkite kalbą"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Siųskite anoniminę naudojimo analizę, kad padėtumėte tobulinti „Anarlog“."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Bendrinti naudojimo duomenis"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Klausydami rodykite kompaktišką slankiojantį valdiklį."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Prisijungę paleiskite Anarlog"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Pradėkite susitikimo pradžioje"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Sustabdykite susitikimui pasibaigus"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Pagrindinė kalba visada įtraukiama transkripcijai"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Pievienot valodu"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Pievienojiet runāto valodu"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Papildu runātās valodas"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Vienmēr gatavs bez manuālas palaišanas."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Lietotne"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automātiski sāciet klausīties, kad ar notikumu nodrošināta piezīme sasniedz ieplānoto sākuma laiku."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automātiski pārtraukt klausīšanos, kad sapulces lietotne atbrīvo mikrofonu."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Valoda un reģions"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Kopsavilkumu, tērzēšanas un AI ģenerētu atbilžu valoda"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Galvenā valoda"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Sapulces"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nav atrasta neviena atbilstoša valoda"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Paziņojumi"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Meklēšanas valoda..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Atlasiet valodu"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Nosūtiet anonīmu lietojuma analīzi, lai palīdzētu uzlabot Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Kopīgojiet lietojuma datus"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Klausīšanās laikā parādiet kompakto peldošo vadību."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Sāciet Anarlog pie pieteikšanās"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Sāciet, kad sākas sapulce"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Pārtraukt, kad sapulce beidzas"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Transkripcijai vienmēr tiek iekļauta galvenā valoda"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ampio fiteny"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ampio fiteny ampiasaina"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Fiteny ampiasaina fanampiny"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Vonona foana nefa tsy alefa amin'ny tanana."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Manomboka mihaino ho azy rehefa tonga amin'ny ora voatondro hanombohana ny naoty tohanan'ny hetsika."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Atsaharo ho azy ny fihainoana rehefa mamoaka ny mikrô ny fampiharana fivoriana."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Fiteny & Faritra"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Fiteny ho an'ny famintinana, resadresaka, ary valiny azo avy amin'ny AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Fiteny fototra"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Fihaonana"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Tsy misy fiteny mifanandrify hita"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Fampandrenesana"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Fiteny fikarohana..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Misafidiana fiteny"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Mandefa fanadihadiana momba ny fampiasana tsy mitonona anarana hanampy amin'ny fanatsarana Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Mizara angona fampiasana"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Asehoy ny fanaraha-maso mitsingevana kanto eo am-pihainoana."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Atombohy Anarlog amin'ny fidirana"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Atombohy rehefa manomboka ny fivoriana"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Atsaharo rehefa tapitra ny fivoriana"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Ampidirina foana ny fiteny fototra ho an'ny fandikana"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tāpiri reo"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Taapirihia te reo korero"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Apiti atu reo korero"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Kua reri tonu me te kore e whakarewa ringa."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Taupānga"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Ka timata te whakarongo aunoa ina tae te tuhipoka tautoko takahanga ki tona wa tiimata kua whakaritea."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Kati aunoa te whakarongo ina tukuna e te taupānga hui te hopuoro."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Reo me te Rohe"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Reo mo nga whakarāpopototanga, nga korerorero, me nga whakautu i hangaia e AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Te reo matua"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Nga Hui"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Kāore he reo ōrite i kitea"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Whakamōhiotanga"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Rapu reo..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Tīpakohia te reo"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Tukuna nga tātaritanga whakamahinga ingoamuna hei whakapai ake i te Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Tirihia nga raraunga whakamahinga"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Whakaatuhia te mana maanu kiato i te wa e whakarongo ana."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Tīmata Anarlog i te takiuru"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Timata ina timata te hui"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Kati ina mutu te hui"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Kei roto tonu te reo matua mo te tuhi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Додајте јазик"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Додајте говорен јазик"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Дополнителни говорни јазици"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Секогаш подготвен без рачно стартување."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Апликација"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Автоматски започнете со слушање кога белешката поддржана со настан ќе го достигне планираното време за почеток."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Автоматски престанете да слушате кога апликацијата за состанок ќе го ослободи микрофонот."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Јазик и регион"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Јазик за резимеа, разговори и одговори генерирани од вештачка интелигенција"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Главен јазик"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Средби"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Не се најдени јазици што се совпаѓаат"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Известувања"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Јазик за пребарување..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Изберете јазик"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Испратете анонимна аналитика за користење за да помогнете во подобрувањето на Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Споделете податоци за користење"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Покажете ја компактната пловечка контрола додека слушате."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Започнете Anarlog при најавување"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Започнете кога ќе започне состанокот"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Стоп кога ќе заврши состанокот"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Главниот јазик е секогаш вклучен за транскрипција"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ഭാഷ ചേർക്കുക"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "സംസാരിക്കുന്ന ഭാഷ ചേർക്കുക"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "കൂടുതൽ സംസാരിക്കുന്ന ഭാഷകൾ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "സ്വയം ലോഞ്ച് ചെയ്യാതെ എപ്പോഴും തയ്യാറാണ്."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ആപ്പ്"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ഒരു ഇവൻ്റ് പിന്തുണയുള്ള കുറിപ്പ് ഷെഡ്യൂൾ ചെയ്ത ആരംഭ സമയത്തിൽ എത്തുമ്പോൾ സ്വയമേവ കേൾക്കാൻ ആരംഭിക്കുക."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "മീറ്റിംഗ് ആപ്പ് മൈക്രോഫോൺ റിലീസ് ചെയ്യുമ്പോൾ കേൾക്കുന്നത് സ്വയമേവ നിർത്തുക."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ഭാഷയും പ്രദേശവും"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "സംഗ്രഹങ്ങൾ, ചാറ്റുകൾ, AI സൃഷ്ടിച്ച പ്രതികരണങ്ങൾ എന്നിവയ്ക്കുള്ള ഭാഷ"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "പ്രധാന ഭാഷ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "മീറ്റിംഗുകൾ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "പൊരുത്തമുള്ള ഭാഷകളൊന്നും കണ്ടെത്തിയില്ല"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "അറിയിപ്പുകൾ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ഭാഷ തിരയുക..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ഭാഷ തിരഞ്ഞെടുക്കുക"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "അനാർലോഗ് മെച്ചപ്പെടുത്താൻ സഹായിക്കുന്നതിന് അജ്ഞാത ഉപയോഗ അനലിറ്റിക്‌സ് അയയ്‌ക്കുക."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ഉപയോഗ ഡാറ്റ പങ്കിടുക"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ശ്രവിക്കുന്ന സമയത്ത് ഒതുക്കമുള്ള ഫ്ലോട്ടിംഗ് നിയന്ത്രണം കാണിക്കുക."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ലോഗിൻ ചെയ്യുമ്പോൾ അനർലോഗ് ആരംഭിക്കുക"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "മീറ്റിംഗ് ആരംഭിക്കുമ്പോൾ ആരംഭിക്കുക"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "മീറ്റിംഗ് അവസാനിക്കുമ്പോൾ നിർത്തുക"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ട്രാൻസ്ക്രിപ്ഷനായി പ്രധാന ഭാഷ എപ്പോഴും ഉൾപ്പെടുത്തിയിട്ടുണ്ട്"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Хэл нэмэх"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ярианы хэл нэмэх"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Нэмэлт ярианы хэлүүд"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Гараар эхлүүлэхгүйгээр үргэлж бэлэн байна."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Програм"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Үйл явдалд тулгуурласан тэмдэглэл төлөвлөсөн эхлэх цагтаа хүрэх үед автоматаар сонсож эхэлнэ."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Уулзалтын апп микрофоноо гаргах үед автоматаар сонсохоо зогсоо."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Хэл ба бүс"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Тойм, чат болон хиймэл оюун ухаанаар үүсгэсэн хариултуудын хэл"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Үндсэн хэл"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Уулзалт"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Тохирох хэл олдсонгүй"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Мэдэгдэл"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Хэл хайх..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Хэл сонгох"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog-г сайжруулахад туслах нэргүй хэрэглээний аналитик илгээнэ үү."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Ашиглалтын өгөгдлийг хуваалцах"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Сонсож байхдаа авсаархан хөвөгч удирдлагыг харуул."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Нэвтрэх үед Anarlog-г эхлүүлнэ үү"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Уулзалт эхлэхэд эхэл"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Уулзалт дуусахад зогсох"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Үндсэн хэлийг транскрипцэд үргэлж оруулдаг"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "भाषा जोडा"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "बोलीची भाषा जोडा"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "अतिरिक्त बोलल्या जाणाऱ्या भाषा"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "मॅन्युअली लॉन्च न करता नेहमी तयार."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ॲप"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "इव्हेंट-बॅक्ड टीप त्याच्या शेड्यूल केलेल्या प्रारंभ वेळेपर्यंत पोहोचल्यावर आपोआप ऐकणे सुरू करा."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "मीटिंग ॲप मायक्रोफोन रिलीज करते तेव्हा आपोआप ऐकणे थांबवा."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "भाषा आणि प्रदेश"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "सारांश, चॅट आणि AI-व्युत्पन्न प्रतिसादांसाठी भाषा"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "मुख्य भाषा"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "मीटिंग्ज"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "कोणत्याही जुळणारी भाषा आढळली नाही"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "भाषा शोधा..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "भाषा निवडा"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog सुधारण्यात मदत करण्यासाठी अनामित वापर विश्लेषण पाठवा."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "वापर डेटा सामायिक करा"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ऐकताना कॉम्पॅक्ट फ्लोटिंग कंट्रोल दाखवा."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "लॉगिनवर Anarlog सुरू करा"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "मीटिंग सुरू झाल्यावर सुरू करा"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "मीटिंग संपल्यावर थांबा"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "मुख्य भाषा नेहमी लिप्यंतरणासाठी समाविष्ट केली जाते"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tambah bahasa"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Tambahkan bahasa pertuturan"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Bahasa pertuturan tambahan"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Sentiasa bersedia tanpa melancarkan secara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Apl"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Mula mendengar secara automatik apabila nota yang disokong acara mencapai masa mula yang dijadualkan."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Berhenti mendengar secara automatik apabila apl mesyuarat mengeluarkan mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Bahasa & Wilayah"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Bahasa untuk ringkasan, sembang dan respons yang dijana AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Bahasa utama"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Mesyuarat"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Tiada bahasa yang sepadan ditemui"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Pemberitahuan"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Bahasa carian..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pilih bahasa"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Hantar analitis penggunaan tanpa nama untuk membantu memperbaik Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Kongsi data penggunaan"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Tunjukkan kawalan terapung padat semasa mendengar."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Mulakan Anarlog semasa log masuk"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Mulakan apabila mesyuarat bermula"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Berhenti apabila mesyuarat tamat"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Bahasa utama sentiasa disertakan untuk transkripsi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Żid il-lingwa"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Żid il-lingwa mitkellma"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Lingwi mitkellma addizzjonali"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Dejjem lest mingħajr tnedija manwalment."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Ibda tisma' awtomatikament meta nota sostnuta minn avveniment tilħaq il-ħin tal-bidu skedat tagħha."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Awtomatikament tieqaf tisma' meta l-app tal-laqgħa toħroġ il-mikrofonu."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Lingwa u Reġjun"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Lingwa għal sommarji, chats, u tweġibiet iġġenerati mill-AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Lingwa prinċipali"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Laqgħat"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "L-ebda lingwa li taqbel ma nstabet"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notifiki"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Fittex fil-lingwa..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Agħżel il-lingwa"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Ibgħat analiżi tal-użu anonima biex tgħin ittejjeb Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Aqsam id-dejta tal-użu"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Uri l-kontroll kompatt f'wiċċ l-ilma waqt li tisma'."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Ibda Anarlog mal-login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Ibda meta tibda l-laqgħa"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Ieqaf meta tintemm il-laqgħa"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Il-lingwa ewlenija hija dejjem inkluża għat-traskrizzjoni"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ဘာသာစကားထည့်ပါ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "ပြောသောဘာသာစကားကို ထည့်ပါ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "နောက်ထပ် ပြောဆိုသော ဘာသာစကားများ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ကိုယ်တိုင်မဖွင့်ဘဲ အမြဲတမ်းအဆင်သင့်ဖြစ်နေပါပြီ။"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "အက်ပ်"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "အစီအစဉ်- ကျောထောက်နောက်ခံပြုထားသော မှတ်စုသည် ၎င်း၏သတ်မှတ်ထားသော စတင်ချိန်သို့ ရောက်ရှိသည့်အခါ အလိုအလျောက် စတင်နားထောင်ပါသည်။"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "အစည်းအဝေးအက်ပ်က မိုက်ခရိုဖုန်းကို ထုတ်သည့်အခါ အလိုအလျောက် နားထောင်ခြင်းကို ရပ်လိုက်ပါ။"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ဘာသာစကားနှင့် ဒေသ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "အနှစ်ချုပ်များ၊ ချတ်များနှင့် AI ဖန်တီးထားသော တုံ့ပြန်မှုများအတွက် ဘာသာစကား"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ပင်မဘာသာစကား"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "အစည်းအဝေးများ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "တူညီသောဘာသာစကားများကိုမတွေ့ပါ"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "သတိပေးချက်များ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ရှာဖွေရန် ဘာသာစကား..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ဘာသာစကားကို ရွေးပါ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Analog ပိုမိုကောင်းမွန်လာစေရန်အတွက် အမည်မသိအသုံးပြုမှု ခွဲခြမ်းစိတ်ဖြာချက်များကို ပေးပို့ပါ။"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "အသုံးပြုမှုဒေတာကို မျှဝေပါ"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "နားထောင်နေစဉ် ကျစ်လျစ်သော ရေပေါ်ထိန်းချုပ်မှုကို ပြသပါ။"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "အကောင့်ဝင်ချိန်တွင် Anarlog စတင်ပါ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "အစည်းအဝေးစတင်သည့်အခါ စတင်ပါ"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "အစည်းအဝေးပြီးဆုံးသည့်အခါ ရပ်ပါ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "အဓိကဘာသာစကားကို စာသားမှတ်တမ်းအတွက် အမြဲထည့်သွင်းထားသည်"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "भाषा थप्नुहोस्"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "बोल्ने भाषा थप्नुहोस्"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "अतिरिक्त बोलिने भाषाहरू"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "मैन्युअल रूपमा सुरु नगरी सधैं तयार।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "एप"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "इभेन्ट-ब्याक गरिएको नोट आफ्नो निर्धारित सुरु समयमा पुग्दा स्वचालित रूपमा सुन्न सुरु गर्नुहोस्।"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "मिटिङ एपले माइक्रोफोन रिलिज गर्दा स्वतः सुन्न बन्द गर्नुहोस्।"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "भाषा र क्षेत्र"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "सारांश, च्याट, र AI-उत्पन्न प्रतिक्रियाहरूको लागि भाषा"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "मुख्य भाषा"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "बैठकहरू"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "कुनै मिल्दो भाषा भेटिएन"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "सूचनाहरू"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "भाषा खोज्नुहोस्..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "भाषा चयन गर्नुहोस्"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog सुधार गर्न मद्दत गर्न बेनामी प्रयोग विश्लेषणहरू पठाउनुहोस्।"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "उपयोग डाटा साझेदारी गर्नुहोस्"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "सुन्दा कम्प्याक्ट फ्लोटिंग नियन्त्रण देखाउनुहोस्।"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "लगइनमा Anarlog सुरु गर्नुहोस्"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "बैठक सुरु हुँदा सुरु गर्नुहोस्"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "बैठक समाप्त हुँदा रोक्नुहोस्"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "मुख्य भाषा सधैँ ट्रान्सक्रिप्शनको लागि समावेश गरिन्छ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Taal toevoegen"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Gesproken taal toevoegen"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Extra gesproken talen"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Altijd klaar zonder handmatig te starten."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Begin automatisch met luisteren wanneer een door een gebeurtenis ondersteunde noot de geplande starttijd bereikt."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Stop automatisch met luisteren wanneer de vergaderapp de microfoon loslaat."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Taal en regio"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Taal voor samenvattingen, chats en door AI gegenereerde reacties"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hoofdtaal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Vergaderingen"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Geen overeenkomende talen gevonden"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Meldingen"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Zoektaal..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Selecteer taal"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Verzend anonieme gebruiksanalyses om Anarlog te helpen verbeteren."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Gebruiksgegevens delen"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Laat de compacte zwevende bediening zien terwijl je luistert."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Start Anarlog bij inloggen"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Start wanneer de vergadering begint"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stoppen wanneer de vergadering eindigt"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "De hoofdtaal is altijd opgenomen voor transcriptie"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Legg til språk"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Legg til talespråk"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Flere talespråk"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Alltid klar uten å starte manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Begynn automatisk å lytte når et hendelsesstøttet notat når sin planlagte starttid."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Slutt automatisk å lytte når møteappen slipper mikrofonen."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Språk og region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Språk for sammendrag, chatter og AI-genererte svar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hovedspråk"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Møter"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Fant ingen samsvarende språk"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Søkespråk..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Velg språk"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Send anonym bruksanalyse for å forbedre Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Del bruksdata"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Vis den kompakte flytende kontrollen mens du lytter."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Start Anarlog ved pålogging"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Start når møtet begynner"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stopp når møtet avsluttes"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Hovedspråket er alltid inkludert for transkripsjon"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Legg til språk"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Legg til talespråk"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Flere talespråk"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Alltid klar uten å starte manuelt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Begynn automatisk å lytte når et hendelsesstøttet notat når sin planlagte starttid."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Slutt automatisk å lytte når møteappen slipper mikrofonen."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Språk og region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Språk for sammendrag, chatter og AI-genererte svar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hovedspråk"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Møter"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Fant ingen samsvarende språk"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Varsler"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Søkespråk..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Velg språk"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Send anonym bruksanalyse for å forbedre Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Del bruksdata"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Vis den kompakte flytende kontrollen mens du lytter."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Start Anarlog ved pålogging"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Start når møtet begynner"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stopp når møtet avsluttes"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Hovedspråket er alltid inkludert for transkripsjon"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Onjezani chilankhulo"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Onjezani chilankhulo"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Zilankhulo zina zoyankhulidwa"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Zimakhala zokonzeka nthawi zonse osatsegula pamanja."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Mapulogalamu"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Yambani kumvetsera mwachisawawa cholembedwa chotsatira chochitika chikafika nthawi yake yoyambira."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Siyani kumvetsera basi pulogalamu yamsonkhano ikatulutsa cholankhulira."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Chinenero & Chigawo"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Chiyankhulo chachidule, macheza, ndi mayankho opangidwa ndi AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Chiyankhulo chachikulu"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Misonkhano"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Palibe zilankhulo zofananira zomwe zapezeka"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Zidziwitso"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Sakani chilankhulo..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Sankhani chinenero"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Tumizani zowerengera zomwe simukuzitchula kuti zithandizire kukonza Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Gawani zogwiritsa ntchito"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Onetsani chowongolera choyandama uku mukumvetsera."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Yambitsani Anarlog polowera"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Yambani msonkhano ukayamba"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Imani msonkhano ukatha"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Chiyankhulo chachikulu chimaphatikizidwa nthawi zonse kuti chilembedwe"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Apondre la lenga"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Apondètz la lenga parlada"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Lengas parladas suplementàrias"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Totjorn prèst sens lo lançament manualament."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplicacion"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Aviar l'escota automaticament quand una nòta sostenguda per un eveniment atenh son ora de començament programada."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Arrèsta automaticament l'escota quand l'aplicacion de reünion libera lo micrò."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Lenga & Region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Lenga pels resumits, las charradissas e las responsas generadas per l'IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Lenga principala"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Reünions"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Cap de lenga correspondenta pas trobada"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificacions"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Cercar lenga..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Seleccionar la lenga"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Mandar d'analisis d'utilizacion anonims per ajudar a melhorar Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Partejar las donadas d'utilizacion"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Afichar lo contraròtle flotant compacte pendent l'escota."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Aviar l'Anarlog al moment de la connexion"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Aviar quand la reünion comença"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "S'arrestar quand la reünion s'acaba"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "La lenga principala es totjorn inclusa per la transcripcion"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ଭାଷା ଯୋଡନ୍ତୁ |"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "କଥିତ ଭାଷା ଯୋଡନ୍ତୁ |"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ଅତିରିକ୍ତ କଥିତ ଭାଷା |"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ମାନୁଆଲ ଲଞ୍ଚ ନକରି ସର୍ବଦା ପ୍ରସ୍ତୁତ |"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ଆପ୍"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ଯେତେବେଳେ ଏକ ଇଭେଣ୍ଟ-ସମର୍ଥିତ ନୋଟ୍ ଏହାର ନିର୍ଦ୍ଧାରିତ ଆରମ୍ଭ ସମୟରେ ପହଞ୍ଚେ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଶୁଣିବା ଆରମ୍ଭ କରେ |"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "ମିଟିଂ ଆପ୍ ମାଇକ୍ରୋଫୋନ୍ ରିଲିଜ୍ କଲାବେଳେ ସ୍ୱୟଂଚାଳିତ ଭାବରେ ଶୁଣିବା ବନ୍ଦ କର |"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ଭାଷା ଏବଂ ଅଞ୍ଚଳ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ସାରାଂଶ, ଚାଟ୍, ଏବଂ AI- ସୃଷ୍ଟି ପ୍ରତିକ୍ରିୟା ପାଇଁ ଭାଷା |"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ମୁଖ୍ୟ ଭାଷା |"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ମିଟିଂ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "କ No ଣସି ମେଳକ ଭାଷା ମିଳିଲା ନାହିଁ |"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "ବିଜ୍ଞପ୍ତିଗୁଡିକ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ସନ୍ଧାନ ଭାଷା ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ଭାଷା ଚୟନ କରନ୍ତୁ |"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "ଅନାର୍ଲଗ୍ ଉନ୍ନତି କରିବାରେ ସାହାଯ୍ୟ କରିବାକୁ ଅଜ୍ଞାତ ବ୍ୟବହାର ଆନାଲିଟିକ୍ସ ପଠାନ୍ତୁ |"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ବ୍ୟବହାର ତଥ୍ୟ ଅଂଶୀଦାର କରନ୍ତୁ |"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ଶୁଣିବା ସମୟରେ କମ୍ପାକ୍ଟ ଫ୍ଲୋଟିଂ କଣ୍ଟ୍ରୋଲ୍ ଦେଖାନ୍ତୁ |"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ଲଗଇନ୍ ରେ ଅନାର୍ଲଗ୍ ଆରମ୍ଭ କରନ୍ତୁ |"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ସଭା ଆରମ୍ଭ ହେବା ପରେ ଆରମ୍ଭ କରନ୍ତୁ |"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ସଭା ସମାପ୍ତ ହେବା ପରେ ବନ୍ଦ କର |"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ମୂଖ୍ୟ ଭାଷା ସର୍ବଦା ଟ୍ରାନ୍ସକ୍ରିପସନ୍ ପାଇଁ ଅନ୍ତର୍ଭୁକ୍ତ |"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ਭਾਸ਼ਾ ਜੋੜੋ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "ਬੋਲੀ ਜਾਣ ਵਾਲੀ ਭਾਸ਼ਾ ਸ਼ਾਮਲ ਕਰੋ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ਵਧੀਕ ਬੋਲੀਆਂ ਜਾਣ ਵਾਲੀਆਂ ਭਾਸ਼ਾਵਾਂ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "ਹੱਥੀਂ ਲਾਂਚ ਕੀਤੇ ਬਿਨਾਂ ਹਮੇਸ਼ਾ ਤਿਆਰ।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ਐਪ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ਜਦੋਂ ਕੋਈ ਇਵੈਂਟ-ਬੈਕਡ ਨੋਟ ਆਪਣੇ ਨਿਰਧਾਰਤ ਸ਼ੁਰੂਆਤੀ ਸਮੇਂ 'ਤੇ ਪਹੁੰਚਦਾ ਹੈ ਤਾਂ ਆਪਣੇ ਆਪ ਸੁਣਨਾ ਸ਼ੁਰੂ ਕਰੋ।"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "ਮੀਟਿੰਗ ਐਪ ਮਾਈਕ੍ਰੋਫ਼ੋਨ ਨੂੰ ਰਿਲੀਜ਼ ਕਰਨ 'ਤੇ ਸਵੈਚਲਿਤ ਤੌਰ 'ਤੇ ਸੁਣਨਾ ਬੰਦ ਕਰੋ।"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ਭਾਸ਼ਾ ਅਤੇ ਖੇਤਰ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ਸਾਰਾਂ, ਚੈਟਾਂ, ਅਤੇ AI ਦੁਆਰਾ ਤਿਆਰ ਕੀਤੇ ਜਵਾਬਾਂ ਲਈ ਭਾਸ਼ਾ"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ਮੁੱਖ ਭਾਸ਼ਾ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ਮੀਟਿੰਗਾਂ"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ਕੋਈ ਮੇਲ ਖਾਂਦੀ ਭਾਸ਼ਾ ਨਹੀਂ ਮਿਲੀ"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "ਸੂਚਨਾਵਾਂ"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ਭਾਸ਼ਾ ਖੋਜੋ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ਭਾਸ਼ਾ ਚੁਣੋ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "ਐਨਾਰਲੌਗ ਨੂੰ ਬਿਹਤਰ ਬਣਾਉਣ ਵਿੱਚ ਮਦਦ ਲਈ ਅਗਿਆਤ ਵਰਤੋਂ ਵਿਸ਼ਲੇਸ਼ਣ ਭੇਜੋ।"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ਵਰਤੋਂ ਡੇਟਾ ਸਾਂਝਾ ਕਰੋ"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ਸੁਣਦੇ ਸਮੇਂ ਸੰਖੇਪ ਫਲੋਟਿੰਗ ਕੰਟਰੋਲ ਦਿਖਾਓ।"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "ਲੌਗਇਨ 'ਤੇ ਐਨਾਰਲੌਗ ਸ਼ੁਰੂ ਕਰੋ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "ਮੀਟਿੰਗ ਸ਼ੁਰੂ ਹੋਣ 'ਤੇ ਸ਼ੁਰੂ ਕਰੋ"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "ਮੀਟਿੰਗ ਖਤਮ ਹੋਣ 'ਤੇ ਰੋਕੋ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ਮੁੱਖ ਭਾਸ਼ਾ ਹਮੇਸ਼ਾ ਟ੍ਰਾਂਸਕ੍ਰਿਪਸ਼ਨ ਲਈ ਸ਼ਾਮਲ ਕੀਤੀ ਜਾਂਦੀ ਹੈ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dodaj język"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Dodaj język mówiony"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Dodatkowe języki mówione"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Zawsze gotowy, bez ręcznego uruchamiania."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikacja"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automatycznie rozpocznij słuchanie, gdy nuta oparta na zdarzeniu osiągnie zaplanowany czas rozpoczęcia."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automatycznie przestań słuchać, gdy aplikacja do spotkań zwolni mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Język i region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Język podsumowań, czatów i odpowiedzi generowanych przez sztuczną inteligencję"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Język główny"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Spotkania"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nie znaleziono pasujących języków"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Powiadomienia"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Wyszukaj język..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Wybierz język"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Wysyłaj anonimowe analizy użytkowania, aby pomóc ulepszyć Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Udostępnij dane o użytkowaniu"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Pokaż kompaktowy, pływający element sterujący podczas słuchania."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Uruchom Anarlog przy logowaniu"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Rozpocznij w momencie rozpoczęcia spotkania"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Zatrzymaj po zakończeniu spotkania"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Do transkrypcji zawsze uwzględniany jest język główny"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ژبه اضافه کړئ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "د ویل شوي ژبه اضافه کړئ"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "اضافي خبرې شوي ژبې"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "د لاسي پیل کولو پرته تل چمتو وي."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ایپ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "په اوتومات ډول اوریدل پیل کړئ کله چې د پیښې ملاتړ شوی یادداشت خپل ټاکل شوي پیل وخت ته ورسیږي."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "کله چې د ناستې ایپ مایکروفون خوشې کوي په اوتومات ډول اوریدل بند کړئ."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ژبه او سیمه"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "د لنډیزونو، چیټونو، او د AI لخوا تولید شوي ځوابونو لپاره ژبه"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "اصلي ژبه"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "غونډې"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "هیڅ ورته ژبه ونه موندل شوه"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "د ژبې لټون..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ژبه وټاکئ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "د انارلوګ په ښه کولو کې د مرستې لپاره د نامعلوم کارونې تحلیلونه واستوئ."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "د کارونې ډاټا شریک کړئ"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "د اوریدلو پر مهال د کمپیکٹ فلوټینګ کنټرول وښایاست."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "په ننوتلو کې انارلوګ پیل کړئ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "کله چې ناسته پیل شي پیل کړئ"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "کله چې ناسته پای ته ورسیږي ودروئ"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "اصلي ژبه تل د لیږد لپاره شامله ده"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Adicionar idioma"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Adicionar idioma falado"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Idiomas falados adicionais"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Sempre pronto sem iniciar manualmente."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplicativo"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Começar a ouvir automaticamente quando uma nota vinculada a um evento chegar ao horário de início agendado."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Parar de ouvir automaticamente quando o aplicativo de reunião liberar o microfone."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Idioma e região"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Idioma para resumos, chats e respostas geradas por IA"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Idioma principal"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Reuniões"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nenhum idioma correspondente encontrado"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificações"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Pesquisar idioma..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Selecionar idioma"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Enviar análises anônimas de uso para ajudar a melhorar o Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Compartilhar dados de uso"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Mostrar o controle flutuante compacto durante a escuta."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Iniciar Anarlog ao entrar"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Iniciar quando a reunião começar"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Parar quando a reunião terminar"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "O idioma principal é sempre incluído para transcrição"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Adăugați limba"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Adăugați limba vorbită"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Limbi vorbite suplimentare"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Întotdeauna gata fără lansare manuală."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplicație"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Începe automat ascultarea când o notă susținută de un eveniment atinge ora de începere programată."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Opriți automat ascultarea când aplicația pentru întâlniri eliberează microfonul."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Limbă și regiune"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Limba pentru rezumate, chaturi și răspunsuri generate de AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Limba principală"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Întâlniri"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nu s-au găsit limbi care se potrivesc"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Notificări"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Căutați limba..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Selectați limba"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Trimiteți analize anonime de utilizare pentru a ajuta la îmbunătățirea Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Partajați datele de utilizare"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Afișați controlul flotant compact în timp ce ascultați."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Porniți Anarlog la conectare"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Începe când începe întâlnirea"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Opriți când întâlnirea se încheie"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Limba principală este întotdeauna inclusă pentru transcriere"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Добавить язык"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Добавить разговорный язык"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Дополнительные разговорные языки"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Всегда готов без запуска вручную."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Приложение"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Автоматически начинать прослушивание, когда заметка, основанная на событии, достигает запланированного времени начала."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Автоматически прекращать прослушивание, когда приложение для встреч отпускает микрофон."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Язык и регион"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Язык для сводок, чатов и ответов, генерируемых искусственным интеллектом"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Основной язык"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Встречи"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Подходящие языки не найдены"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Уведомления"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Язык поиска..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Выбрать язык"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Отправлять анонимную аналитику использования, чтобы помочь улучшить Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Поделиться данными об использовании"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Показывать компактный плавающий элемент управления во время прослушивания."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Запускать Anarlog при входе в систему"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Начать, когда начнется собрание"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Остановиться, когда встреча закончится"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Основной язык всегда включен в транскрипцию"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "भाषा योजयतु"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "भाषितभाषा योजयतु"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "अतिरिक्तभाष्यभाषा"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "हस्तेन प्रक्षेपणं विना सर्वदा सज्जम्।"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "अनुप्रयोग"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "यदा घटना-समर्थित-टिप्पणी स्वस्य निर्धारित-प्रारम्भसमयं प्राप्नोति तदा स्वयमेव श्रोतुं आरभत ।"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "यदा सभा-अनुप्रयोगः माइक्रोफोनं मुक्तं करोति तदा स्वयमेव श्रवणं स्थगयति ।"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "भाषा एवं क्षेत्र"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "सारांशानां, गपशपानां, एआइ-जनितप्रतिसादानां च भाषा"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "मुख्यभाषा"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "समागमाः"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "न सङ्गतभाषा लभ्यते"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "सूचना"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "भाषां अन्वेष्टुम्..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "भाषां चिनोतु"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog इत्यस्य उन्नयनार्थं सहायतार्थं अनामिकं उपयोगविश्लेषणं प्रेषयन्तु ।"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "उपयोगदत्तांशं साझां कुर्वन्तु"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "श्रवणकाले संकुचितं प्लवमानं नियन्त्रणं दर्शयतु।"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "प्रवेशसमये Anarlog आरभत"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "समागमस्य आरम्भे आरभत"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "समागमस्य समाप्तेः समये स्थगयतु"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "प्रतिलेखनार्थं मुख्यभाषा सर्वदा समाविष्टा भवति"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "ٻولي شامل ڪريو"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "ڳالهائيندڙ ٻولي شامل ڪريو"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "اضافي ڳالهائيندڙ ٻوليون"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "دستي طور تي لانچ ڪرڻ کان سواءِ هميشه تيار."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ايپ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "خود بخود ٻڌڻ شروع ڪريو جڏھن ھڪڙي واقعي جي پٺڀرائي نوٽ پنھنجي مقرر ڪيل وقت تي پھچي."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "خود بخود ٻڌڻ بند ڪريو جڏھن ميٽنگ ايپ مائڪروفون جاري ڪري ٿي."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ٻولي ۽ علائقو"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "خلاصو، چيٽ، ۽ AI جي ٺاهيل جوابن لاءِ ٻولي"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "مکيه ٻولي"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "ملاقات"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ڪابه ملندڙ ٻوليون نه مليون"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ٻولي ڳولھيو..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "ٻولي چونڊيو"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "انارلاگ کي بهتر ڪرڻ ۾ مدد لاءِ گمنام استعمال جا تجزيا موڪليو."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "استعمال ڊيٽا حصيداري ڪريو"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ٻڌڻ دوران ڪمپيڪٽ سچل ڪنٽرول ڏيکاريو."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "لاگ ان تي Anarlog شروع ڪريو"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "شروع ڪريو جڏهن ميٽنگ شروع ٿئي"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "جڏهن ميٽنگ ختم ٿئي ته روڪيو"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "مکيه ٻولي هميشه ٽرانسپشن لاءِ شامل ڪئي ويندي آهي"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "භාෂාව එක් කරන්න"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "කථන භාෂාව එක් කරන්න"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "අමතර කථන භාෂා"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "අතින් දියත් නොකර සැම විටම සූදානම්."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "යෙදුම"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "සිදුවීම් පිටුබලය සහිත සටහනක් එහි නියමිත ආරම්භක වේලාවට ළඟා වූ විට ස්වයංක්‍රීයව සවන් දීම ආරම්භ කරන්න."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "රැස්වීම් යෙදුම මයික්‍රෆෝනය මුදා හරින විට ස්වයංක්‍රීයව සවන් දීම නවත්වන්න."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "භාෂාව සහ කලාපය"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "සාරාංශ, කතාබස් සහ AI-උත්පාදිත ප්‍රතිචාර සඳහා භාෂාව"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ප්‍රධාන භාෂාව"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "රැස්වීම්"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ගැළපෙන භාෂා කිසිවක් හමු නොවීය"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "දැනුම්දීම්"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "සෙවුම් භාෂාව..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "භාෂාව තෝරන්න"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog වැඩිදියුණු කිරීමට උදවු කිරීමට නිර්නාමික භාවිත විශ්ලේෂණ යවන්න."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "භාවිතා දත්ත බෙදා ගන්න"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "සවන් දෙන අතරතුර සංයුක්ත පාවෙන පාලනය පෙන්වන්න."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "පිවිසීමේදී Anarlog ආරම්භ කරන්න"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "රැස්වීම ආරම්භ වන විට ආරම්භ කරන්න"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "රැස්වීම අවසන් වූ විට නවත්වන්න"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ප්‍රධාන භාෂාව සෑම විටම පිටපත් කිරීම සඳහා ඇතුළත් වේ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Pridať jazyk"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Pridať hovorený jazyk"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ďalšie hovorené jazyky"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Vždy pripravené bez manuálneho spúšťania."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikácia"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Automaticky začať počúvať, keď poznámka podporovaná udalosťou dosiahne naplánovaný čas začiatku."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Automaticky prestať počúvať, keď aplikácia na schôdzku uvoľní mikrofón."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Jazyk a oblasť"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Jazyk pre súhrny, čety a odpovede generované AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Hlavný jazyk"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Stretnutia"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nenašli sa žiadne zodpovedajúce jazyky"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Upozornenia"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Jazyk vyhľadávania..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Vyberte jazyk"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Odosielajte anonymné analýzy používania, aby ste pomohli zlepšiť Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Zdieľať údaje o používaní"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Pri počúvaní ukážte kompaktné plávajúce ovládanie."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Spustite Anarlog pri prihlásení"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Začať, keď sa schôdza začína"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Zastavte, keď sa stretnutie skončí"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Pri prepise je vždy zahrnutý hlavný jazyk"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dodaj jezik"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Dodaj govorjeni jezik"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Dodatni govorjeni jeziki"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Vedno pripravljen brez ročnega zagona."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikacija"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Samodejno začni poslušati, ko beležka, podprta z dogodkom, doseže načrtovani začetni čas."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Samodejno prenehajte poslušati, ko aplikacija za srečanja sprosti mikrofon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Jezik in regija"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Jezik za povzetke, klepete in odgovore, ustvarjene z umetno inteligenco"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Glavni jezik"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Sestanki"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ni ustreznih jezikov"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Obvestila"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Jezik iskanja ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Izberite jezik"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Pošljite anonimno analizo uporabe za pomoč pri izboljšanju Anarloga."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Skupna raba podatkov o uporabi"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Prikažite kompaktni lebdeči kontrolnik med poslušanjem."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Zaženi Anarlog ob prijavi"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Začni, ko se sestanek začne"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Ustavite se, ko se sestanek konča"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Glavni jezik je vedno vključen v prepis"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Wedzera mutauro"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Wedzera mutauro unotaurwa"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Mitauro inowedzerwa"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Yagara yakagadzirira pasina kuvhura nemaoko."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Chibva watanga kuteerera kana chinyorwa chinotsigirwa nechiitiko chasvika panguva yayakarongwa kutanga."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Misa kuteerera kana purogiramu yemusangano yaburitsa maikorofoni."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Mutauro & Nharaunda"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Mutauro wepfupiso, chats, nemhinduro dzakagadzirwa neAI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Mutauro mukuru"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Misangano"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Hapana mitauro inoenderana yawanikwa"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Zviziviso"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Tsvaga mutauro..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Sarudza mutauro"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Tumira ma analytics asingazivikanwe kuti ubatsire kunatsiridza Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Goverana data rekushandisa"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Ratidza chibatiso chinoyangarara uchiteerera."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Tanga Anarlog paunopinda"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Tanga kana musangano watanga"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Mira kana musangano wapera"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Mutauro mukuru unogara uchisanganisirwa pakunyora"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Kudar luqadda"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ku dar luqadda lagu hadlo"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Afafka lagu hadlo dheeraadka ah"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Had iyo jeer diyaar adiga oo aan gacanta ku soo daacin."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App-ka"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Si otomaatig ah u billow dhegeysiga marka qoraalka ay taageerto dhacdo uu gaaro wakhtiga bilowga loo qorsheeyay."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Si toos ah u jooji dhegeysiga marka abka kulanku uu sii daayo makarafoonka."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Luqadda & Gobolka"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Luqadda soo koobidda, sheekaysiga, iyo jawaabaha AI-abuuray"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Luqadda ugu weyn"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Kulamada"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Lama helin luuqado u dhigma"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Ogaysiisyo"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Luqadda raadi..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Dooro luqadda"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "U dir isticmaalka falanqaynta qarsoodiga ah si ay gacan uga geysato horumarinta Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "La wadaag xogta isticmaalka"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Muuji xakamaynta sabbaynaysa is haysta markaad dhegaysanayso."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Bilow Anarlog marka la soo galo"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Bilow marka kulanku bilaabmo"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Jooji marka kulanku dhamaado"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Luqadda ugu weyn ayaa had iyo jeer lagu daraa qoraalka"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Shto gjuhën"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Shto gjuhën e folur"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Gjuhë të tjera të folura"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Gjithmonë gati pa nisur manualisht."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikacioni"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Filloni automatikisht dëgjimin kur një shënim i mbështetur nga ngjarje arrin kohën e planifikuar të fillimit."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Ndalo automatikisht dëgjimin kur aplikacioni i takimit lëshon mikrofonin."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Gjuha dhe rajoni"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Gjuha për përmbledhjet, bisedat dhe përgjigjet e krijuara nga AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Gjuha kryesore"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Takime"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Nuk u gjet asnjë gjuhë që përputhet"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Njoftimet"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Kërko gjuhën..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Zgjidh gjuhën"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Dërgo analitikë anonime përdorimi për të ndihmuar në përmirësimin e Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Ndani të dhënat e përdorimit"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Trego kontrollin kompakt lundrues gjatë dëgjimit."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Filloni Anarlog në hyrje"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Fillo kur të fillojë takimi"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Ndalo kur të përfundojë takimi"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Gjuha kryesore përfshihet gjithmonë për transkriptim"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Додајте језик"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Додајте говорни језик"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Додатни говорни језици"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Увек спреман без ручног покретања."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Апп"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Аутоматски почните да слушате када белешка подржана догађајем достигне заказано време почетка."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Аутоматски заустави слушање када апликација за састанак пусти микрофон."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Језик и регион"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Језик за резимее, ћаскање и одговоре генерисане вештачком интелигенцијом"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Главни језик"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Састанци"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Није пронађен ниједан одговарајући језик"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Обавештења"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Претражи језик..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Изаберите језик"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Пошаљите анонимну аналитику коришћења да бисте побољшали Анарлог."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Делите податке о коришћењу"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Покажите компактну плутајућу контролу док слушате."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Покрените Анарлог приликом пријављивања"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Почните када састанак почне"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Зауставите се када се састанак заврши"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Главни језик је увек укључен за транскрипцију"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Tambahkeun basa"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Tambahkeun basa lisan"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Basa lisan tambahan"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Salawasna siap tanpa diluncurkeun sacara manual."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Aplikasi"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Sacara otomatis mimitian ngadangukeun nalika catetan anu dicadangkeun acara ngahontal waktos mimiti anu dijadwalkeun."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Sacara otomatis eureun ngadangukeun nalika aplikasi rapat ngaleupaskeun mikropon."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Basa & Wewengkon"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Basa pikeun kasimpulan, obrolan, sareng réspon anu dihasilkeun ku AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Basa utama"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Rapat"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Teu kapanggih basa nu cocog"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Bewara"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Teangan basa..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pilih basa"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Kirim analisis pamakean anonim pikeun mantuan ningkatkeun Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Bagikeun data pamakean"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Témbongkeun kadali ngambang kompak bari ngadangukeun."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Mimitian Anarlog nalika asup"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Mimitian nalika rapat dimimitian"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Eureun nalika rapat réngsé"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Basa utama sok kaasup pikeun transkripsi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Lägg till språk"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Lägg till talat språk"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ytterligare talade språk"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Alltid redo utan att starta manuellt."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Börja automatiskt lyssna när en händelsestödd anteckning når sin schemalagda starttid."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Sluta automatiskt att lyssna när mötesappen släpper mikrofonen."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Språk och region"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Språk för sammanfattningar, chattar och AI-genererade svar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Huvudspråk"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Möten"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Inga matchande språk hittades"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Aviseringar"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Sökspråk..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Välj språk"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Skicka anonym användningsanalys för att förbättra Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Dela användningsdata"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Visa den kompakta flytande kontrollen medan du lyssnar."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Starta Anarlog vid inloggning"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Börja när mötet börjar"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Stoppa när mötet slutar"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Huvudspråket ingår alltid för transkription"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Ongeza lugha"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Ongeza lugha inayozungumzwa"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Lugha za ziada zinazozungumzwa"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Tayari kila wakati bila kuzindua wewe mwenyewe."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Programu"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Anza kusikiliza kiotomatiki wakati dokezo linaloungwa mkono na tukio linapofikia wakati wake wa kuanza ulioratibiwa."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Acha kusikiliza kiotomatiki wakati programu ya mkutano ikitoa maikrofoni."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Lugha na Eneo"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Lugha ya muhtasari, gumzo, na majibu yanayotokana na AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Lugha kuu"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Mikutano"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Hakuna lugha zinazolingana zilizopatikana"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Arifa"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Tafuta lugha..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Chagua lugha"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Tuma takwimu za matumizi bila kukutambulisha ili kusaidia kuboresha Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Shiriki data ya matumizi"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Onyesha kidhibiti fumbatio cha kuelea unaposikiliza."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Anzisha Anarlog wakati wa kuingia"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Anza mkutano unapoanza"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Simama mkutano unapoisha"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Lugha kuu hujumuishwa kila wakati kwa unukuzi"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "மொழியைச் சேர்"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "பேசும் மொழியைச் சேர்"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "கூடுதல் பேசும் மொழிகள்"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "கைமுறையாகத் தொடங்காமல் எப்போதும் தயார்."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "பயன்பாடு"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "நிகழ்வு ஆதரவுக் குறிப்பு அதன் திட்டமிடப்பட்ட தொடக்க நேரத்தை அடையும் போது தானாகவே கேட்கத் தொடங்கும்."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "மீட்டிங் ஆப்ஸ் மைக்ரோஃபோனை வெளியிடும் போது தானாகவே கேட்பதை நிறுத்துங்கள்."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "மொழி & பகுதி"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "சுருக்கங்கள், அரட்டைகள் மற்றும் AI-உருவாக்கிய பதில்களுக்கான மொழி"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "முக்கிய மொழி"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "கூட்டங்கள்"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "பொருந்தும் மொழிகள் எதுவும் இல்லை"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "அறிவிப்புகள்"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "தேடல் மொழி..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "மொழியைத் தேர்ந்தெடு"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog ஐ மேம்படுத்த உதவ அநாமதேய பயன்பாட்டு பகுப்பாய்வுகளை அனுப்பவும்."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "பயன்பாட்டுத் தரவைப் பகிரவும்"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "கேட்கும்போது சிறிய மிதக்கும் கட்டுப்பாட்டைக் காட்டு."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "உள்நுழைவில் Anarlog ஐத் தொடங்கவும்"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "மீட்டிங் தொடங்கும் போது தொடங்கவும்"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "சந்திப்பு முடிந்ததும் நிறுத்து"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "பிரதான மொழி எப்போதும் டிரான்ஸ்கிரிப்ஷனுக்கு சேர்க்கப்படும்"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "భాషను జోడించు"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "మాట్లాడే భాషను జోడించు"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "అదనపు మాట్లాడే భాషలు"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "మాన్యువల్‌గా ప్రారంభించకుండానే ఎల్లప్పుడూ సిద్ధంగా ఉంటుంది."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "యాప్"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ఈవెంట్-బ్యాక్డ్ నోట్ షెడ్యూల్ చేసిన ప్రారంభ సమయానికి చేరుకున్నప్పుడు స్వయంచాలకంగా వినడం ప్రారంభించండి."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "మీటింగ్ యాప్ మైక్రోఫోన్‌ను విడుదల చేసినప్పుడు స్వయంచాలకంగా వినడం ఆపివేయండి."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "భాష & ప్రాంతం"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "సారాంశాలు, చాట్‌లు మరియు AI రూపొందించిన ప్రతిస్పందనల కోసం భాష"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ప్రధాన భాష"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "సమావేశాలు"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "సరిపోయే భాషలు ఏవీ కనుగొనబడలేదు"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "నోటిఫికేషన్‌లు"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "భాషను శోధించండి..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "భాషను ఎంచుకోండి"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlogని మెరుగుపరచడంలో సహాయపడటానికి అనామక వినియోగ విశ్లేషణలను పంపండి."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "వినియోగ డేటాను భాగస్వామ్యం చేయండి"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "వింటున్నప్పుడు కాంపాక్ట్ ఫ్లోటింగ్ కంట్రోల్‌ని చూపండి."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "లాగిన్ వద్ద Anarlogని ప్రారంభించండి"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "సమావేశం ప్రారంభమైనప్పుడు ప్రారంభించండి"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "సమావేశం ముగిసినప్పుడు ఆపివేయండి"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ప్రధాన భాష ఎల్లప్పుడూ లిప్యంతరీకరణ కోసం చేర్చబడుతుంది"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Иловаи забон"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Забони гуфтугӯиро илова кунед"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Забонҳои иловагии гуфтугӯӣ"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ҳамеша бидуни оғози дастӣ омода аст."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Барнома"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Ҳангоме ки ёддоште, ки аз рӯйдод пуштибонӣ мешавад, ба вақти ба нақша гирифтаи оғози оғозёбӣ мерасад, ба таври худкор гӯш карданро оғоз кунед."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Вақте ки барномаи вохӯрӣ микрофонро озод мекунад, худкор гӯш карданро қатъ кунед."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Забон ва минтақа"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Забон барои хулосаҳо, чатҳо ва посухҳои аз ҷониби AI тавлидшуда"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Забони асосӣ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Вохангҳо"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ягон забонҳои мувофиқ ёфт нашуд"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Огоҳиҳо"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Забони ҷустуҷӯ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Забонро интихоб кунед"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Таҳлили истифодаи беном барои беҳтар кардани Anarlog фиристед."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Мубодилаи маълумоти истифода"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Ҳангоми гӯш кардани назорати шинокунандаи паймон нишон диҳед."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Дар ворид шудан ба Anarlog оғоз кунед"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Вақте ки вохӯрӣ оғоз мешавад, оғоз кунед"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Ҳангоми ба охир расидани вохӯрӣ қатъ кунед"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Забони асосӣ ҳамеша барои транскрипсия дохил карда мешавад"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "เพิ่มภาษา"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "เพิ่มภาษาพูด"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "ภาษาพูดเพิ่มเติม"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "พร้อมเสมอโดยไม่ต้องเปิดด้วยตนเอง"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "แอป"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "เริ่มฟังโดยอัตโนมัติเมื่อโน้ตที่ได้รับการสนับสนุนจากกิจกรรมถึงเวลาเริ่มต้นที่กำหนดไว้"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "หยุดฟังโดยอัตโนมัติเมื่อแอปการประชุมปล่อยไมโครโฟน"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "ภาษาและภูมิภาค"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "ภาษาสำหรับการสรุป แชท และการตอบกลับที่สร้างโดย AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "ภาษาหลัก"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "การประชุม"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "ไม่พบภาษาที่ตรงกัน"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "การแจ้งเตือน"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "ภาษาการค้นหา..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "เลือกภาษา"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "ส่งการวิเคราะห์การใช้งานแบบไม่เปิดเผยตัวตนเพื่อช่วยปรับปรุง Anarlog"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "แชร์ข้อมูลการใช้งาน"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "แสดงตัวควบคุมแบบลอยขนาดกะทัดรัดขณะฟัง"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "เริ่ม Anarlog เมื่อเข้าสู่ระบบ"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "เริ่มเมื่อการประชุมเริ่มต้นขึ้น"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "หยุดเมื่อการประชุมสิ้นสุดลง"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "ภาษาหลักจะรวมอยู่ในการถอดเสียงเสมอ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dil goşuň"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Gepleşik dilini goşuň"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Goşmaça gürleýän diller"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "El bilen işlemezden elmydama taýýar."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "programma"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Wakany goldaýan bellik bellenen başlangyç wagtyna ýetende awtomatiki diňläp başlaň."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Duşuşyk programmasy mikrofony çykaranda awtomatiki diňlemegi bes ediň."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Dil we sebit"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Gysgaça mazmunlar, söhbetdeşlikler we AI tarapyndan döredilen jogaplar üçin dil"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Esasy dil"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Duşuşyklar"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Gabat gelýän diller tapylmady"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Duýduryşlar"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Gözleg dili ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Dil saýlaň"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlogy gowulaşdyrmak üçin anonim ulanyş analitikasyny iberiň."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Ulanyş maglumatlaryny paýlaşyň"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Diňlän wagtyňyz ykjam ýüzýän dolandyryşy görkeziň."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Anarlogy girişden başlaň"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Duşuşyk başlanda başlaň"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Duşuşyk gutaranda duruň"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Esasy dil elmydama transkripsiýa üçin goşulýar"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Magdagdag ng wika"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Magdagdag ng sinasalitang wika"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Mga karagdagang sinasalitang wika"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Palaging handa nang hindi manu-manong inilulunsad."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "App"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Awtomatikong magsimulang makinig kapag naabot ng isang tala na may suporta sa kaganapan ang nakaiskedyul na oras ng pagsisimula nito."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Awtomatikong huminto sa pakikinig kapag inilabas ng meeting app ang mikropono."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Wika at Rehiyon"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Wika para sa mga buod, pakikipag-chat, at mga tugon na binuo ng AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Pangunahing wika"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Mga Pagpupulong"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Walang nakitang katugmang mga wika"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Mga Notification"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Wika sa paghahanap..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Pumili ng wika"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Magpadala ng anonymous na analytics sa paggamit upang makatulong na mapabuti ang Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Ibahagi ang data ng paggamit"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Ipakita ang compact floating control habang nakikinig."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Simulan ang Anarlog sa pag-login"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Magsimula kapag nagsimula ang pulong"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Ihinto kapag natapos na ang pulong"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Ang pangunahing wika ay palaging kasama para sa transkripsyon"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Dil ekle"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Konuşulan dili ekle"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ek konuşulan diller"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Manuel olarak başlatmaya gerek kalmadan her zaman hazır."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Uygulama"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Etkinlik destekli not, planlanan başlangıç saatine ulaştığında otomatik olarak dinlemeye başlayın."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Toplantı uygulaması mikrofonu bıraktığında dinleme otomatik olarak durdurulur."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Dil ve Bölge"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Özetler, sohbetler ve yapay zeka tarafından oluşturulan yanıtlar için dil"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Ana dil"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Toplantılar"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Eşleşen dil bulunamadı"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Bildirimler"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Dil ara..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Dil seçin"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlog'un iyileştirilmesine yardımcı olmak için anonim kullanım analizleri gönderin."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Kullanım verilerini paylaşın"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Dinlerken kompakt değişken kontrolü gösterin."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Giriş sırasında Anarlog'u başlatın"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Toplantı başladığında başla"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Toplantı sona erdiğinde dur"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Çeviri yazıya her zaman ana dil dahil edilir"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Тел өстәгез"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Сөйләм телен өстәү"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Өстәмә сөйләм телләре"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Кул белән эшләтеп җибәрмичә һәрвакыт әзер."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "кушымта"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Вакыйга ярдәмендә язылган план билгеләнгән старт вакытына җиткәч, автоматик рәвештә тыңлый башлый."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Очрашу кушымтасы микрофонны чыгарганда тыңлауны автоматик рәвештә туктатыгыз."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Тел һәм Төбәк"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Кыскача мәгълүматлар, чатлар, ЯИ ясаган җаваплар өчен тел"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Төп тел"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Очрашулар"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Бер-берсенә туры килгән телләр табылмады"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Хәбәрләр"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Эзләү теле ..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Телне сайлагыз"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Анарлогны яхшырту өчен аноним куллану аналитикасын җибәрегез."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Куллану мәгълүматларын бүлешү"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Тыңлаганда компакт йөзү контролен күрсәтегез."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Анарлогны логинда башлау"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Очрашу башлангач башлагыз"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Очрашу беткәч туктагыз"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Төп тел һәрвакыт транскрипция өчен кертелә"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Додати мову"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Додати розмовну мову"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Додаткові розмовні мови"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Завжди готовий без запуску вручну."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Програма"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Автоматично починати прослуховування, коли нотатка, пов’язана з подією, досягає запланованого часу початку."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Автоматично припиняти прослуховування, коли програма для зустрічей відпускає мікрофон."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Мова та регіон"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Мова для підсумків, чатів і відповідей, створених ШІ"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Основна мова"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Зустрічі"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Відповідних мов не знайдено"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Сповіщення"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Мова пошуку..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Виберіть мову"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Надсилайте анонімну аналітику використання, щоб допомогти покращити Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Обмін даними про використання"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Показувати компактний плаваючий елемент керування під час прослуховування."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Запускати Anarlog під час входу"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Почати під час зустрічі"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Зупинити, коли зустріч закінчиться"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Основна мова завжди включається для транскрипції"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "زبان شامل کریں"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "بولی جانے والی زبان شامل کریں"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "اضافی بولی جانے والی زبانیں"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "دستی طور پر لانچ کیے بغیر ہمیشہ تیار۔"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "ایپ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "ایونٹ کی حمایت یافتہ نوٹ اپنے مقررہ وقت پر پہنچنے پر خود بخود سننا شروع کر دیں۔"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "جب میٹنگ ایپ مائکروفون جاری کرتی ہے تو خود بخود سننا بند کر دیں۔"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "زبان اور علاقہ"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "خلاصوں، چیٹس، اور AI سے تیار کردہ جوابات کے لیے زبان"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "مرکزی زبان"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "میٹنگز"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "کوئی مماثل زبانیں نہیں ملی"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "اطلاعات"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "تلاش زبان..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "زبان منتخب کریں"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "انارلاگ کو بہتر بنانے میں مدد کے لیے گمنام استعمال کے تجزیات بھیجیں۔"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "استعمال کا ڈیٹا شیئر کریں"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "سنتے وقت کمپیکٹ فلوٹنگ کنٹرول دکھائیں۔"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "لاگ ان پر Anarlog شروع کریں"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "میٹنگ شروع ہونے پر شروع کریں"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "میٹنگ ختم ہونے پر رکیں"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "نقل کے لیے مرکزی زبان ہمیشہ شامل کی جاتی ہے"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Til qo'shish"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Og'zaki til qo'shing"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Qo'shimcha og'zaki tillar"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Qo'lda ishga tushirmasdan ham doim tayyor."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ilova"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Tadbirga asoslangan eslatma belgilangan boshlanish vaqtiga yetganda, avtomatik ravishda tinglashni boshlang."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Uchrashuv ilovasi mikrofonni qoʻyib yuborganida tinglashni avtomatik ravishda toʻxtating."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Til va mintaqa"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Xulosalar, chatlar va AI tomonidan yaratilgan javoblar uchun til"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Asosiy til"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Uchrashuvlar"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Mos tillar topilmadi"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Bildirishnomalar"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Tilni qidirish..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Tilni tanlang"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Anarlogni yaxshilashga yordam berish uchun anonim foydalanish tahlilini yuboring."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Foydalanish ma'lumotlarini baham ko'rish"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Tinglash paytida ixcham suzuvchi boshqaruvni ko'rsating."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Kirish vaqtida Anarlogni ishga tushiring"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Uchrashuv boshlanganda boshlang"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Uchrashuv tugashi bilan toʻxtating"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Asosiy til har doim transkripsiya uchun kiritilgan"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Thêm ngôn ngữ"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Thêm ngôn ngữ nói"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Ngôn ngữ nói bổ sung"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Luôn sẵn sàng mà không cần khởi chạy thủ công."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ứng dụng"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Tự động bắt đầu nghe khi ghi chú dựa trên sự kiện đạt đến thời gian bắt đầu đã lên lịch."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Tự động ngừng nghe khi ứng dụng cuộc họp nhả micrô."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Ngôn ngữ & Khu vực"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ngôn ngữ tóm tắt, trò chuyện và phản hồi do AI tạo"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Ngôn ngữ chính"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Cuộc họp"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Không tìm thấy ngôn ngữ phù hợp"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Thông báo"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Ngôn ngữ tìm kiếm..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Chọn ngôn ngữ"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Gửi phân tích sử dụng ẩn danh để giúp cải thiện Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Chia sẻ dữ liệu sử dụng"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Hiển thị điều khiển nổi nhỏ gọn trong khi nghe."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Bắt đầu Anarlog khi đăng nhập"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Bắt đầu khi cuộc họp bắt đầu"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Dừng khi cuộc họp kết thúc"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Ngôn ngữ chính luôn được đưa vào để phiên âm"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Yokk làkk"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Yokk làkk wiñ làkk"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Yeneen làkk yi ñuy làkk"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Dafay waajal saa yu nekk te doo tàmbali ko ak loxo."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Jëfekaay"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Tàmbali déglu ci saasi su ab nota buñu jàppale ci xew-xew yeggee ci waxtu tàmbali biñu ko jàppale."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Dafay bàyyi déglu ci saasi su aplikaasioŋu ndaje bi bàyyee mikro bi."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Làkk wi ak Réew mi"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Làkk ngir tënk, waxtaan, ak tontu yu IA defar"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Làkk wi gëna am solo"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Ndaje yi"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Gisu ñu làkk wu méngoo"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Yégle yi"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Làkku seetlu..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Tannal làkk wi"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Yonnee jàngat jëfandikoo bu nëbbu ngir jàppale ci gëna suqali Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Séddoo done jëfandikoo"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Waneel seytukat biy féey bi ngay déglu."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Tàmbali Anarlog ci dugg bi"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Tàmbali su ndaje bi tàmbalee"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Taxawal su ndaje bi jeexee"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Làkk wiñ gëna jëfandikoo dañu koy boole saa yu nekk ngir bind"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Yongeza ulwimi"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Yongeza ulwimi oluthethwayo"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Iilwimi ezongezelelweyo ezithethwayo"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ihlala ilungile ngaphandle kokuyizisa ngesandla."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Usetyenziso"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Qalisa ngokuzenzekelayo xa inqaku elixhasa isiganeko lifikelela kwixesha elicwangcisiweyo lokuqala."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Yeka ukumamela ngokuzenzekelayo xa usetyenziso lwentlanganiso lukhupha imayikrofoni."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Ulwimi & neNgingqi"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ulwimi lwesishwankathelo, iincoko, kunye neempendulo ezenziwe nge-AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Ulwimi oluphambili"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Iintlanganiso"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Akukho lwimi ludibanayo lufunyenweyo"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Khangela ulwimi..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Khetha ulwimi"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Thumela uhlalutyo losetyenziso olungachazwanga ukuze uncede uphucule i-Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Yabelana ngedatha yosetyenziso"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Bonisa ulawulo olubambekayo xa umamele."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Qalisa i-Anarlog ekungeneni"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Qala xa intlanganiso iqala"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Yima xa kuphela intlanganiso"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Olona lwimi lusoloko lubandakanyiwe kushicilelo"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "צוגעבן שפּראַך"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "צוגעבן גערעדט שפּראַך"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "נאך גערעדטע שפראכן"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "שטענדיק גרייט אָן מאַניואַלי קאַטער."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "אַפּ"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "אָטאַמאַטיק אָנהייב צוגעהערט ווען אַ געשעעניש-באַקט טאָן ריטשאַז זיין סקעדזשולד אָנהייב צייט."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "אָטאַמאַטיק האַלטן צוגעהערט ווען די באַגעגעניש אַפּ ריליסיז די מיקראָפאָן."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "שפּראַך און געגנט"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "שפּראַך פֿאַר סאַמעריז, טשאַץ און אַי-דזשענערייטאַד רעספּאָנסעס"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "הויפּט שפּראַך"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "מיטינגז"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "קיין שטיפעריש שפראכן געפונען"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "נאָטיפיקאַטיאָנס"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "זוכן שפּראַך..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "סעלעקט שפּראַך"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "שיקן אַנאָנימע באַנוצערס אַנאַליטיקס צו העלפֿן פֿאַרבעסערן אַנאַלאָג."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "ייַנטיילן באַניץ דאַטן"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "ווייַזן די סאָליד פלאָוטינג קאָנטראָל בשעת צוגעהערט."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "אָנהייב אַנאַלאָג ביי לאָגין"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "אָנהייב ווען באַגעגעניש הייבט זיך אָן"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "האַלטן ווען באַגעגעניש ענדס"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "די הויפּט שפּראַך איז שטענדיק אַרייַנגערעכנט פֿאַר טראַנסקריפּציע"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Fi ede kun"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Fi ede sisọ kun"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Awọn ede ti a sọ ni afikun"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ṣetan nigbagbogbo lai ṣe ifilọlẹ pẹlu ọwọ."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Ohun elo"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Bẹrẹ gbigbọ ni aladaaṣe nigbati akọsilẹ ti o ṣe atilẹyin iṣẹlẹ ba de akoko ibẹrẹ ti a ṣeto."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Da gbigbọran duro ni aladaaṣe nigbati app ipade ba tu gbohungbohun silẹ."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Ede & Ekun"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ede fun awọn akojọpọ, awọn ibaraẹnisọrọ, ati awọn idahun ti ipilẹṣẹ AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Ede akọkọ"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Awọn ipade"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Ko si awọn ede ti o baamu ti a rii"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Awọn iwifunni"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Ede wa..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Yan ede"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Firanṣẹ atupale lilo ailorukọ lati ṣe iranlọwọ ilọsiwaju Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Pin data lilo"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Ṣafihan iṣakoso lilefoofo iwapọ lakoko gbigbọ."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Bẹrẹ Anarlog ni wiwọle"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Bẹrẹ nigbati ipade ba bẹrẹ"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Duro nigbati ipade ba pari"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Ede akọkọ wa nigbagbogbo fun kikọ silẹ"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "添加语言"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "添加口语语言"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "其他口语语言"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "无需手动启动，随时就绪。"
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "应用"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "当关联日程的笔记到达预定开始时间时，自动开始聆听。"
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "当会议应用释放麦克风时，自动停止聆听。"
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "语言和地区"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "摘要、聊天和 AI 生成回复使用的语言"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "主要语言"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "会议"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "未找到匹配的语言"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "通知"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "搜索语言..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "选择语言"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "发送匿名使用分析，帮助改进 Anarlog。"
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "分享使用数据"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "聆听时显示紧凑的浮动控件。"
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "登录时启动 Anarlog"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "会议开始时启动"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "会议结束时停止"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "主要语言始终包含在转录中"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -13,1942 +13,1890 @@ msgstr ""
 "Language-Team: \n"
 "Plural-Forms: \n"
 
-#: src/settings/general/notification.tsx:333
+#: src/settings/general/notification.tsx
 msgid "(default)"
 msgstr ""
 
 #. placeholder {0}: issue.user?.login
-#: src/task/resource-view.tsx:115
+#: src/task/resource-view.tsx
 msgid "{0} opened on"
 msgstr ""
 
-#: src/settings/general/account.tsx:223
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} day left"
 msgstr ""
 
-#: src/settings/general/account.tsx:224
+#: src/settings/general/account.tsx
 msgid "{trialDaysRemaining} days left"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:185
+#: src/settings/ai/llm/select.tsx
 msgid "<0>Language model</0> is needed to make Anarlog summarize and chat about your conversations."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:159
+#: src/settings/ai/stt/select.tsx
 msgid "<0>Transcription model</0> is needed to make Anarlog listen to your conversations."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:167
+#: src/settings/general/storage/index.tsx
 msgid "1 day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:179
+#: src/settings/general/storage/index.tsx
 msgid "1 month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:175
+#: src/settings/general/storage/index.tsx
 msgid "1 week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:171
+#: src/settings/general/storage/index.tsx
 msgid "3 days"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:315
+#: src/templates/template-sidebar.tsx
 msgid "A to Z"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:180
+#: src/settings/general/permissions.tsx
 msgid "Accessibility"
 msgstr ""
 
-#: src/onboarding/index.tsx:234
-#: src/settings/general/account.tsx:76
-#: src/settings/general/account.tsx:104
-#: src/settings/general/account.tsx:139
-#: src/sidebar/settings.tsx:72
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
+#: src/sidebar/settings.tsx
 msgid "Account"
 msgstr ""
 
-#: src/contacts/shared.tsx:151
-#: src/settings/personalization/index.tsx:105
-#: src/settings/todo/github.tsx:206
+#: src/contacts/shared.tsx
+#: src/settings/personalization/index.tsx
+#: src/settings/todo/github.tsx
 msgid "Add"
 msgstr ""
 
 #. placeholder {0}: option.name
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:645
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Add \"{0}\""
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:225
-#: src/calendar/components/sidebar.tsx:304
+#: src/calendar/components/sidebar.tsx
 msgid "Add {0} account"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:177
+#: src/settings/general/spoken-languages.tsx
 msgid "Add language"
 msgstr "Engeza ulimi"
 
-#: src/settings/personalization/index.tsx:84
+#: src/settings/personalization/index.tsx
 msgid "Add names, jargon, or product terms to prefer"
 msgstr ""
 
-#: src/contacts/details.tsx:554
+#: src/contacts/details.tsx
 msgid "Add notes about this contact..."
 msgstr ""
 
-#: src/contacts/details.tsx:607
+#: src/contacts/details.tsx
 msgid "Add organization"
 msgstr ""
 
-#: src/contacts/new-person-form.tsx:72
-#: src/contacts/new-person-form.tsx:80
+#: src/contacts/new-person-form.tsx
 msgid "Add person"
 msgstr ""
 
-#: src/settings/todo/github.tsx:252
+#: src/settings/todo/github.tsx
 msgid "Add repository"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:175
+#: src/settings/general/spoken-languages.tsx
 msgid "Add spoken language"
 msgstr "Engeza ulimi olukhulunywayo"
 
-#: src/settings/general/spoken-languages.tsx:116
+#: src/settings/general/spoken-languages.tsx
 msgid "Additional spoken languages"
 msgstr "Izilimi ezengeziwe ezikhulunywayo"
 
-#: src/settings/ai/shared/index.tsx:296
+#: src/settings/ai/shared/index.tsx
 msgid "Advanced"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "After recording"
 msgstr ""
 
-#: src/contacts/details.tsx:322
+#: src/contacts/details.tsx
 msgid "AI-generated summary of all interactions and notes with this contact will appear here. This will synthesize key discussion points, action items, and relationship context across all meetings and notes."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:282
+#: src/shared/open-note-dialog.tsx
 msgid "All Notes"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:46
+#: src/onboarding/permissions.tsx
 msgid "Allow access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:142
+#: src/onboarding/permissions.tsx
 msgid "Allow microphone access"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:154
+#: src/onboarding/permissions.tsx
 msgid "Allow system audio access"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:37
+#: src/settings/general/app-settings.tsx
 msgid "Always ready without manually launching."
 msgstr "Ihlala ilungile ngaphandle kokuyiqalisa mathupha."
 
-#: src/session/components/note-input/enhanced/streaming.tsx:64
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Analyzing structure..."
 msgstr ""
 
-#: src/onboarding/permissions.tsx:153
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:141
+#: src/onboarding/permissions.tsx
 msgid "Anarlog can hear your voice"
 msgstr ""
 
-#: src/onboarding/index.tsx:207
+#: src/onboarding/index.tsx
 msgid "Anarlog needs access to your microphone and system audio to record and transcribe your meetings"
 msgstr ""
 
-#: src/onboarding/index.tsx:256
+#: src/onboarding/index.tsx
 msgid "Anarlog will sync your calendar to get meeting reminders"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:249
-#: src/settings/ai/shared/index.tsx:309
+#: src/settings/ai/shared/index.tsx
 msgid "API Key"
 msgstr ""
 
-#: src/settings/general/index.tsx:167
-#: src/sidebar/settings.tsx:71
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "App"
 msgstr "Uhlelo lokusebenza"
 
-#: src/settings/general/theme.tsx:45
+#: src/settings/general/theme.tsx
 msgid "Appearance"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Apply and Restart"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:552
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Apply to all"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:395
+#: src/settings/general/storage/index.tsx
 msgid "Applying..."
 msgstr ""
 
-#: src/chat/components/input/index.tsx:69
+#: src/chat/components/input/index.tsx
 msgid "Ask & search about anything, or be creative!"
 msgstr ""
 
-#: src/shared/chat-cta.tsx:32
+#: src/shared/chat-cta.tsx
 msgid "Ask Anarlog anything"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:68
-#: src/shared/chat-cta.tsx:18
+#: src/chat/components/input/index.tsx
+#: src/shared/chat-cta.tsx
 msgid "Ask anything"
 msgstr ""
 
-#: src/task/resource-view.tsx:156
+#: src/task/resource-view.tsx
 msgid "Assignees:"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:158
-#: src/settings/general/storage/index.tsx:193
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Audio"
 msgstr ""
 
-#: src/instruction/index.tsx:188
+#: src/instruction/index.tsx
 msgid "Authorize access in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/notification.tsx:238
+#: src/settings/general/notification.tsx
 msgid "Automatically detect when a meeting starts based on microphone activity."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:79
+#: src/settings/general/app-settings.tsx
 msgid "Automatically start listening when an event-backed note reaches its scheduled start time."
 msgstr "Qala ngokuzenzakalelayo ukulalela lapho inothi elisekelwa umcimbi lifinyelela isikhathi salo sokuqala esihleliwe."
 
-#: src/settings/general/app-settings.tsx:90
+#: src/settings/general/app-settings.tsx
 msgid "Automatically stop listening when the meeting app releases the microphone."
 msgstr "Yeka ukulalela ngokuzenzakalela uma uhlelo lokusebenza lomhlangano lukhulula imakrofoni."
 
-#: src/calendar/components/apple/permission.tsx:161
-#: src/instruction/index.tsx:63
-#: src/sidebar/custom-sidebar-header.tsx:54
+#: src/calendar/components/apple/permission.tsx
+#: src/instruction/index.tsx
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Back"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:241
-#: src/settings/ai/shared/index.tsx:301
+#: src/settings/ai/shared/index.tsx
 msgid "Base URL"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:332
+#: src/settings/general/storage/index.tsx
 msgid "Browse"
 msgstr ""
 
-#: src/instruction/index.tsx:277
+#: src/instruction/index.tsx
 msgid "Browser handoff not working? Paste the callback link instead"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:325
-#: src/settings/general/permissions.tsx:191
-#: src/sidebar/calendar.tsx:10
-#: src/sidebar/settings.tsx:81
+#: src/calendar/components/sidebar.tsx
+#: src/settings/general/permissions.tsx
+#: src/sidebar/calendar.tsx
+#: src/sidebar/settings.tsx
 msgid "Calendar"
 msgstr ""
 
-#: src/onboarding/index.tsx:260
+#: src/onboarding/index.tsx
 msgid "Calendar connected"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:755
+#: src/settings/ai/stt/select.tsx
 msgid "Can transcribe while the meeting is happening."
 msgstr ""
 
-#: src/settings/general/account.tsx:266
-#: src/settings/general/account.tsx:293
-#: src/settings/todo/github.tsx:217
+#: src/settings/general/account.tsx
+#: src/settings/todo/github.tsx
 msgid "Cancel"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:146
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Cancel date edit"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:129
+#: src/onboarding/folder-location.tsx
 msgid "Change"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:291
+#: src/settings/general/storage/index.tsx
 msgid "Change content location"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:168
+#: src/chat/components/toolbar-controls.tsx
 msgid "Chat history"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:271
+#: src/settings/general/storage/index.tsx
 msgid "Checking folder..."
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:15
+#: src/onboarding/account/after-login.tsx
 msgid "Checking trial eligibility..."
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:470
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Choose a file format and what to include."
 msgstr ""
 
-#: src/settings/general/theme.tsx:48
+#: src/settings/general/theme.tsx
 msgid "Choose light, dark, or match your system setting."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:93
+#: src/onboarding/folder-location.tsx
 msgid "Choose storage location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:294
+#: src/settings/general/storage/index.tsx
 msgid "Choose where Anarlog should store data. (notes, settings, etc)"
 msgstr ""
 
-#: src/contacts/shared.tsx:173
-#: src/templates/template-sidebar.tsx:365
+#: src/contacts/shared.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Clear search"
 msgstr ""
 
-#: src/shared/ui/resource-list/preview-header.tsx:53
+#: src/shared/ui/resource-list/preview-header.tsx
 msgid "Clone"
 msgstr ""
 
-#: src/changelog/index.tsx:176
-#: src/session/components/note-input/search/bar.tsx:280
-#: src/shared/open-note-dialog.tsx:223
+#: src/changelog/index.tsx
+#: src/session/components/note-input/search/bar.tsx
+#: src/shared/open-note-dialog.tsx
 msgid "Close"
 msgstr ""
 
-#: src/changelog/index.tsx:175
+#: src/changelog/index.tsx
 msgid "Close changelog"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:84
+#: src/chat/components/toolbar-controls.tsx
 msgid "Close chat"
 msgstr ""
 
-#: src/task/resource-view.tsx:274
+#: src/task/resource-view.tsx
 msgid "Closed"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comment"
 msgstr ""
 
-#: src/task/resource-view.tsx:217
+#: src/task/resource-view.tsx
 msgid "commented on"
 msgstr ""
 
-#: src/task/resource-view.tsx:125
-#: src/task/resource-view.tsx:196
+#: src/task/resource-view.tsx
 msgid "comments"
 msgstr ""
 
-#: src/contacts/details.tsx:302
+#: src/contacts/details.tsx
 msgid "Company"
 msgstr ""
 
-#: src/settings/general/account.tsx:460
+#: src/settings/general/account.tsx
 msgid "Compare Free, Lite, and Pro before you sign in."
 msgstr ""
 
-#: src/instruction/index.tsx:241
+#: src/instruction/index.tsx
 msgid "Complete sign-in in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:80
+#: src/settings/general/account.tsx
 msgid "Complete the sign-in flow in your browser, then come back here if Anarlog does not reconnect automatically."
 msgstr ""
 
-#: src/instruction/index.tsx:170
+#: src/instruction/index.tsx
 msgid "Complete your purchase"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:91
-#: src/session/components/note-input/enhanced/config-error.tsx:30
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Configure"
 msgstr ""
 
-#: src/settings/ai/llm/configure.tsx:16
-#: src/settings/ai/stt/configure.tsx:16
+#: src/settings/ai/llm/configure.tsx
+#: src/settings/ai/stt/configure.tsx
 msgid "Configure Providers"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:240
+#: src/settings/ai/llm/select.tsx
 msgid "Configure this provider to use it."
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:136
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:565
+#: src/onboarding/folder-location.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Confirm"
 msgstr ""
 
 #. placeholder {0}: config.displayName
 #. placeholder {0}: integration.displayName
-#: src/instruction/index.tsx:185
-#: src/settings/todo/provider-content.tsx:75
-#: src/settings/todo/provider-content.tsx:118
+#: src/instruction/index.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Connect {0}"
 msgstr ""
 
-#: src/onboarding/index.tsx:254
+#: src/onboarding/index.tsx
 msgid "Connect calendar"
 msgstr ""
 
-#: src/settings/todo/github.tsx:128
+#: src/settings/todo/github.tsx
 msgid "Connect GitHub for private repos."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:527
+#: src/onboarding/calendar.tsx
 msgid "Connect Google Calendar"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:421
+#: src/onboarding/calendar.tsx
 msgid "Connect Outlook"
 msgstr ""
 
-#: src/instruction/index.tsx:186
+#: src/instruction/index.tsx
 msgid "Connect your integration"
 msgstr ""
 
-#: src/sidebar/contacts.tsx:304
-#: src/sidebar/settings.tsx:86
+#: src/sidebar/contacts.tsx
+#: src/sidebar/settings.tsx
 msgid "Contacts"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:109
+#: src/settings/general/storage/index.tsx
 msgid "Content"
 msgstr ""
 
-#: src/sidebar/settings.tsx:77
+#: src/sidebar/settings.tsx
 msgid "Context"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:569
+#: src/onboarding/calendar.tsx
 msgid "Continue"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:56
+#: src/onboarding/account/after-login.tsx
 msgid "Continuing without trial"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:83
+#: src/chat/components/message/normal.tsx
 msgid "Copy message"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:68
+#: src/onboarding/account/after-login.tsx
 msgid "Could not start trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:221
+#: src/onboarding/index.tsx
 msgid "Create account"
 msgstr ""
 
-#: src/templates/details.tsx:92
+#: src/templates/details.tsx
 msgid "Create template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:212
-#: src/session/components/outer-header/overflow/export-modal.tsx:317
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Created"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:120
+#: src/settings/general/storage/index.tsx
 msgid "Customize"
 msgstr ""
 
-#: src/settings/general/theme.tsx:35
+#: src/settings/general/theme.tsx
 msgid "Dark"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:88
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Date and time are required"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:73
-#: src/templates/sections-editor.tsx:280
-#: src/templates/template-form.tsx:285
+#: src/session/components/outer-header/overflow/delete.tsx
+#: src/templates/sections-editor.tsx
+#: src/templates/template-form.tsx
 msgid "Delete"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:414
+#: src/sidebar/timeline/item.tsx
 msgid "Delete All Recurring Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Event"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:827
+#: src/settings/ai/stt/select.tsx
 msgid "Delete model"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:575
+#: src/sidebar/timeline/item.tsx
 msgid "Delete Note"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:44
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Delete recording"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:402
+#: src/sidebar/timeline/index.tsx
 msgid "Delete Selected ({sessionCount})"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:407
+#: src/sidebar/timeline/item.tsx
 msgid "Delete This Event"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/delete.tsx:42
+#: src/session/components/outer-header/overflow/delete.tsx
 msgid "Deleting..."
 msgstr ""
 
-#: src/templates/template-form.tsx:321
+#: src/templates/template-form.tsx
 msgid "Describe the template purpose..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:257
+#: src/settings/general/notification.tsx
 msgid "Detection delay"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:76
+#: src/settings/personalization/index.tsx
 msgid "Dictionary"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:196
-#: src/settings/todo/provider-content.tsx:216
+#: src/settings/todo/provider-content.tsx
 msgid "Disconnect"
 msgstr ""
 
-#: src/settings/todo/github.tsx:143
+#: src/settings/todo/github.tsx
 msgid "Disconnect private repo access."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:164
+#: src/settings/general/storage/index.tsx
 msgid "Do not keep recordings after processing"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:163
+#: src/settings/general/storage/index.tsx
 msgid "Don't save"
 msgstr ""
 
-#: src/settings/general/notification.tsx:422
+#: src/settings/general/notification.tsx
 msgid "Don't show notifications when Do-Not-Disturb is enabled on your system"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Download"
 msgstr ""
 
-#: src/templates/details.tsx:178
-#: src/templates/template-form.tsx:279
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Duplicate"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:220
-#: src/session/components/outer-header/overflow/export-modal.tsx:268
-#: src/session/components/outer-header/overflow/export-modal.tsx:325
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Duration"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:39
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Edit date"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:23
-#: src/onboarding/account/after-login.tsx:44
-#: src/onboarding/account/after-login.tsx:64
+#: src/onboarding/account/after-login.tsx
 msgid "Eligible for free trial"
 msgstr ""
 
-#: src/contacts/details.tsx:453
+#: src/contacts/details.tsx
 msgid "Email"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
-#: src/onboarding/permissions.tsx:64
+#: src/onboarding/permissions.tsx
 msgid "Enable {0}"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:136
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/participants/chip.tsx:120
+#: src/session/components/outer-header/metadata/participants/chip.tsx
 msgid "Enhance contact {label}"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:232
+#: src/settings/ai/stt/select.tsx
 msgid "Enter a model identifier"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:96
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Enter a valid date and time"
 msgstr ""
 
-#: src/templates/template-form.tsx:309
+#: src/templates/template-form.tsx
 msgid "Enter template title"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:250
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:310
+#: src/settings/ai/shared/index.tsx
 msgid "Enter your API key (optional)"
 msgstr ""
 
-#: src/settings/general/notification.tsx:213
+#: src/settings/general/notification.tsx
 msgid "Event notifications"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:136
+#: src/settings/personalization/index.tsx
 msgid "Examples"
 msgstr ""
 
-#: src/settings/general/notification.tsx:289
+#: src/settings/general/notification.tsx
 msgid "Exclude apps from detection"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:376
+#: src/settings/general/storage/index.tsx
 msgid "existing data to new location"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:168
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one day"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:180
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one month"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:176
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after one week"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:172
+#: src/settings/general/storage/index.tsx
 msgid "Expire recordings after three days"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:467
-#: src/session/components/outer-header/overflow/export-modal.tsx:552
-#: src/session/components/outer-header/overflow/index.tsx:116
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Export"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:549
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Exporting..."
 msgstr ""
 
-#: src/onboarding/calendar.tsx:467
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Google Calendar"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:104
+#: src/settings/todo/provider-content.tsx
 msgid "Failed to load integration status"
 msgstr ""
 
-#: src/task/resource-view.tsx:89
+#: src/task/resource-view.tsx
 msgid "Failed to load issue"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:362
+#: src/onboarding/calendar.tsx
 msgid "Failed to load Outlook Calendar"
 msgstr ""
 
-#: src/task/resource-view.tsx:87
+#: src/task/resource-view.tsx
 msgid "Failed to load pull request"
 msgstr ""
 
-#: src/templates/details.tsx:152
-#: src/templates/details.tsx:153
+#: src/templates/details.tsx
 msgid "Favorite template"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:477
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "File format"
 msgstr ""
 
 #. placeholder {0}: (config.filterLabel ?? "repository").toLowerCase()
-#: src/settings/todo/provider-content.tsx:139
+#: src/settings/todo/provider-content.tsx
 msgid "Filter synced items by {0}."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:216
+#: src/shared/open-note-dialog.tsx
 msgid "Find a note..."
 msgstr ""
 
-#: src/instruction/index.tsx:171
+#: src/instruction/index.tsx
 msgid "Finish checkout in your browser, then return to Anarlog."
 msgstr ""
 
-#: src/settings/general/account.tsx:78
+#: src/settings/general/account.tsx
 msgid "Finish sign-in"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:58
+#: src/settings/general/week-start.tsx
 msgid "First day of the week in the calendar view"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:74
+#: src/chat/components/toolbar-controls.tsx
 msgid "Float chat"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:318
+#: src/settings/general/storage/index.tsx
 msgid "Folder is not empty. Uncheck Move to use it as-is, or pick a dedicated empty folder (for example \"meetings\") for a full migration."
 msgstr ""
 
-#: src/settings/general/notification.tsx:409
+#: src/settings/general/notification.tsx
 msgid "For enabled notifications"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:183
+#: src/settings/general/storage/index.tsx
 msgid "Forever"
 msgstr ""
 
-#: src/settings/general/account.tsx:218
+#: src/settings/general/account.tsx
 msgid "Free"
 msgstr ""
 
-#: src/sidebar/settings.tsx:69
+#: src/sidebar/settings.tsx
 msgid "General"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:28
-#: src/session/components/title-input.tsx:97
+#: src/session/components/note-input/enhanced/streaming.tsx
+#: src/session/components/title-input.tsx
 msgid "Generating title..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:216
+#: src/settings/general/notification.tsx
 msgid "Get notified 5 minutes before calendar events start"
 msgstr ""
 
-#: src/settings/general/account.tsx:124
+#: src/settings/general/account.tsx
 msgid "Get started"
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:19
+#: src/onboarding/account/before-login.tsx
 msgid "Get started for free"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:799
+#: src/sidebar/timeline/index.tsx
 msgid "Go back to now"
 msgstr ""
 
-#: src/sidebar/custom-sidebar-header.tsx:53
+#: src/sidebar/custom-sidebar-header.tsx
 msgid "Go home"
 msgstr ""
 
-#: src/onboarding/shared.tsx:111
+#: src/onboarding/shared.tsx
 msgid "Go to next section"
 msgstr ""
 
-#: src/onboarding/shared.tsx:90
+#: src/onboarding/shared.tsx
 msgid "Go to previous section"
 msgstr ""
 
-#: src/chat/components/body/index.tsx:104
+#: src/chat/components/body/index.tsx
 msgid "Go to recent"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:143
-#: src/settings/general/permissions.tsx:86
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Having trouble?"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:156
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to others"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:144
+#: src/onboarding/permissions.tsx
 msgid "Help Anarlog listen to you"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:411
+#: src/sidebar/timeline/index.tsx
 msgid "Hide Deleted Events"
 msgstr ""
 
-#: src/settings/general/notification.tsx:260
+#: src/settings/general/notification.tsx
 msgid "How long the mic must be active before triggering"
 msgstr ""
 
-#: src/contacts/humans.tsx:14
+#: src/contacts/humans.tsx
 msgid "Human"
 msgstr ""
 
-#: src/settings/general/account.tsx:92
+#: src/settings/general/account.tsx
 msgid "If the browser does not reopen Anarlog, use the paste-link fallback in the sign-in instruction window."
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minute"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:164
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {minutes} minutes"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:160
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} second"
 msgstr ""
 
-#: src/sidebar/timeline/upcoming-meeting.ts:161
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "In {totalSeconds} seconds"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:504
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Include"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:254
+#: src/templates/sections-editor.tsx
 msgid "Insert above"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:260
+#: src/templates/sections-editor.tsx
 msgid "Insert below"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:973
+#: src/session/components/note-input/header.tsx
 msgid "Insights"
 msgstr ""
 
-#: src/settings/ai/llm/index.tsx:13
-#: src/sidebar/settings.tsx:100
+#: src/settings/ai/llm/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Intelligence"
 msgstr ""
 
-#: src/contacts/details.tsx:424
+#: src/contacts/details.tsx
 msgid "Job Title"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:170
+#: src/session/components/outer-header/index.tsx
 msgid "Join"
 msgstr ""
 
-#: src/session/components/outer-header/index.tsx:150
+#: src/session/components/outer-header/index.tsx
 msgid "Join {name}"
 msgstr ""
 
-#: src/onboarding/final.tsx:38
+#: src/onboarding/final.tsx
 msgid "Join our community and stay updated:"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:63
+#: src/settings/general/app-settings.tsx
 msgid "Keep Anarlog available from the menu bar."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:184
+#: src/settings/general/storage/index.tsx
 msgid "Keep recordings until manually deleted"
 msgstr ""
 
-#: src/settings/general/index.tsx:252
+#: src/settings/general/index.tsx
 msgid "Language & Region"
 msgstr "Ulimi Nesifunda"
 
-#: src/settings/general/main-language.tsx:53
+#: src/settings/general/main-language.tsx
 msgid "Language for summaries, chats, and AI-generated responses"
 msgstr "Ulimi lokufingqa, izingxoxo, nezimpendulo ezikhiqizwe yi-AI"
 
-#: src/chat/components/message/error.tsx:49
+#: src/chat/components/message/error.tsx
 msgid "Learn how to fix this"
 msgstr ""
 
-#: src/settings/general/theme.tsx:34
+#: src/settings/general/theme.tsx
 msgid "Light"
 msgstr ""
 
-#: src/contacts/details.tsx:518
+#: src/contacts/details.tsx
 msgid "LinkedIn"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:750
+#: src/settings/ai/stt/select.tsx
 msgid "Live"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:63
+#: src/calendar/components/calendar-selection.tsx
 msgid "Loading calendars..."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:162
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Loading models..."
 msgstr ""
 
-#: src/changelog/index.tsx:92
-#: src/settings/general/account.tsx:332
-#: src/task/resource-view.tsx:81
+#: src/changelog/index.tsx
+#: src/settings/general/account.tsx
+#: src/task/resource-view.tsx
 msgid "Loading..."
 msgstr ""
 
-#: src/onboarding/account/before-login.tsx:29
+#: src/onboarding/account/before-login.tsx
 msgid "Login with existing account"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:50
+#: src/settings/general/main-language.tsx
 msgid "Main language"
 msgstr "Ulimi oluyinhloko"
 
-#: src/onboarding/permissions.tsx:43
+#: src/onboarding/permissions.tsx
 msgid "Manage"
 msgstr ""
 
-#: src/settings/general/account.tsx:384
+#: src/settings/general/account.tsx
 msgid "Manage billing"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:216
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match case"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:223
+#: src/session/components/note-input/search/bar.tsx
 msgid "Match whole word"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:635
+#: src/sidebar/timeline/index.tsx
 msgid "Meeting"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:73
+#: src/settings/general/app-settings.tsx
 msgid "Meetings"
 msgstr "Imihlangano"
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "member"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:69
+#: src/contacts/organization-details.tsx
 msgid "members"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:227
-#: src/session/components/outer-header/overflow/export-modal.tsx:275
-#: src/session/components/outer-header/overflow/export-modal.tsx:332
-#: src/session/components/outer-header/overflow/export-modal.tsx:509
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Memo"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:294
+#: src/session/components/note-input/header.tsx
 msgid "Memos"
 msgstr ""
 
-#: src/task/resource-view.tsx:270
+#: src/task/resource-view.tsx
 msgid "Merged"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:314
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Metadata"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:146
-#: src/settings/general/permissions.tsx:160
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Microphone"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:143
+#: src/onboarding/permissions.tsx
 msgid "Microphone access turned on"
 msgstr ""
 
-#: src/settings/general/notification.tsx:235
+#: src/settings/general/notification.tsx
 msgid "Microphone detection"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:197
-#: src/settings/ai/stt/select.tsx:171
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Model being used"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:40
+#: src/settings/general/week-start.tsx
 msgid "Monday"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:68
+#: src/session/components/floating/options-menu.tsx
 msgid "More options"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:373
+#: src/settings/general/storage/index.tsx
 msgid "Move"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:274
+#: src/templates/sections-editor.tsx
 msgid "Move down"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:267
+#: src/templates/sections-editor.tsx
 msgid "Move up"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:273
+#: src/settings/general/storage/index.tsx
 msgid "Moving existing data requires an empty folder. Uncheck Move to switch locations without migrating files."
 msgstr ""
 
-#: src/contacts/details.tsx:292
-#: src/contacts/details.tsx:402
-#: src/contacts/organization-details.tsx:53
+#: src/contacts/details.tsx
+#: src/contacts/organization-details.tsx
 msgid "Name"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:64
+#: src/chat/components/toolbar-controls.tsx
 msgid "New chat"
 msgstr ""
 
-#: src/main/empty.tsx:41
+#: src/main/empty.tsx
 msgid "New Note"
 msgstr ""
 
-#: src/contacts/shared.tsx:106
+#: src/contacts/shared.tsx
 msgid "Newest"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:266
+#: src/session/components/note-input/search/bar.tsx
 msgid "Next match"
 msgstr ""
 
-#: src/settings/general/notification.tsx:370
+#: src/settings/general/notification.tsx
 msgid "No apps found."
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:71
+#: src/calendar/components/calendar-selection.tsx
 msgid "No calendars found"
 msgstr ""
 
-#: src/changelog/index.tsx:121
+#: src/changelog/index.tsx
 msgid "No changelog available for this version."
 msgstr ""
 
-#: src/templates/details.tsx:51
+#: src/templates/details.tsx
 msgid "No community templates available"
 msgstr ""
 
-#: src/task/resource-view.tsx:240
+#: src/task/resource-view.tsx
 msgid "No content."
 msgstr ""
 
-#: src/task/resource-view.tsx:186
+#: src/task/resource-view.tsx
 msgid "No description provided."
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:900
+#: src/sidebar/timeline/index.tsx
 msgid "No items today"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:64
-#: src/settings/general/spoken-languages.tsx:218
+#: src/settings/general/main-language.tsx
+#: src/settings/general/spoken-languages.tsx
 msgid "No matching languages found"
 msgstr "Azikho izilimi ezifanayo ezitholiwe"
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:537
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No matching people"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:206
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models available."
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:202
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "No models ready to use."
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:240
+#: src/shared/open-note-dialog.tsx
 msgid "No notes found."
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:539
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "No people"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:166
+#: src/contacts/organization-details.tsx
 msgid "No people in this organization"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:225
+#: src/chat/components/toolbar-controls.tsx
 msgid "No recent chats"
 msgstr ""
 
-#: src/contacts/details.tsx:365
+#: src/contacts/details.tsx
 msgid "No related notes found"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:198
-#: src/settings/general/searchable-select.tsx:122
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "No results found."
 msgstr ""
 
-#: src/templates/details.tsx:82
+#: src/templates/details.tsx
 msgid "No templates yet"
 msgstr ""
 
-#: src/session/components/title-breadcrumb.tsx:27
+#: src/session/components/title-breadcrumb.tsx
 msgid "Note breadcrumb"
 msgstr ""
 
-#: src/contacts/details.tsx:548
+#: src/contacts/details.tsx
 msgid "Notes"
 msgstr ""
 
-#: src/settings/general/index.tsx:303
-#: src/sidebar/settings.tsx:73
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Notifications"
 msgstr "Izaziso"
 
-#: src/sidebar/timeline/index.tsx:108
-#: src/sidebar/timeline/index.tsx:811
-#: src/sidebar/timeline/upcoming-meeting.ts:62
+#: src/sidebar/timeline/index.tsx
+#: src/sidebar/timeline/upcoming-meeting.ts
 msgid "Now"
 msgstr ""
 
-#: src/contacts/shared.tsx:100
+#: src/contacts/shared.tsx
 msgid "Oldest"
 msgstr ""
 
-#: src/settings/todo/github.tsx:102
+#: src/settings/todo/github.tsx
 msgid "Only public repositories are supported."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:156
-#: src/settings/general/permissions.tsx:100
-#: src/task/resource-view.tsx:280
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/task/resource-view.tsx
 msgid "Open"
 msgstr ""
 
 #. placeholder {0}: permissionName.toLowerCase()
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:105
-#: src/onboarding/permissions.tsx:63
-#: src/settings/general/permissions.tsx:118
+#: src/calendar/components/apple/permission.tsx
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "Open {0} settings"
 msgstr ""
 
-#: src/onboarding/final.tsx:66
+#: src/onboarding/final.tsx
 msgid "Open Anarlog"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:588
-#: src/sidebar/timeline/index.tsx:592
+#: src/sidebar/timeline/index.tsx
 msgid "Open calendar"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:170
+#: src/calendar/components/calendar-selection.tsx
 msgid "Open calendar account actions"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:152
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Open floating panel"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:401
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Tab"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/index.tsx:164
-#: src/sidebar/timeline/item.tsx:564
+#: src/session/components/outer-header/overflow/index.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Open in New Window"
 msgstr ""
 
-#: src/chat/components/toolbar-controls.tsx:97
+#: src/chat/components/toolbar-controls.tsx
 msgid "Open in right panel"
 msgstr ""
 
-#: src/task/resource-view.tsx:107
+#: src/task/resource-view.tsx
 msgid "Open on GitHub"
 msgstr ""
 
-#: src/settings/todo/github.tsx:162
+#: src/settings/todo/github.tsx
 msgid "Open repository on GitHub"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:45
+#: src/onboarding/permissions.tsx
 msgid "Open settings"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:154
-#: src/settings/general/permissions.tsx:98
-#: src/settings/todo/provider-content.tsx:182
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "or"
 msgstr ""
 
-#: src/contacts/details.tsx:706
+#: src/contacts/details.tsx
 msgid "Organization"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:212
+#: src/contacts/organization-details.tsx
 msgid "Organization name"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:189
-#: src/settings/general/storage/index.tsx:126
+#: src/settings/general/permissions.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Others"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:66
+#: src/settings/general/timezone.tsx
 msgid "Override the timezone used for the sidebar timeline"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:503
-#: src/session/components/outer-header/overflow/export-modal.tsx:216
-#: src/session/components/outer-header/overflow/export-modal.tsx:264
-#: src/session/components/outer-header/overflow/export-modal.tsx:321
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Participants"
 msgstr ""
 
-#: src/instruction/index.tsx:263
+#: src/instruction/index.tsx
 msgid "Paste the browser URL here if the browser button did not reopen Anarlog."
 msgstr ""
 
-#: src/contacts/organization-details.tsx:65
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:505
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:523
+#: src/contacts/organization-details.tsx
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "People"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:158
-#: src/settings/general/permissions.tsx:102
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "permission panel."
 msgstr ""
 
-#: src/settings/general/index.tsx:312
-#: src/sidebar/settings.tsx:113
+#: src/settings/general/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Permissions"
 msgstr ""
 
-#: src/onboarding/index.tsx:205
+#: src/onboarding/index.tsx
 msgid "Permissions granted"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:31
-#: src/sidebar/settings.tsx:103
+#: src/settings/personalization/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Personalization"
 msgstr ""
 
-#: src/contacts/details.tsx:483
+#: src/contacts/details.tsx
 msgid "Phone"
 msgstr ""
 
-#: src/settings/general/account.tsx:376
+#: src/settings/general/account.tsx
 msgid "Plan & Billing"
 msgstr ""
 
-#: src/settings/general/account.tsx:457
+#: src/settings/general/account.tsx
 msgid "Plans"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:551
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Preparing transcript..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:252
+#: src/session/components/note-input/search/bar.tsx
 msgid "Previous match"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:207
+#: src/settings/ai/stt/select.tsx
 msgid "Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:227
+#: src/settings/general/account.tsx
 msgid "Pro trial"
 msgstr ""
 
-#: src/onboarding/index.tsx:285
+#: src/onboarding/index.tsx
 msgid "Ready to go"
 msgstr ""
 
-#: src/shared/open-note-dialog.tsx:251
+#: src/shared/open-note-dialog.tsx
 msgid "Recent"
 msgstr ""
 
-#: src/calendar/components/oauth/status.tsx:16
-#: src/settings/todo/provider-content.tsx:179
+#: src/calendar/components/oauth/status.tsx
+#: src/settings/todo/provider-content.tsx
 msgid "Reconnect required"
 msgstr ""
 
-#: src/settings/general/account.tsx:614
+#: src/settings/general/account.tsx
 msgid "Refresh billing status"
 msgstr ""
 
-#: src/calendar/components/calendar-selection.tsx:78
+#: src/calendar/components/calendar-selection.tsx
 msgid "Refresh calendars"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:138
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerate insights"
 msgstr ""
 
-#: src/chat/components/message/normal.tsx:91
+#: src/chat/components/message/normal.tsx
 msgid "Regenerate message"
 msgstr ""
 
-#: src/session/components/note-input/insights.tsx:156
+#: src/session/components/note-input/insights.tsx
 msgid "Regenerating insights"
 msgstr ""
 
-#: src/contacts/details.tsx:335
+#: src/contacts/details.tsx
 msgid "Related Notes"
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:229
+#: src/settings/todo/provider-content.tsx
 msgid "Reminders"
 msgstr ""
 
-#: src/settings/personalization/index.tsx:126
+#: src/settings/personalization/index.tsx
 msgid "Remove {term}"
 msgstr ""
 
-#: src/settings/todo/github.tsx:170
+#: src/settings/todo/github.tsx
 msgid "Remove repository"
 msgstr ""
 
-#: src/instruction/index.tsx:172
+#: src/instruction/index.tsx
 msgid "Reopen checkout page"
 msgstr ""
 
-#: src/instruction/index.tsx:190
+#: src/instruction/index.tsx
 msgid "Reopen in browser"
 msgstr ""
 
-#: src/settings/general/account.tsx:87
+#: src/settings/general/account.tsx
 msgid "Reopen sign-in page"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:233
-#: src/session/components/note-input/search/bar.tsx:307
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:320
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace all"
 msgstr ""
 
-#: src/settings/todo/github.tsx:250
+#: src/settings/todo/github.tsx
 msgid "Replace repository"
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:298
+#: src/session/components/note-input/search/bar.tsx
 msgid "Replace with..."
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:149
+#: src/calendar/components/apple/permission.tsx
 msgid "Request"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/calendar/components/apple/permission.tsx:106
+#: src/calendar/components/apple/permission.tsx
 msgid "Request {0}"
 msgstr ""
 
 #. placeholder {0}: title.toLowerCase()
-#: src/settings/general/permissions.tsx:119
+#: src/settings/general/permissions.tsx
 msgid "Request {0} permission"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:93
+#: src/settings/general/permissions.tsx
 msgid "Request,"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:170
+#: src/settings/general/permissions.tsx
 msgid "Required to capture other participants' voices in meetings"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:181
+#: src/settings/general/permissions.tsx
 msgid "Required to detect meeting apps and sync mute status"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:161
+#: src/settings/general/permissions.tsx
 msgid "Required to record your voice during meetings and calls"
 msgstr ""
 
-#: src/settings/general/permissions.tsx:192
+#: src/settings/general/permissions.tsx
 msgid "Required to sync Apple Calendar events into Anarlog"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:152
-#: src/settings/general/permissions.tsx:96
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "Reset"
 msgstr ""
 
-#: src/settings/general/notification.tsx:419
+#: src/settings/general/notification.tsx
 msgid "Respect Do-Not-Disturb mode"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Resume"
 msgstr ""
 
-#: src/chat/components/message/error.tsx:57
-#: src/session/components/note-input/enhanced/enhance-error.tsx:57
+#: src/chat/components/message/error.tsx
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Retry"
 msgstr ""
 
-#: src/settings/ai/shared/index.tsx:348
-#: src/settings/ai/stt/select.tsx:757
+#: src/settings/ai/shared/index.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Runs after the recording finishes, not during the meeting."
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:198
+#: src/settings/general/storage/index.tsx
 msgid "Save audio after meeting"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:161
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Save date"
 msgstr ""
 
-#: src/contacts/shared.tsx:166
+#: src/contacts/shared.tsx
 msgid "Search contacts..."
 msgstr ""
 
-#: src/settings/general/notification.tsx:292
+#: src/settings/general/notification.tsx
 msgid "Search installed apps to exclude them. Click an excluded app to include it again."
 msgstr ""
 
-#: src/settings/general/notification.tsx:352
-#: src/settings/general/notification.tsx:364
+#: src/settings/general/notification.tsx
 msgid "Search installed apps..."
 msgstr ""
 
-#: src/settings/general/main-language.tsx:63
+#: src/settings/general/main-language.tsx
 msgid "Search language..."
 msgstr "Sesha ulimi..."
 
-#: src/contacts/details.tsx:723
+#: src/contacts/details.tsx
 msgid "Search or add company"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:185
+#: src/settings/ai/shared/model-combobox.tsx
 msgid "Search or create new"
 msgstr ""
 
-#: src/settings/todo/github.tsx:193
+#: src/settings/todo/github.tsx
 msgid "Search or type owner/repo"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:489
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Search people"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1351
-#: src/templates/template-sidebar.tsx:354
+#: src/session/components/note-input/header.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Search templates..."
 msgstr ""
 
-#: src/settings/general/timezone.tsx:74
+#: src/settings/general/timezone.tsx
 msgid "Search timezone..."
 msgstr ""
 
-#: src/session/components/note-input/search/bar.tsx:209
-#: src/settings/general/searchable-select.tsx:116
+#: src/session/components/note-input/search/bar.tsx
+#: src/settings/general/searchable-select.tsx
 msgid "Search..."
 msgstr ""
 
-#: src/templates/sections-editor.tsx:243
+#: src/templates/sections-editor.tsx
 msgid "Section actions"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1417
+#: src/session/components/note-input/header.tsx
 msgid "See all templates"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:270
+#: src/settings/general/storage/index.tsx
 msgid "Select a different folder"
 msgstr ""
 
-#: src/settings/ai/shared/model-combobox.tsx:163
-#: src/settings/ai/stt/select.tsx:249
+#: src/settings/ai/shared/model-combobox.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a model"
 msgstr ""
 
-#: src/contacts/details.tsx:377
+#: src/contacts/details.tsx
 msgid "Select a person to view details"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:206
-#: src/settings/ai/stt/select.tsx:180
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Select a provider"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:178
+#: src/contacts/organization-details.tsx
 msgid "Select an organization to view details"
 msgstr ""
 
-#: src/settings/general/theme.tsx:61
+#: src/settings/general/theme.tsx
 msgid "Select appearance"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:63
+#: src/settings/general/week-start.tsx
 msgid "Select day"
 msgstr ""
 
-#: src/settings/general/main-language.tsx:62
+#: src/settings/general/main-language.tsx
 msgid "Select language"
 msgstr "Khetha ulimi"
 
-#: src/settings/general/timezone.tsx:73
+#: src/settings/general/timezone.tsx
 msgid "Select timezone"
 msgstr ""
 
-#: src/settings/general/searchable-select.tsx:95
+#: src/settings/general/searchable-select.tsx
 msgid "Select..."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:45
+#: src/settings/general/app-settings.tsx
 msgid "Send anonymous usage analytics to help improve Anarlog."
 msgstr "Thumela izibalo zokusetshenziswa ezingaziwa ukuze usize ukuthuthukisa i-Anarlog."
 
-#: src/contacts/organization-details.tsx:134
+#: src/contacts/organization-details.tsx
 msgid "Send email"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:134
+#: src/chat/components/input/index.tsx
 msgid "Send message"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:1458
+#: src/session/components/note-input/header.tsx
 msgid "Session note tabs"
 msgstr ""
 
-#: src/session/components/title-input.tsx:382
+#: src/session/components/title-input.tsx
 msgid "Session title"
 msgstr ""
 
-#: src/templates/details.tsx:144
+#: src/templates/details.tsx
 msgid "Set as default"
 msgstr ""
 
-#: src/main/empty.tsx:52
-#: src/sidebar/settings.tsx:120
+#: src/main/empty.tsx
+#: src/sidebar/settings.tsx
 msgid "Settings"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:43
+#: src/settings/general/app-settings.tsx
 msgid "Share usage data"
 msgstr "Yabelana ngedatha yokusetshenziswa"
 
-#: src/sidebar/timeline/item.tsx:389
+#: src/sidebar/timeline/item.tsx
 msgid "Show All Recurring Events"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:55
+#: src/settings/general/app-settings.tsx
 msgid "Show Anarlog in the Dock and app switcher."
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:53
+#: src/settings/general/app-settings.tsx
 msgid "Show app in Dock"
 msgstr ""
 
-#: src/sidebar/timeline/index.tsx:412
+#: src/sidebar/timeline/index.tsx
 msgid "Show Deleted Events"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:395
+#: src/sidebar/timeline/item.tsx
 msgid "Show Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:99
+#: src/settings/general/app-settings.tsx
 msgid "Show floating bar"
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:812
-#: src/sidebar/timeline/item.tsx:569
+#: src/settings/ai/stt/select.tsx
+#: src/sidebar/timeline/item.tsx
 msgid "Show in Finder"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:101
+#: src/settings/general/app-settings.tsx
 msgid "Show the compact floating control while listening."
 msgstr "Bonisa isilawuli esintantayo esihlangene ngenkathi ulalele."
 
-#: src/sidebar/timeline/item.tsx:384
+#: src/sidebar/timeline/item.tsx
 msgid "Show This Event"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:61
+#: src/settings/general/app-settings.tsx
 msgid "Show tray icon"
 msgstr ""
 
-#: src/settings/general/account.tsx:428
-#: src/settings/general/account.tsx:437
+#: src/settings/general/account.tsx
 msgid "Sign in"
 msgstr ""
 
-#: src/settings/general/account.tsx:425
+#: src/settings/general/account.tsx
 msgid "Sign in for Lite"
 msgstr ""
 
-#: src/settings/todo/github.tsx:105
+#: src/settings/todo/github.tsx
 msgid "Sign in for private repo access."
 msgstr ""
 
-#: src/settings/general/account.tsx:427
+#: src/settings/general/account.tsx
 msgid "Sign in for Pro"
 msgstr ""
 
-#: src/settings/general/account.tsx:110
+#: src/settings/general/account.tsx
 msgid "Sign in to Anarlog"
 msgstr ""
 
-#: src/onboarding/calendar.tsx:396
-#: src/onboarding/calendar.tsx:415
-#: src/onboarding/calendar.tsx:502
-#: src/onboarding/calendar.tsx:521
+#: src/onboarding/calendar.tsx
 msgid "Sign in to connect"
 msgstr ""
 
 #. placeholder {0}: config.displayName
-#: src/settings/todo/provider-content.tsx:79
+#: src/settings/todo/provider-content.tsx
 msgid "Sign in to connect {0}"
 msgstr ""
 
-#: src/settings/general/account.tsx:113
+#: src/settings/general/account.tsx
 msgid "Sign in to unlock cloud transcription and AI models, plus Pro features like sharing."
 msgstr ""
 
-#: src/onboarding/index.tsx:223
+#: src/onboarding/index.tsx
 msgid "Sign in to unlock powerful AI models, sync across devices, and personalization."
 msgstr ""
 
-#: src/instruction/index.tsx:240
+#: src/instruction/index.tsx
 msgid "Sign in to your account"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Sign out"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:10
-#: src/onboarding/account/after-login.tsx:87
-#: src/onboarding/index.tsx:230
-#: src/settings/general/account.tsx:142
+#: src/onboarding/account/after-login.tsx
+#: src/onboarding/index.tsx
+#: src/settings/general/account.tsx
 msgid "Signed in"
 msgstr ""
 
-#: src/settings/general/account.tsx:152
+#: src/settings/general/account.tsx
 msgid "Signing out..."
 msgstr ""
 
-#: src/onboarding/shared.tsx:105
+#: src/onboarding/shared.tsx
 msgid "Skip"
 msgstr ""
 
-#: src/onboarding/index.tsx:232
+#: src/onboarding/index.tsx
 msgid "Skipped"
 msgstr ""
 
-#: src/contacts/details.tsx:430
+#: src/contacts/details.tsx
 msgid "Software Engineer"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/enhance-error.tsx:46
+#: src/session/components/note-input/enhanced/enhance-error.tsx
 msgid "Something went wrong while generating the summary."
 msgstr ""
 
-#: src/contacts/shared.tsx:74
+#: src/contacts/shared.tsx
 msgid "Sort options"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:35
+#: src/settings/general/app-settings.tsx
 msgid "Start Anarlog at login"
 msgstr "Qala i-Anarlog ekungeneni ngemvume"
 
-#: src/main/empty.tsx:46
+#: src/main/empty.tsx
 msgid "Start Recording"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:77
+#: src/settings/general/app-settings.tsx
 msgid "Start when meeting begins"
 msgstr "Qala uma umhlangano uqala"
 
-#: src/onboarding/index.tsx:204
+#: src/onboarding/index.tsx
 msgid "Start with permissions"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:27
+#: src/onboarding/account/after-login.tsx
 msgid "Starting your trial..."
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:690
+#: src/session/components/note-input/header.tsx
 msgid "Stop"
 msgstr ""
 
-#: src/sidebar/timeline/item.tsx:239
+#: src/sidebar/timeline/item.tsx
 msgid "Stop listening"
 msgstr ""
 
-#: src/chat/components/input/index.tsx:127
+#: src/chat/components/input/index.tsx
 msgid "Stop response"
 msgstr ""
 
-#: src/settings/general/app-settings.tsx:88
+#: src/settings/general/app-settings.tsx
 msgid "Stop when meeting ends"
 msgstr "Yima lapho umhlangano uphela"
 
-#: src/onboarding/index.tsx:272
-#: src/settings/general/storage/index.tsx:103
+#: src/onboarding/index.tsx
+#: src/settings/general/storage/index.tsx
 msgid "Storage"
 msgstr ""
 
-#: src/onboarding/index.tsx:276
+#: src/onboarding/index.tsx
 msgid "Storage configured"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:51
+#: src/onboarding/folder-location.tsx
 msgid "Storage Updated"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:127
+#: src/settings/general/storage/index.tsx
 msgid "Stores app-wide settings and configurations"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:110
+#: src/settings/general/storage/index.tsx
 msgid "Stores your notes, recordings, and session data"
 msgstr ""
 
-#: src/instruction/index.tsx:259
+#: src/instruction/index.tsx
 msgid "Submit callback URL"
 msgstr ""
 
-#: src/contacts/details.tsx:318
-#: src/session/components/outer-header/overflow/export-modal.tsx:236
-#: src/session/components/outer-header/overflow/export-modal.tsx:285
-#: src/session/components/outer-header/overflow/export-modal.tsx:341
-#: src/session/components/outer-header/overflow/export-modal.tsx:512
+#: src/contacts/details.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Summary"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:39
+#: src/settings/general/week-start.tsx
 msgid "Sunday"
 msgstr ""
 
-#: src/settings/general/theme.tsx:36
+#: src/settings/general/theme.tsx
 msgid "System"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:158
-#: src/settings/general/permissions.tsx:169
+#: src/onboarding/permissions.tsx
+#: src/settings/general/permissions.tsx
 msgid "System audio"
 msgstr ""
 
-#: src/onboarding/permissions.tsx:155
+#: src/onboarding/permissions.tsx
 msgid "System audio enabled"
 msgstr ""
 
-#: src/templates/details.tsx:167
-#: src/templates/template-form.tsx:268
+#: src/templates/details.tsx
+#: src/templates/template-form.tsx
 msgid "Template actions"
 msgstr ""
 
-#: src/templates/sections-editor.tsx:301
+#: src/templates/sections-editor.tsx
 msgid "Template content with Jinja2: {{ variable }}, {% if condition %}"
 msgstr ""
 
-#: src/sidebar/settings.tsx:91
-#: src/templates/template-sidebar.tsx:298
+#: src/sidebar/settings.tsx
+#: src/templates/template-sidebar.tsx
 msgid "Templates"
 msgstr ""
 
-#: src/onboarding/folder-location.tsx:48
+#: src/onboarding/folder-location.tsx
 msgid "The app will restart after onboarding to apply your storage changes"
 msgstr ""
 
-#: src/settings/general/spoken-languages.tsx:119
+#: src/settings/general/spoken-languages.tsx
 msgid "The main language is always included for transcription"
 msgstr "Ulimi oluyinhloko luhlala lufakiwe ekulotshweni"
 
-#: src/chat/components/message/loading.tsx:13
+#: src/chat/components/message/loading.tsx
 msgid "Thinking..."
 msgstr ""
 
-#: src/settings/todo/index.tsx:28
+#: src/settings/todo/index.tsx
 msgid "Ticket"
 msgstr ""
 
-#: src/settings/general/timezone.tsx:63
+#: src/settings/general/timezone.tsx
 msgid "Timezone"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/streaming.tsx:72
+#: src/session/components/note-input/enhanced/streaming.tsx
 msgid "Tip: The Anarlog team loves our users!"
 msgstr ""
 
-#: src/session/components/note-input/header.tsx:688
-#: src/session/components/outer-header/overflow/export-modal.tsx:245
-#: src/session/components/outer-header/overflow/export-modal.tsx:295
-#: src/session/components/outer-header/overflow/export-modal.tsx:350
-#: src/session/components/outer-header/overflow/export-modal.tsx:518
+#: src/session/components/note-input/header.tsx
+#: src/session/components/outer-header/overflow/export-modal.tsx
 msgid "Transcript"
 msgstr ""
 
-#: src/settings/ai/stt/index.tsx:17
-#: src/sidebar/settings.tsx:99
+#: src/settings/ai/stt/index.tsx
+#: src/sidebar/settings.tsx
 msgid "Transcription"
 msgstr ""
 
-#: src/settings/general/account.tsx:525
-#: src/settings/general/account.tsx:584
+#: src/settings/general/account.tsx
 msgid "Trial"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:48
+#: src/onboarding/account/after-login.tsx
 msgid "Trial activated - 14 days of Pro"
 msgstr ""
 
-#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx:320
+#: src/session/components/note-input/transcript/renderer/speaker-assign.tsx
 msgid "Unknown"
 msgstr ""
 
-#: src/session/components/outer-header/metadata/date.tsx:24
+#: src/session/components/outer-header/metadata/date.tsx
 msgid "Unknown date"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:114
+#: src/contacts/organization-details.tsx
 msgid "Unnamed"
 msgstr ""
 
-#: src/session/components/outer-header/overflow/export-modal.tsx:208
-#: src/session/components/outer-header/overflow/export-modal.tsx:255
-#: src/session/components/outer-header/overflow/export-modal.tsx:306
-#: src/session/components/outer-header/overflow/export-modal.tsx:365
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/outer-header/overflow/export-modal.tsx:400
-#: src/session/components/title-input.tsx:250
-#: src/session/components/title-input.tsx:251
-#: src/session/components/title-input.tsx:385
-#: src/shared/open-note-dialog.tsx:107
-#: src/shared/ui/resource-list/preview-header.tsx:73
-#: src/sidebar/timeline/item.tsx:200
-#: src/sidebar/timeline/item.tsx:307
-#: src/sidebar/timeline/item.tsx:543
-#: src/templates/details.tsx:122
-#: src/templates/sections-editor.tsx:293
+#: src/session/components/outer-header/overflow/export-modal.tsx
+#: src/session/components/title-input.tsx
+#: src/shared/open-note-dialog.tsx
+#: src/shared/ui/resource-list/preview-header.tsx
+#: src/sidebar/timeline/item.tsx
+#: src/templates/details.tsx
+#: src/templates/sections-editor.tsx
 msgid "Untitled"
 msgstr ""
 
-#: src/contacts/details.tsx:348
+#: src/contacts/details.tsx
 msgid "Untitled Note"
 msgstr ""
 
-#: src/settings/todo/github.tsx:113
+#: src/settings/todo/github.tsx
 msgid "Upgrade for private repos."
 msgstr ""
 
-#: src/settings/todo/provider-content.tsx:94
+#: src/settings/todo/provider-content.tsx
 msgid "Upgrade to connect"
 msgstr ""
 
-#: src/calendar/components/sidebar.tsx:297
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro"
 msgstr ""
 
 #. placeholder {0}: provider.displayName
-#: src/calendar/components/sidebar.tsx:295
+#: src/calendar/components/sidebar.tsx
 msgid "Upgrade to Pro for {0}"
 msgstr ""
 
-#: src/settings/ai/llm/select.tsx:235
-#: src/settings/ai/stt/select.tsx:213
+#: src/settings/ai/llm/select.tsx
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to Pro to use this provider."
 msgstr ""
 
-#: src/settings/ai/stt/select.tsx:708
+#: src/settings/ai/stt/select.tsx
 msgid "Upgrade to use"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:134
-#: src/session/components/outer-header/overflow/index.tsx:131
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload audio"
 msgstr ""
 
-#: src/session/components/floating/options-menu.tsx:143
-#: src/session/components/outer-header/overflow/index.tsx:140
+#: src/session/components/floating/options-menu.tsx
+#: src/session/components/outer-header/overflow/index.tsx
 msgid "Upload transcript"
 msgstr ""
 
-#: src/contacts/organization-details.tsx:153
+#: src/contacts/organization-details.tsx
 msgid "View LinkedIn profile"
 msgstr ""
 
-#: src/settings/general/storage/index.tsx:338
+#: src/settings/general/storage/index.tsx
 msgid "Want to use with your vault?"
 msgstr ""
 
-#: src/settings/general/week-start.tsx:55
+#: src/settings/general/week-start.tsx
 msgid "Week starts on"
 msgstr ""
 
-#: src/onboarding/index.tsx:197
+#: src/onboarding/index.tsx
 msgid "Welcome to Anarlog"
 msgstr ""
 
-#: src/changelog/index.tsx:165
+#: src/changelog/index.tsx
 msgid "What's new in {version}?"
 msgstr ""
 
-#: src/onboarding/index.tsx:274
+#: src/onboarding/index.tsx
 msgid "Where your notes and recordings are stored"
 msgstr ""
 
-#: src/task/tab-content.tsx:59
+#: src/task/tab-content.tsx
 msgid "Work on this task"
 msgstr ""
 
-#: src/calendar/components/apple/permission.tsx:147
-#: src/settings/general/permissions.tsx:91
+#: src/calendar/components/apple/permission.tsx
+#: src/settings/general/permissions.tsx
 msgid "You can"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:33
+#: src/onboarding/account/after-login.tsx
 msgid "You have an active plan"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:41
-#: src/session/components/note-input/enhanced/config-error.tsx:91
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure a language model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:68
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key and base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:76
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the API key for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:83
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to configure the base URL for your language model provider"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:48
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to select a model to summarize this meeting"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:52
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "You need to sign in to use Anarlog's language model"
 msgstr ""
 
-#: src/onboarding/account/after-login.tsx:37
+#: src/onboarding/account/after-login.tsx
 msgid "You're on a Pro trial"
 msgstr ""
 
-#: src/settings/general/account.tsx:231
+#: src/settings/general/account.tsx
 msgid "You're on the <0>{planLabel}</0> plan"
 msgstr ""
 
-#: src/settings/general/account.tsx:141
+#: src/settings/general/account.tsx
 msgid "Your Account"
 msgstr ""
 
-#: src/session/components/note-input/enhanced/config-error.tsx:57
+#: src/session/components/note-input/enhanced/config-error.tsx
 msgid "Your Anarlog plan has expired. Configure another language model or renew your plan"
 msgstr ""
 
-#: src/templates/template-sidebar.tsx:320
+#: src/templates/template-sidebar.tsx
 msgid "Z to A"
 msgstr ""

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -361,6 +361,9 @@ importers:
       '@lingui/cli':
         specifier: ^6.0.1
         version: 6.0.1(babel-plugin-macros@3.1.0)
+      '@lingui/format-po':
+        specifier: ^6.0.1
+        version: 6.0.1
       '@lingui/vite-plugin':
         specifier: ^6.0.1
         version: 6.0.1(@babel/core@7.29.0)(@lingui/babel-plugin-lingui-macro@6.0.1)(@rolldown/plugin-babel@0.2.3(@babel/core@7.29.0)(@babel/runtime@7.29.2)(rolldown@1.0.0-rc.15)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0)))(babel-plugin-macros@3.1.0)(rolldown@1.0.0-rc.15)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -9577,8 +9580,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.6.0:
-    resolution: {integrity: sha512-MAFw9r+5WUNthgy6J6HtVKdk6B7orqGMOTBiBYz3YMI7WJNM5nE8cfQgp+ZoS7gnD1DQalEW5GqqA/emUSmD8w==}
+  deslop-js@0.6.2:
+    resolution: {integrity: sha512-3+wV56jJd4zx6Mob2nQ4B8nIF4J12Xc2iCagNE9kdVTzMbNEIe99vwfaxrgdFC+RQ1NHXfjUkR3C4HVYnLLSfg==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -12874,8 +12877,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-plugin-react-doctor@0.6.0:
-    resolution: {integrity: sha512-oByEUczXDnxO5ZsevbOscpFlpmya7dnH6Nne5StYy02AJtyEDAiCSKkXj21GDMjDDkD42708LRfWXRAY32IL9w==}
+  oxlint-plugin-react-doctor@0.6.2:
+    resolution: {integrity: sha512-8+YU8hwSPmS2dglPxLGRTSpaSHA5A2L0x7zU/7G+dp9V779jrpHiYMhJ5Ga9JUa0VtECHfpY+xUOYSt1IEP3YA==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.21.1:
@@ -13658,8 +13661,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-doctor@0.6.0:
-    resolution: {integrity: sha512-AqsoQqKQve8Zahxs48hXJuFgMcdY0AdV0fcO5eTdAKZQ/QICEoMCf0bTwxPKwN9Ix/4wWiAR+dNkBcm0ouFq+Q==}
+  react-doctor@0.6.2:
+    resolution: {integrity: sha512-uPFyoWhRvAG6vc7uLVbf2wg7ox0R8y+SgOAhAfAcs1soP4sIPwl4gEuWCNbAir/QIGcb5xrwFJvCM30WmgmeUg==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -22952,7 +22955,7 @@ snapshots:
 
   '@vue/compiler-core@3.5.32':
     dependencies:
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       '@vue/shared': 3.5.32
       entities: 7.0.1
       estree-walker: 2.0.2
@@ -23308,7 +23311,7 @@ snapshots:
       jsonc-parser: 3.3.1
       picocolors: 1.1.1
       prompts: 2.4.2
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   agent-install@0.0.6:
     dependencies:
@@ -23317,7 +23320,7 @@ snapshots:
       jsonc-parser: 3.3.1
       picocolors: 1.1.1
       prompts: 2.4.2
-      yaml: 2.8.3
+      yaml: 2.9.0
 
   ahooks@3.9.7(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
@@ -24702,7 +24705,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.6.0:
+  deslop-js@0.6.2:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -25265,7 +25268,7 @@ snapshots:
   eslint-plugin-react-hooks@7.1.1(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@babel/core': 7.29.0
-      '@babel/parser': 7.29.2
+      '@babel/parser': 7.29.7
       eslint: 9.39.4(jiti@2.7.0)
       hermes-parser: 0.25.1
       zod: 4.3.6
@@ -27561,7 +27564,7 @@ snapshots:
   magicast@0.5.3:
     dependencies:
       '@babel/parser': 7.29.7
-      '@babel/types': 7.29.0
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   make-dir@4.0.0:
@@ -29209,7 +29212,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.45.0
       '@oxfmt/binding-win32-x64-msvc': 0.45.0
 
-  oxlint-plugin-react-doctor@0.6.0:
+  oxlint-plugin-react-doctor@0.6.2:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-scope: 9.1.2
@@ -30175,19 +30178,19 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  react-doctor@0.6.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1):
+  react-doctor@0.6.2(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@sentry/node': 10.63.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.6.0
+      deslop-js: 0.6.2
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.21.1)
-      oxlint-plugin-react-doctor: 0.6.0
+      oxlint-plugin-react-doctor: 0.6.2
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -30328,7 +30331,7 @@ snapshots:
       preact: 10.29.1
       prompts: 2.4.2
       react: 19.2.5
-      react-doctor: 0.6.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1)
+      react-doctor: 0.6.2(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1)
       react-dom: 19.2.5(react@19.2.5)
       react-grab: 0.1.47(react@19.2.5)
     optionalDependencies:


### PR DESCRIPTION
Disable Lingui PO line numbers and normalize desktop locale catalogs so source-only line shifts do not fail i18n checks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling and generated PO metadata only; no runtime app logic or translation strings change.
> 
> **Overview**
> Desktop i18n catalogs are updated so **line-number-only edits in source no longer fail** `i18n:check`.
> 
> **Lingui** now uses `@lingui/format-po` with `lineNumbers: false` in `lingui.config.ts`, so `#:` references in `.po` files are **file paths only** (e.g. `src/foo.tsx` instead of `src/foo.tsx:333`). Locale `messages.po` files were re-extracted to match, which also **deduplicates** repeated `#:` lines for the same file into a single reference per message where applicable.
> 
> **Translations (`msgstr`) are unchanged**; only catalog metadata and formatting shift.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 57f4ac0395d556dee1b34384d0e39ad39ea8a0d7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->