### PR TITLE
Keep sidebar update control fixed

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -43,6 +43,10 @@ const mocks = vi.hoisted(() => ({
     devtoolsPanelHide: vi.fn(async () => ({ status: "ok" as const })),
     devtoolsPanelShow: vi.fn(async () => ({ status: "ok" as const })),
   },
+  updateControl: {
+    status: null as null | "available" | "downloading" | "ready" | "failed",
+    version: null as string | null,
+  },
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -178,10 +182,17 @@ vi.mock("~/store/zustand/tabs", () => ({
 }));
 
 vi.mock("./shell-sidebar", () => ({
-  ClassicMainSidebar: ({ forceMount = false }: { forceMount?: boolean }) =>
+  ClassicMainSidebar: ({
+    forceMount = false,
+    timelineHeader,
+  }: {
+    forceMount?: boolean;
+    timelineHeader?: React.ReactNode;
+  }) =>
     (forceMount || mocks.leftsidebar.expanded) &&
     mocks.currentTab?.type !== "onboarding" ? (
       <aside data-testid="classic-main-sidebar">
+        {timelineHeader}
         <div data-sidebar-timeline-scroll />
       </aside>
     ) : null,
@@ -196,7 +207,7 @@ vi.mock("./tab-content", () => ({
 
 vi.mock("./update-banner", () => ({
   SidebarTimelineUpdateButton: () => <button type="button">Update</button>,
-  useDesktopUpdateControl: () => ({ status: null, version: null }),
+  useDesktopUpdateControl: () => mocks.updateControl,
 }));
 
 vi.mock("./useShortcuts", () => ({
@@ -261,6 +272,8 @@ describe("ClassicMainBody", () => {
     mocks.devtoolsPanelActionListeners = [];
     mocks.windowsCommands.devtoolsPanelHide.mockClear();
     mocks.windowsCommands.devtoolsPanelShow.mockClear();
+    mocks.updateControl.status = null;
+    mocks.updateControl.version = null;
     vi.mocked(commands.showDevtool).mockClear();
     vi.mocked(commands.showDevtool).mockResolvedValue(true);
   });
@@ -275,6 +288,7 @@ describe("ClassicMainBody", () => {
     expect(screen.getByTestId("panel-group").dataset.autoSaveId).toBe(
       "classic-main-sidebar",
     );
+    expect(screen.getByTestId("panel-group").previousElementSibling).toBeNull();
     expect(screen.getByTestId("classic-main-sidebar")).toBeTruthy();
     expect(screen.getByTestId("resize-handle").dataset.className).toContain(
       "after:w-2",
@@ -305,13 +319,16 @@ describe("ClassicMainBody", () => {
     const sidebarChrome = document.querySelector<HTMLElement>(
       "[data-left-sidebar-chrome]",
     );
+    const sidebarTimelineHeader = document.querySelector<HTMLElement>(
+      "[data-sidebar-timeline-header]",
+    );
 
     expect(sidebarContent?.className).toContain("translate-x-0");
     expect(sidebarContent?.getAttribute("aria-hidden")).toBe("false");
-    expect(sidebarChrome?.style.width).toBe("var(--left-sidebar-panel-width)");
-    expect(sidebarChrome?.style.minWidth).toBe("200px");
-    expect(sidebarChrome?.style.maxWidth).toBe("360px");
-    expect(sidebarChrome?.className).not.toContain("w-[200px]");
+    expect(sidebarChrome).toBeNull();
+    expect(sidebarTimelineHeader).toBeTruthy();
+    expect(sidebarTimelineHeader?.className).toContain("h-12");
+    expect(sidebarTimelineHeader?.className).not.toContain("absolute");
 
     const bodyRoot = screen.getByTestId("panel-group").parentElement;
     expect(bodyRoot?.getAttribute("style")).toContain(
@@ -557,6 +574,18 @@ describe("ClassicMainBody", () => {
     );
   });
 
+  it("keeps the update button in the fixed sidebar control group", () => {
+    mocks.updateControl.status = "available";
+    mocks.updateControl.version = "1.0.34";
+
+    render(<ClassicMainBody />);
+
+    const searchButton = screen.getByRole("button", { name: "Search" });
+    const updateButton = screen.getByRole("button", { name: "Update" });
+
+    expect(updateButton.parentElement).toBe(searchButton.parentElement);
+  });
+
   it("keeps near-equal sidebar size commits in sync with drag-time CSS variables", () => {
     render(<ClassicMainBody />);
 
@@ -789,31 +818,41 @@ describe("ClassicMainBody", () => {
     expect(mocks.devtoolsPanelActionListeners).toHaveLength(0);
   });
 
-  it("routes wheel gestures from sidebar chrome into the timeline scroller", () => {
+  it("renders expanded sidebar controls in the sidebar layout", () => {
     render(<ClassicMainBody />);
 
     const sidebarChrome = document.querySelector<HTMLElement>(
       "[data-left-sidebar-chrome]",
     );
-    const timelineScroller = document.querySelector<HTMLElement>(
+    const timelineHeader = document.querySelector<HTMLElement>(
+      "[data-sidebar-timeline-header]",
+    );
+    const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
+    const searchButton = screen.getByRole("button", { name: "Search" });
+
+    expect(sidebarChrome).toBeNull();
+    expect(timelineHeader).toBeInstanceOf(HTMLElement);
+    expect(timelineHeader?.parentElement?.dataset.testid).toBe(
+      "classic-main-sidebar",
+    );
+    expect(searchButton.parentElement).toBe(sidebarToggle.parentElement);
+
+    const scroller = document.querySelector<HTMLElement>(
       "[data-sidebar-timeline-scroll]",
     );
-
-    expect(sidebarChrome).toBeInstanceOf(HTMLElement);
-    expect(timelineScroller).toBeInstanceOf(HTMLElement);
-
-    Object.defineProperty(timelineScroller, "clientHeight", {
+    expect(scroller).toBeInstanceOf(HTMLElement);
+    Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
       value: 200,
     });
-    Object.defineProperty(timelineScroller, "scrollHeight", {
+    Object.defineProperty(scroller, "scrollHeight", {
       configurable: true,
       value: 1200,
     });
 
-    fireEvent.wheel(sidebarChrome!, { deltaY: 96 });
+    fireEvent.wheel(timelineHeader!, { deltaY: 80 });
 
-    expect(timelineScroller!.scrollTop).toBe(96);
+    expect(scroller?.scrollTop).toBe(80);
   });
 
   it("does not reserve a sidebar panel during onboarding", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -12,7 +12,7 @@ import {
   type CSSProperties,
   type MouseEvent,
   type PointerEvent,
-  type WheelEvent,
+  type WheelEvent as ReactWheelEvent,
   useCallback,
   useMemo,
   useRef,
@@ -156,6 +156,8 @@ export function ClassicMainBody() {
   const showSidebarTimelineChrome = !hasCustomSidebar && !isOnboarding;
   const canResizeLeftSidebarPanel = showSidebarTimelineChrome;
   const showSidebarTimeline = showSidebarTimelineChrome && leftsidebar.expanded;
+  const showCollapsedSidebarTimelineChrome =
+    showSidebarTimelineChrome && !leftsidebar.expanded;
   const mountLeftSidebarPanel = !isOnboarding;
   const showLeftSidebarPanel = mountLeftSidebarPanel && leftsidebar.expanded;
   const showLeftSurfaceChromeBack = hasLeftSurfaceCustomSidebar;
@@ -319,6 +321,16 @@ export function ClassicMainBody() {
     leftsidebar.toggleExpanded,
     restoreLeftSidebarPanelSize,
   ]);
+  const handleSidebarTimelineHeaderWheel = useCallback(
+    (event: ReactWheelEvent<HTMLDivElement>) => {
+      const scroller = event.currentTarget
+        .closest("[data-left-sidebar-panel-content]")
+        ?.querySelector<HTMLElement>("[data-sidebar-timeline-scroll]");
+
+      scrollElementByWheel(scroller ?? null, event);
+    },
+    [],
+  );
   const syncDefaultLeftSidebarPanelSize = useCallback(() => {
     if (!mountLeftSidebarPanel || leftSidebarResizeDraggingRef.current) {
       return;
@@ -416,21 +428,6 @@ export function ClassicMainBody() {
       resizeObserver?.disconnect();
     };
   });
-  const handleLeftSidebarChromeWheel = useCallback(
-    (event: WheelEvent<HTMLDivElement>) => {
-      if (!showSidebarTimeline) {
-        return;
-      }
-
-      const timelineScroller =
-        event.currentTarget.parentElement?.querySelector<HTMLElement>(
-          "[data-sidebar-timeline-scroll]",
-        ) ?? null;
-
-      scrollElementByWheel(timelineScroller, event);
-    },
-    [showSidebarTimeline],
-  );
   const leftSidebarChromeStyle = useMemo(
     () =>
       ({
@@ -504,6 +501,26 @@ export function ClassicMainBody() {
     "--left-sidebar-panel-size": `${renderedLeftSidebarPanelSize}`,
     "--left-sidebar-panel-width": `${renderedLeftSidebarPanelSize}%`,
   } as LeftSidebarSizeStyle;
+  const timelineHeader = showSidebarTimeline ? (
+    <div
+      data-tauri-drag-region
+      data-sidebar-timeline-header
+      className="flex h-12 shrink-0 items-start pt-[9px] pr-1 pl-[76px]"
+      onWheelCapture={handleSidebarTimelineHeaderWheel}
+    >
+      <SidebarTimelineChrome
+        sidebarExpanded
+        showDevtoolsPanelButton={showDevtoolsPanelButton}
+        devtoolsPanelOpen={devtoolsPanelOpen}
+        onNewNote={createNewNote}
+        onSearch={handleOpenNoteDialog}
+        onOpenDevtools={handleOpenDevtoolsPanel}
+        onToggleSidebar={handleToggleLeftSidebar}
+        hasUpcomingMeeting={hasUpcomingMeetingBadge}
+        update={update}
+      />
+    </div>
+  ) : null;
 
   return (
     <div
@@ -511,16 +528,15 @@ export function ClassicMainBody() {
       style={leftSidebarSizeStyle}
       className="relative flex h-full min-w-0 flex-1 flex-col"
     >
-      {isOnboarding ? null : showSidebarTimelineChrome ? (
+      {isOnboarding ||
+      showSidebarTimeline ? null : showCollapsedSidebarTimelineChrome ? (
         <div
           data-tauri-drag-region
           data-left-sidebar-chrome
           style={leftSidebarChromeStyle}
-          onWheel={handleLeftSidebarChromeWheel}
           className={cn([
             "absolute top-0 z-40 h-12",
-            leftsidebar.expanded ? "left-0" : "left-1",
-            !leftsidebar.expanded && "pointer-events-none",
+            "pointer-events-none left-1",
           ])}
         >
           <div
@@ -528,7 +544,7 @@ export function ClassicMainBody() {
             className="flex h-full min-w-0 items-start pt-[9px] pr-1 pl-[76px]"
           >
             <SidebarTimelineChrome
-              sidebarExpanded={leftsidebar.expanded}
+              sidebarExpanded={false}
               showDevtoolsPanelButton={showDevtoolsPanelButton}
               devtoolsPanelOpen={devtoolsPanelOpen}
               onNewNote={createNewNote}
@@ -616,6 +632,7 @@ export function ClassicMainBody() {
                 ])}
               >
                 <ClassicMainSidebar
+                  timelineHeader={timelineHeader}
                   showIgnoredTimelineEvents={showIgnoredTimelineEvents}
                   onShowIgnoredTimelineEventsChange={
                     setShowIgnoredTimelineEvents
@@ -911,10 +928,7 @@ function SidebarTimelineChrome({
     : null;
 
   return (
-    <div
-      data-tauri-drag-region
-      className="flex w-full items-center justify-between"
-    >
+    <div data-tauri-drag-region className="flex w-full items-center">
       <div data-tauri-drag-region className="flex items-center gap-0">
         <LeftSurfaceChromeButton
           ariaLabel={sidebarExpanded ? "Hide sidebar" : "Show sidebar"}
@@ -943,12 +957,12 @@ function SidebarTimelineChrome({
                 <WrenchIcon size={15} />
               </LeftSurfaceChromeButton>
             ) : null}
+            {showUpdateButton ? (
+              <SidebarTimelineUpdateButton update={update} />
+            ) : null}
           </>
         ) : null}
       </div>
-      {showUpdateButton ? (
-        <SidebarTimelineUpdateButton update={update} />
-      ) : null}
     </div>
   );
 }

--- a/apps/desktop/src/main/shell-sidebar.tsx
+++ b/apps/desktop/src/main/shell-sidebar.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from "react";
+
 import { useShell } from "~/contexts/shell";
 import { LeftSidebar } from "~/sidebar";
 import {
@@ -8,10 +10,12 @@ import { useTabs } from "~/store/zustand/tabs";
 
 export function ClassicMainSidebar({
   forceMount = false,
+  timelineHeader,
   showIgnoredTimelineEvents,
   onShowIgnoredTimelineEventsChange,
 }: {
   forceMount?: boolean;
+  timelineHeader?: ReactNode;
   showIgnoredTimelineEvents?: boolean;
   onShowIgnoredTimelineEventsChange?: (showIgnored: boolean) => void;
 } = {}) {
@@ -29,6 +33,7 @@ export function ClassicMainSidebar({
 
   return (
     <LeftSidebar
+      timelineHeader={timelineHeader}
       showIgnoredTimelineEvents={showIgnoredTimelineEvents}
       onShowIgnoredTimelineEventsChange={onShowIgnoredTimelineEventsChange}
     />

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -119,7 +119,16 @@ vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
 }));
 
 vi.mock("~/main/shell-sidebar", () => ({
-  ClassicMainSidebar: () => <div data-testid="main-sidebar" />,
+  ClassicMainSidebar: ({
+    timelineHeader,
+  }: {
+    timelineHeader?: React.ReactNode;
+  }) => (
+    <div data-testid="main-sidebar">
+      {timelineHeader}
+      <div data-sidebar-timeline-scroll />
+    </div>
+  ),
 }));
 
 vi.mock("~/contexts/shell", () => ({
@@ -208,7 +217,9 @@ describe("ClassicMainBody", () => {
     const newNoteButton = screen.getByRole("button", { name: "New note" });
     const chrome = sidebarToggle.parentElement?.parentElement;
     const chromeFrame = chrome?.parentElement;
-    const topArea = chrome?.parentElement?.parentElement;
+    const timelineHeader = document.querySelector<HTMLElement>(
+      "[data-sidebar-timeline-header]",
+    );
 
     fireEvent.click(searchButton);
     fireEvent.click(newNoteButton);
@@ -224,13 +235,13 @@ describe("ClassicMainBody", () => {
     expect(sidebarToggle.parentElement?.className.split(" ")).not.toContain(
       "gap-0.5",
     );
-    expect(chrome?.className).toContain("justify-between");
+    expect(chrome?.className).toContain("items-center");
     expect(chrome?.className).toContain("w-full");
+    expect(chromeFrame).toBe(timelineHeader);
     expect(chromeFrame?.className).toContain("pr-1");
     expect(chromeFrame?.className).not.toContain("pr-3");
-    expect(topArea?.className).toContain("h-12");
-    expect(topArea?.className).toContain("absolute");
-    expect(topArea?.className).toContain("left-0");
+    expect(timelineHeader?.className).toContain("h-12");
+    expect(timelineHeader?.className).not.toContain("absolute");
     expect(chrome?.hasAttribute("data-tauri-drag-region")).toBe(true);
     expect(
       sidebarToggle.parentElement?.hasAttribute("data-tauri-drag-region"),
@@ -295,7 +306,7 @@ describe("ClassicMainBody", () => {
     expect(mocks.toggleLeftSidebar).toHaveBeenCalledTimes(1);
   });
 
-  it("shows the update button at the far edge of the expanded sidebar chrome row", () => {
+  it("shows the update button in the expanded sidebar control group", () => {
     mocks.sidebarUpdateControl.status = "available";
     mocks.sidebarUpdateControl.version = "1.0.34";
 
@@ -307,16 +318,22 @@ describe("ClassicMainBody", () => {
     const updateButton = screen.getByTestId("sidebar-update-button");
     const chrome = sidebarToggle.parentElement?.parentElement;
     const chromeFrame = chrome?.parentElement;
+    const timelineHeader = document.querySelector<HTMLElement>(
+      "[data-sidebar-timeline-header]",
+    );
 
     expect(updateButton).toBeTruthy();
-    expect(updateButton.parentElement).toBe(chrome);
-    expect(updateButton.parentElement).not.toBe(sidebarToggle.parentElement);
+    expect(updateButton.parentElement).toBe(sidebarToggle.parentElement);
     expect(searchButton.compareDocumentPosition(newNoteButton)).toBe(
+      Node.DOCUMENT_POSITION_FOLLOWING,
+    );
+    expect(newNoteButton.compareDocumentPosition(updateButton)).toBe(
       Node.DOCUMENT_POSITION_FOLLOWING,
     );
     expect(searchButton.parentElement).toBe(sidebarToggle.parentElement);
     expect(newNoteButton.parentElement).toBe(sidebarToggle.parentElement);
-    expect(chrome?.className).toContain("justify-between");
+    expect(chrome?.className).toContain("items-center");
+    expect(chromeFrame).toBe(timelineHeader);
     expect(chromeFrame?.className).toContain("pr-1");
     expect(chromeFrame?.className).not.toContain("pr-3");
     expect(
@@ -324,7 +341,7 @@ describe("ClassicMainBody", () => {
     ).toBeNull();
   });
 
-  it("shows ready updates at the far edge of the expanded sidebar chrome row", () => {
+  it("shows ready updates in the expanded sidebar control group", () => {
     mocks.sidebarUpdateControl.status = "ready";
     mocks.sidebarUpdateControl.version = "1.0.34";
 
@@ -332,11 +349,9 @@ describe("ClassicMainBody", () => {
 
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
     const updateButton = screen.getByTestId("sidebar-update-button");
-    const chrome = sidebarToggle.parentElement?.parentElement;
 
     expect(updateButton).toBeTruthy();
-    expect(updateButton.parentElement).toBe(chrome);
-    expect(updateButton.parentElement).not.toBe(sidebarToggle.parentElement);
+    expect(updateButton.parentElement).toBe(sidebarToggle.parentElement);
   });
 
   it("shows an update badge on the collapsed sidebar toggle", () => {
@@ -427,7 +442,7 @@ describe("ClassicMainBody", () => {
 
     const sidebarToggle = screen.getByRole("button", { name: "Hide sidebar" });
     const chrome = sidebarToggle.parentElement?.parentElement;
-    const topArea = chrome?.parentElement?.parentElement;
+    const timelineHeader = chrome?.parentElement;
 
     expect(screen.queryByTestId("timeline-update-banner")).toBeNull();
     expect(screen.queryByRole("button", { name: "Go back" })).toBeNull();
@@ -437,8 +452,8 @@ describe("ClassicMainBody", () => {
     expect(sidebarToggle.parentElement?.className.split(" ")).not.toContain(
       "gap-0.5",
     );
-    expect(topArea?.className).toContain("h-12");
-    expect(topArea?.className).toContain("absolute");
+    expect(timelineHeader?.className).toContain("h-12");
+    expect(timelineHeader?.className).not.toContain("absolute");
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "changelog",
     );

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -1,5 +1,5 @@
-import { render, screen } from "@testing-library/react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   currentTab: { type: "empty" } as { type: string } | null,
@@ -54,6 +54,10 @@ describe("LeftSidebar", () => {
     mocks.currentTab = { type: "empty" };
   });
 
+  afterEach(() => {
+    cleanup();
+  });
+
   it("uses the timeline layout without a duplicate sidebar top offset", () => {
     const { container } = render(<LeftSidebar />);
 
@@ -68,6 +72,21 @@ describe("LeftSidebar", () => {
     ).toBe("true");
     expect(container.firstElementChild?.className).toContain("pt-0");
     expect(container.firstElementChild?.className).not.toContain("pr-1");
+  });
+
+  it("renders timeline header as normal sidebar content", () => {
+    render(
+      <LeftSidebar timelineHeader={<div data-testid="timeline-header" />} />,
+    );
+
+    expect(
+      screen
+        .getByTestId("timeline-header")
+        .parentElement?.contains(screen.getByTestId("timeline-view")),
+    ).toBe(true);
+    expect(
+      screen.getByTestId("timeline-view").getAttribute("data-top-chrome-inset"),
+    ).toBe("false");
   });
 
   it.each([

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -1,3 +1,5 @@
+import { type ReactNode } from "react";
+
 import { cn } from "@hypr/utils";
 
 import { CalendarNav } from "./calendar";
@@ -9,9 +11,11 @@ import { TimelineView } from "./timeline";
 import { useTabs } from "~/store/zustand/tabs";
 
 export function LeftSidebar({
+  timelineHeader,
   showIgnoredTimelineEvents,
   onShowIgnoredTimelineEventsChange,
 }: {
+  timelineHeader?: ReactNode;
   showIgnoredTimelineEvents?: boolean;
   onShowIgnoredTimelineEventsChange?: (showIgnored: boolean) => void;
 } = {}) {
@@ -34,6 +38,7 @@ export function LeftSidebar({
       ])}
     >
       <div className="flex flex-1 flex-col gap-1 overflow-hidden">
+        {isTimelineSidebarLayout ? timelineHeader : null}
         <div className="relative min-h-0 flex-1 overflow-hidden">
           {isSettingsMode ? (
             <SettingsNav />
@@ -47,7 +52,7 @@ export function LeftSidebar({
             <TimelineView
               showIgnoredEvents={showIgnoredTimelineEvents}
               onShowIgnoredEventsChange={onShowIgnoredTimelineEventsChange}
-              topChromeInset={isTimelineSidebarLayout}
+              topChromeInset={isTimelineSidebarLayout && !timelineHeader}
             />
           )}
         </div>


### PR DESCRIPTION
Move the update button into the sidebar control cluster and cover the placement with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop sidebar layout and interaction tests only; no auth, data, or backend changes.
> 
> **Overview**
> Moves **expanded** timeline sidebar controls (toggle, search, new note, devtools, update) out of the absolute `data-left-sidebar-chrome` overlay and into the resizable sidebar via a `timelineHeader` slot on `ClassicMainSidebar` / `LeftSidebar` (`data-sidebar-timeline-header`).
> 
> The desktop update action now sits in the same button group as the other sidebar controls instead of on the far end of the chrome row. Collapsed sidebar still uses the floating chrome overlay; wheel-to-scroll on the timeline is wired on the new header (`onWheelCapture`) rather than the old overlay.
> 
> `TimelineView` only uses `topChromeInset` when there is no injected header, so the timeline does not double-reserve top space. Tests were updated for the new DOM and to lock update-button placement.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 240874c0c685e6079ea509ab79415c4af6515a29. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->