### PR TITLE
Preserve IME composition in note editor

### DIFF
--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "vitest";
+
+import type { JSONContent } from "./index";
+import { shouldReplaceEditorContent } from "./index";
+
+const baseDoc: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "old" }] }],
+};
+
+const nextDoc: JSONContent = {
+  type: "doc",
+  content: [{ type: "paragraph", content: [{ type: "text", text: "new" }] }],
+};
+
+describe("shouldReplaceEditorContent", () => {
+  it("does not replace content while IME composition is active", () => {
+    expect(
+      shouldReplaceEditorContent({
+        currentContent: baseDoc,
+        nextContent: nextDoc,
+        hasFocus: true,
+        isComposing: true,
+        syncContentWhenFocused: true,
+      }),
+    ).toBe(false);
+  });
+
+  it("allows focused content sync after composition ends when enabled", () => {
+    expect(
+      shouldReplaceEditorContent({
+        currentContent: baseDoc,
+        nextContent: nextDoc,
+        hasFocus: true,
+        isComposing: false,
+        syncContentWhenFocused: true,
+      }),
+    ).toBe(true);
+  });
+});

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -189,6 +189,34 @@ function isSameContent(
   return JSON.stringify(left) === JSON.stringify(right);
 }
 
+export function shouldReplaceEditorContent({
+  currentContent,
+  nextContent,
+  hasFocus,
+  isComposing,
+  syncContentWhenFocused,
+}: {
+  currentContent: JSONContent;
+  nextContent: JSONContent;
+  hasFocus: boolean;
+  isComposing: boolean;
+  syncContentWhenFocused: boolean;
+}) {
+  if (isSameContent(currentContent, nextContent)) {
+    return false;
+  }
+
+  if (isComposing) {
+    return false;
+  }
+
+  if (hasFocus && !syncContentWhenFocused) {
+    return false;
+  }
+
+  return true;
+}
+
 function wrapNodeViewComponents(nodeViews?: NodeViewComponents) {
   if (!nodeViews) {
     return {};
@@ -636,8 +664,15 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         return;
       }
 
-      if (view.hasFocus() && !syncContentWhenFocused) {
-        previousContentRef.current = reconciledInitialContent;
+      if (
+        !shouldReplaceEditorContent({
+          currentContent,
+          nextContent: reconciledInitialContent,
+          hasFocus: view.hasFocus(),
+          isComposing: view.composing,
+          syncContentWhenFocused,
+        })
+      ) {
         return;
       }
 


### PR DESCRIPTION
Adds a composition guard before replacing editor content and covers it with a focused regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized change to when external content overwrites the editor, with unit tests and no auth or data-path impact.
> 
> **Overview**
> Prevents the note editor from **replacing document content from `initialContent` while IME composition is active**, which could interrupt CJK input when external updates arrive during typing.
> 
> The sync effect now delegates the replace decision to a new exported **`shouldReplaceEditorContent`** helper that centralizes unchanged-content, **composition**, and focused-sync rules; it passes **`view.composing`** from ProseMirror. When a replace is skipped, the effect returns without advancing **`previousContentRef`** (the old focus-only path had been updating that ref).
> 
> **Vitest** coverage asserts composition blocks replace and that focused sync still runs after composition ends when **`syncContentWhenFocused`** is enabled.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e74cbc48c771fff320e2da5f3b79524e826e925a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->