### PR TITLE
Add session-scoped transcription hints

### DIFF
--- a/apps/desktop/src/stt/useKeywords.test.ts
+++ b/apps/desktop/src/stt/useKeywords.test.ts
@@ -6,9 +6,11 @@ import {
   parseDictionaryTermsText,
 } from "./keywords";
 import {
+  buildKeywords,
   buildKeywordSourceText,
   extractKeywordsFromMarkdown,
   getSessionKeywords,
+  type KeywordStore,
 } from "./useKeywords";
 
 describe("extractKeywordsFromMarkdown", () => {
@@ -158,11 +160,130 @@ describe("getSessionKeywords", () => {
 
     expect(
       getSessionKeywords({
-        store,
+        store: store as unknown as KeywordStore,
         sessionId: "session-1",
         dictionaryTerms: ["Anarlog"],
       }),
     ).toEqual(expect.arrayContaining(["Anarlog", "Launch"]));
+  });
+
+  it("prioritizes mapped participants and attached event attendees", () => {
+    const tables = {
+      sessions: new Map([
+        [
+          "session-1",
+          {
+            raw_md: "Discuss #Launch and production systems",
+            title: "Erebor sync",
+            event_json: JSON.stringify({
+              tracking_id: "tracking-1",
+              calendar_id: "calendar-1",
+              title: "OpenWorld review",
+              description: "Airborne Brothers follow-up",
+              location: "Zoom",
+            }),
+          },
+        ],
+      ]),
+      mapping_session_participant: new Map([
+        [
+          "mapping-1",
+          {
+            session_id: "session-1",
+            human_id: "human-1",
+          },
+        ],
+        [
+          "mapping-2",
+          {
+            session_id: "other-session",
+            human_id: "human-2",
+          },
+        ],
+        [
+          "mapping-3",
+          {
+            session_id: "session-1",
+            human_id: "human-3",
+            source: "excluded",
+          },
+        ],
+      ]),
+      humans: new Map([
+        ["human-1", { name: "Alice Kim" }],
+        ["human-2", { name: "Bob Stone" }],
+        ["human-3", { name: "Hidden Person" }],
+      ]),
+      events: new Map([
+        [
+          "event-1",
+          {
+            tracking_id_event: "tracking-1",
+            calendar_id: "calendar-1",
+            participants_json: JSON.stringify([
+              { name: "Alice Kim", email: "alice@example.com" },
+              { name: "Mina Park", email: "mina@example.com" },
+              {
+                name: "John Jeong",
+                email: "john@example.com",
+                is_current_user: true,
+              },
+            ]),
+          },
+        ],
+      ]),
+    };
+    const store = {
+      getCell: (tableId: keyof typeof tables, rowId: string, cellId: string) =>
+        (tables[tableId].get(rowId) as Record<string, unknown> | undefined)?.[
+          cellId
+        ],
+      forEachRow: (
+        tableId: "mapping_session_participant" | "events",
+        callback: (rowId: string, forEachCell: unknown) => void,
+      ) => {
+        for (const rowId of tables[tableId].keys()) {
+          callback(rowId, undefined);
+        }
+      },
+    };
+
+    const result = getSessionKeywords({
+      store: store as unknown as KeywordStore,
+      sessionId: "session-1",
+      dictionaryTerms: ["Anarlog"],
+    });
+
+    expect(result.slice(0, 3)).toEqual(["Alice Kim", "Mina Park", "Anarlog"]);
+    expect(result).toEqual(expect.arrayContaining(["Launch"]));
+    expect(result).not.toContain("Bob Stone");
+    expect(result).not.toContain("Hidden Person");
+    expect(result).not.toContain("John Jeong");
+  });
+});
+
+describe("buildKeywords", () => {
+  it("dedupes higher-priority hints and caps the result", () => {
+    const result = buildKeywords({
+      rawMd: "",
+      title: "",
+      eventJson: "",
+      sessionParticipantTerms: ["Alice Kim"],
+      eventParticipantTerms: ["alice kim", "Mina Park"],
+      dictionaryTerms: Array.from(
+        { length: 60 },
+        (_, index) => `Term ${index}`,
+      ),
+    });
+
+    expect(result).toHaveLength(50);
+    expect(result.slice(0, 4)).toEqual([
+      "Alice Kim",
+      "Mina Park",
+      "Term 0",
+      "Term 1",
+    ]);
+    expect(result).not.toContain("alice kim");
   });
 });
 

--- a/apps/desktop/src/stt/useKeywords.ts
+++ b/apps/desktop/src/stt/useKeywords.ts
@@ -14,6 +14,8 @@ import { useConfigValue } from "~/shared/config";
 import * as main from "~/store/tinybase/store/main";
 import { normalizeKeywordList } from "~/stt/keywords";
 
+const MAX_TRANSCRIPTION_HINTS = 50;
+
 export function useKeywords(sessionId: string) {
   const rawMd = main.UI.useCell("sessions", sessionId, "raw_md", main.STORE_ID);
   const title = main.UI.useCell("sessions", sessionId, "title", main.STORE_ID);
@@ -23,6 +25,12 @@ export function useKeywords(sessionId: string) {
     "event_json",
     main.STORE_ID,
   );
+  const participantMappings = main.UI.useTable(
+    "mapping_session_participant",
+    main.STORE_ID,
+  );
+  const humans = main.UI.useTable("humans", main.STORE_ID);
+  const events = main.UI.useTable("events", main.STORE_ID);
   const dictionaryTerms = useConfigValue("personalization_dictionary_terms");
 
   return useMemo(() => {
@@ -30,17 +38,32 @@ export function useKeywords(sessionId: string) {
       rawMd,
       title,
       eventJson,
+      sessionParticipantTerms: getSessionParticipantNamesFromTables(
+        participantMappings,
+        humans,
+        sessionId,
+      ),
+      eventParticipantTerms: getAttachedEventParticipantNamesFromTable(
+        events,
+        eventJson,
+      ),
       dictionaryTerms,
     });
-  }, [dictionaryTerms, eventJson, rawMd, title]);
+  }, [
+    dictionaryTerms,
+    eventJson,
+    events,
+    humans,
+    participantMappings,
+    rawMd,
+    sessionId,
+    title,
+  ]);
 }
 
-type KeywordStore = {
-  getCell: (
-    tableId: "sessions",
-    rowId: string,
-    cellId: "raw_md" | "title" | "event_json",
-  ) => unknown;
+export type KeywordStore = {
+  getCell: main.Store["getCell"];
+  forEachRow?: main.Store["forEachRow"];
 };
 
 export function getSessionKeywords({
@@ -52,10 +75,30 @@ export function getSessionKeywords({
   sessionId: string;
   dictionaryTerms: string[];
 }) {
+  return getSessionTranscriptionHints({
+    store,
+    sessionId,
+    dictionaryTerms,
+  });
+}
+
+export function getSessionTranscriptionHints({
+  store,
+  sessionId,
+  dictionaryTerms,
+}: {
+  store: KeywordStore;
+  sessionId: string;
+  dictionaryTerms: string[];
+}) {
+  const eventJson = store.getCell("sessions", sessionId, "event_json");
+
   return buildKeywords({
     rawMd: store.getCell("sessions", sessionId, "raw_md"),
     title: store.getCell("sessions", sessionId, "title"),
-    eventJson: store.getCell("sessions", sessionId, "event_json"),
+    eventJson,
+    sessionParticipantTerms: getSessionParticipantNames(store, sessionId),
+    eventParticipantTerms: getAttachedEventParticipantNames(store, eventJson),
     dictionaryTerms,
   });
 }
@@ -64,11 +107,15 @@ export function buildKeywords({
   rawMd,
   title,
   eventJson,
+  sessionParticipantTerms = [],
+  eventParticipantTerms = [],
   dictionaryTerms,
 }: {
   rawMd: unknown;
   title: unknown;
   eventJson: unknown;
+  sessionParticipantTerms?: string[];
+  eventParticipantTerms?: string[];
   dictionaryTerms: string[];
 }) {
   const sourceText = buildKeywordSourceText({
@@ -81,7 +128,13 @@ export function buildKeywords({
       ? extractKeywordsFromMarkdown(sourceText)
       : { keywords: [], keyphrases: [] };
 
-  return normalizeKeywordList([...dictionaryTerms, ...keywords, ...keyphrases]);
+  return normalizeKeywordList([
+    ...sessionParticipantTerms,
+    ...eventParticipantTerms,
+    ...dictionaryTerms,
+    ...keywords,
+    ...keyphrases,
+  ]).slice(0, MAX_TRANSCRIPTION_HINTS);
 }
 
 export function buildKeywordSourceText({
@@ -193,6 +246,158 @@ const eventKeywordFields = (eventJson: unknown): string[] => {
         return text ? [text] : [];
       },
     );
+  } catch {
+    return [];
+  }
+};
+
+const getSessionParticipantNames = (
+  store: KeywordStore,
+  sessionId: string,
+): string[] => {
+  if (!store.forEachRow) {
+    return [];
+  }
+
+  const names: string[] = [];
+  store.forEachRow("mapping_session_participant", (mappingId, _forEachCell) => {
+    const mappedSessionId = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "session_id",
+    );
+    const source = store.getCell(
+      "mapping_session_participant",
+      mappingId,
+      "source",
+    );
+    if (mappedSessionId !== sessionId || source === "excluded") {
+      return;
+    }
+
+    const humanId = stringValue(
+      store.getCell("mapping_session_participant", mappingId, "human_id"),
+    );
+    if (!humanId) {
+      return;
+    }
+
+    const name = stringValue(store.getCell("humans", humanId, "name"));
+    if (name) {
+      names.push(name);
+    }
+  });
+
+  return names;
+};
+
+const getSessionParticipantNamesFromTables = (
+  mappings: TableRows,
+  humans: TableRows,
+  sessionId: string,
+): string[] =>
+  Object.values(mappings).flatMap((mapping) => {
+    if (mapping?.session_id !== sessionId || mapping.source === "excluded") {
+      return [];
+    }
+
+    const humanId = stringValue(mapping.human_id);
+    if (!humanId) {
+      return [];
+    }
+
+    const name = stringValue(humans[humanId]?.name);
+    return name ? [name] : [];
+  });
+
+const getAttachedEventParticipantNames = (
+  store: KeywordStore,
+  eventJson: unknown,
+): string[] => {
+  if (!store.forEachRow) {
+    return [];
+  }
+
+  const sessionEvent = parseSessionEvent(eventJson);
+  if (!sessionEvent) {
+    return [];
+  }
+
+  let participantsJson: unknown;
+  store.forEachRow("events", (eventId, _forEachCell) => {
+    if (participantsJson !== undefined) {
+      return;
+    }
+
+    const trackingId = store.getCell("events", eventId, "tracking_id_event");
+    const calendarId = store.getCell("events", eventId, "calendar_id");
+    if (
+      trackingId === sessionEvent.trackingId &&
+      calendarId === sessionEvent.calendarId
+    ) {
+      participantsJson = store.getCell("events", eventId, "participants_json");
+    }
+  });
+
+  return parseEventParticipantNames(participantsJson);
+};
+
+type TableRows = Record<string, Record<string, unknown> | undefined>;
+
+const getAttachedEventParticipantNamesFromTable = (
+  events: TableRows,
+  eventJson: unknown,
+): string[] => {
+  const sessionEvent = parseSessionEvent(eventJson);
+  if (!sessionEvent) {
+    return [];
+  }
+
+  const event = Object.values(events).find(
+    (event) =>
+      event?.tracking_id_event === sessionEvent.trackingId &&
+      event?.calendar_id === sessionEvent.calendarId,
+  );
+
+  return parseEventParticipantNames(event?.participants_json);
+};
+
+const parseSessionEvent = (
+  eventJson: unknown,
+): { trackingId: string; calendarId: string } | null => {
+  if (typeof eventJson !== "string" || !eventJson) {
+    return null;
+  }
+
+  try {
+    const event = JSON.parse(eventJson);
+    const trackingId = stringValue(event?.tracking_id);
+    const calendarId = stringValue(event?.calendar_id);
+    return trackingId && calendarId ? { trackingId, calendarId } : null;
+  } catch {
+    return null;
+  }
+};
+
+const parseEventParticipantNames = (participantsJson: unknown): string[] => {
+  if (typeof participantsJson !== "string" || !participantsJson) {
+    return [];
+  }
+
+  try {
+    const participants = JSON.parse(participantsJson);
+    if (!Array.isArray(participants)) {
+      return [];
+    }
+
+    return participants.flatMap((participant) => {
+      if (participant?.is_current_user === true) {
+        return [];
+      }
+
+      const name = stringValue(participant?.name);
+      return name ? [name] : [];
+    });
   } catch {
     return [];
   }


### PR DESCRIPTION
Build dynamic transcription hints from session participants, event attendees, dictionary terms, and session metadata with dedupe and caps.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Local Tinybase reads only; behavior is bounded by tests and a 50-hint cap with no auth or network changes.
> 
> **Overview**
> **Session transcription hints** are expanded so STT gets names and terms in a fixed priority order instead of only dictionary plus note-derived keywords.
> 
> `useKeywords` and `getSessionKeywords` now pull **mapped session participants** (`mapping_session_participant` → `humans`, skipping `source: "excluded"`) and **attendees from the attached calendar event** (match `event_json` `tracking_id` / `calendar_id` to `events`, parse `participants_json`, omit `is_current_user`). Those lists are merged ahead of personalization dictionary terms and markdown/hashtag extraction in `buildKeywords`, then **normalized and capped at 50** (`MAX_TRANSCRIPTION_HINTS`).
> 
> `KeywordStore` gains optional `forEachRow` for the non-React store path; `getSessionTranscriptionHints` is the shared implementation. Tests cover ordering, cross-session exclusion, dedupe of case variants, and the cap.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 76a99acce4c18e06f6700b2013fdfea6ed0dfcf1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->