### PR TITLE
Fix overflow menu separators

### DIFF
--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -172,6 +172,30 @@ describe("OverflowButton", () => {
     ).toBeNull();
   });
 
+  it("renders one separator when no meeting actions are visible", () => {
+    const { container } = render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(container.querySelectorAll("hr")).toHaveLength(1);
+  });
+
+  it("separates visible meeting actions from the static actions", () => {
+    useHasTranscriptMock.mockReturnValue(false);
+
+    const { container } = render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    expect(container.querySelectorAll("hr")).toHaveLength(2);
+  });
+
   it("keeps the overflow trigger out of the header drag region", () => {
     const { container } = render(
       <OverflowButton

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -64,10 +64,14 @@ export function OverflowButton({
   const settings = settingsStore.UI.useStore(settingsStore.STORE_ID);
   const isMeetingInProgress =
     sessionMode === "active" || sessionMode === "finalizing";
+  const showListeningAction =
+    allowListening && (!hasTranscript || isMeetingInProgress);
   const showUploadActions =
     !hasTranscript && !currentNoteHasContent && !isMeetingInProgress;
   const canOpenFloatingPanel =
     allowListening && floatingBarEnabled && sessionMode === "active";
+  const hasMeetingActions =
+    showListeningAction || showUploadActions || canOpenFloatingPanel;
   const openExportModal = () => {
     setOpen(false);
     requestAnimationFrame(() => setIsExportModalOpen(true));
@@ -119,7 +123,7 @@ export function OverflowButton({
               </span>
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            {allowListening && (
+            {showListeningAction && (
               <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
             )}
             {showUploadActions && (
@@ -155,7 +159,7 @@ export function OverflowButton({
                 </span>
               </DropdownMenuItem>
             )}
-            <DropdownMenuSeparator />
+            {hasMeetingActions && <DropdownMenuSeparator />}
             {!standaloneWindow && (
               <DropdownMenuItem
                 onClick={handleOpenStandaloneWindow}


### PR DESCRIPTION
Only render the second overflow menu separator when meeting actions are visible. Adds tests for grouped and ungrouped menu states.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only overflow menu layout and visibility tweaks with unit test coverage; no auth or data paths.
> 
> **Overview**
> Fixes the session **overflow menu** showing an extra divider when listening, upload, and floating-panel items are all hidden.
> 
> **Listening** now uses `showListeningAction` (listening allowed and either no transcript or a meeting in progress) instead of only `allowListening`. A **`hasMeetingActions`** flag gates the separator before window/finder/delete items so it appears only when at least one of those meeting actions is shown.
> 
> Tests assert **one** `hr` when meeting actions are absent (default transcript case) and **two** when upload actions are visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10990c6f7bfbd88d75f4ffbb034a6c500d977fc8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->