### PR TITLE
Add 1.1.7 desktop changelog

### DIFF
--- a/packages/changelog/content/1.1.7.md
+++ b/packages/changelog/content/1.1.7.md
@@ -1,0 +1,23 @@
+---
+date: "2026-07-05"
+summary: "Anarlog improves transcription hints, keeps live deletion safer, and cleans up personalization details."
+---
+
+## Transcription
+
+- Transcription hints now include people attached to the current note and attendees from linked calendar events
+- Session-specific terms now combine participant names, event details, note metadata, and your personalization dictionary more consistently
+- People who were excluded from a note are no longer included in transcription hints
+
+## Live Notes
+
+- Deleting the note that is actively recording now stops live capture before removing the note
+
+## Settings
+
+- Personalization dictionary inputs now keep a lighter border and cleaner focus styling
+- Empty personalization dictionaries now start without example terms in the input
+
+## Changelog
+
+- Changelog entries now use spacing that better matches the note editor


### PR DESCRIPTION
## Summary\n- Add the 1.1.7 desktop changelog entry for the next stable patch release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds the **1.1.7** desktop changelog at `packages/changelog/content/1.1.7.md` (dated 2026-07-05) documenting the upcoming stable patch.
> 
> The entry covers **transcription** (richer hints from note people and calendar attendees, better session-term merging, excluding removed people), **live notes** (stop recording before deleting the active note), **settings** (personalization dictionary UI tweaks and empty-state behavior), and **changelog** layout spacing aligned with the note editor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a36f3d71309ac58f21684c82224575b4decbcb4c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->