### PR TITLE
Stop recording when deleting active session

### DIFF
--- a/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
+++ b/apps/desktop/src/session/hooks/useDeleteSession.test.tsx
@@ -35,6 +35,8 @@ const mocks = vi.hoisted(() => {
     ignoreEvent: vi.fn(),
     indexes: {},
     invalidateResource: vi.fn(),
+    listenerGetState: vi.fn(),
+    listenerStop: vi.fn(),
     listen: vi.fn(),
     store: {},
     deletedSessionData,
@@ -74,6 +76,12 @@ vi.mock("~/store/tinybase/store/main", () => ({
   },
 }));
 
+vi.mock("~/store/zustand/listener/instance", () => ({
+  listenerStore: {
+    getState: mocks.listenerGetState,
+  },
+}));
+
 vi.mock("~/store/zustand/tabs", () => ({
   useTabs: (
     selector: (state: {
@@ -107,6 +115,14 @@ describe("useDeleteSession", () => {
     mocks.emitTo.mockResolvedValue(undefined);
     mocks.getAllWebviewWindows.mockResolvedValue([]);
     mocks.getCurrentWebviewWindowLabel.mockReturnValue("main");
+    mocks.listenerGetState.mockReturnValue({
+      live: {
+        sessionId: null,
+        status: "inactive",
+        loading: false,
+      },
+      stop: mocks.listenerStop,
+    });
     mocks.listen.mockResolvedValue(vi.fn());
   });
 
@@ -138,6 +154,45 @@ describe("useDeleteSession", () => {
       expect.any(Function),
     );
     expect(mocks.emitTo).not.toHaveBeenCalled();
+  });
+
+  it("stops listening before deleting the active session", () => {
+    mocks.listenerGetState.mockReturnValue({
+      live: {
+        sessionId: "session-1",
+        status: "active",
+        loading: false,
+      },
+      stop: mocks.listenerStop,
+    });
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    expect(mocks.listenerStop).toHaveBeenCalledTimes(1);
+    expect(mocks.listenerStop.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.deleteSessionCascade.mock.invocationCallOrder[0],
+    );
+  });
+
+  it("does not stop listening when deleting an inactive session", () => {
+    mocks.listenerGetState.mockReturnValue({
+      live: {
+        sessionId: "session-2",
+        status: "active",
+        loading: false,
+      },
+      stop: mocks.listenerStop,
+    });
+    const { result } = renderHook(() => useDeleteSession());
+
+    act(() => {
+      result.current("session-1");
+    });
+
+    expect(mocks.listenerStop).not.toHaveBeenCalled();
   });
 
   it("forwards undo data to main and closes the matching note window", async () => {

--- a/apps/desktop/src/session/hooks/useDeleteSession.ts
+++ b/apps/desktop/src/session/hooks/useDeleteSession.ts
@@ -11,6 +11,7 @@ import {
   finalizeSessionDeletion,
 } from "~/store/tinybase/store/deleteSession";
 import * as main from "~/store/tinybase/store/main";
+import { listenerStore } from "~/store/zustand/listener/instance";
 import { useTabs } from "~/store/zustand/tabs";
 import {
   type DeletedSessionData,
@@ -71,6 +72,15 @@ export function useDeleteSession() {
 
       const capturedData = captureSessionData(store, indexes, sessionId);
       const windowLabel = getCurrentWebviewWindowLabel();
+      const listenerState = listenerStore.getState();
+      const live = listenerState.live;
+
+      if (
+        live.sessionId === sessionId &&
+        (live.status === "active" || live.loading)
+      ) {
+        listenerState.stop();
+      }
 
       invalidateResource("sessions", sessionId);
       deleteSessionCascade(store, indexes, sessionId, {


### PR DESCRIPTION
Stop live capture before deleting the active session and add regression coverage for the delete hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to the delete path plus tests; avoids orphaned recording after delete without touching auth or persistence beyond existing cascade.
> 
> **Overview**
> Deleting a session now **stops live capture first** when that session is the one currently being recorded (or still loading), via `listenerStore` **`stop()`** before invalidation and `deleteSessionCascade`.
> 
> Regression tests mock the listener store and assert **`stop` runs once and before cascade** for the active session, and **is not called** when another session is live.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 684d6a71f3822c0c1f408dee10ac8de01a77a7c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->