### PR TITLE
Update desktop release changelog

### DIFF
--- a/packages/changelog/content/1.1.8.md
+++ b/packages/changelog/content/1.1.8.md
@@ -1,0 +1,23 @@
+---
+date: "2026-07-06"
+summary: "Anarlog keeps sidebar controls steadier, improves transcript finalizing feedback, and preserves IME typing."
+---
+
+## Notes
+
+- Typing with CJK and other IME keyboards now stays uninterrupted while note content syncs in the background
+- Note tabs are simpler now that the older Insights tab has been removed
+
+## Transcripts
+
+- Transcript views now show a finalizing indicator while the recording is being wrapped up
+- The transcript tab stays available during finalizing so you can keep context while Anarlog finishes processing
+
+## Sidebar
+
+- The desktop update control now stays grouped with the sidebar controls instead of drifting into the note area
+- Expanded sidebar controls keep the timeline aligned at the top and continue to scroll naturally under the pointer
+
+## Menus
+
+- Note overflow menus no longer show an extra divider when meeting actions are hidden


### PR DESCRIPTION
Refresh the desktop changelog for the 1.1.8 stable release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.8.md`** for the stable **1.1.8** desktop release (dated 2026-07-06), with frontmatter summary and user-facing notes grouped by area.
> 
> **Notes:** IME/CJK typing stays uninterrupted during background note sync; Insights tab removed for simpler note tabs.
> 
> **Transcripts:** Finalizing indicator while wrap-up runs; transcript tab remains available during finalizing.
> 
> **Sidebar:** Update control stays with sidebar controls; expanded sidebar keeps timeline top-aligned and scrolls under the pointer.
> 
> **Menus:** Extra divider removed from note overflow when meeting actions are hidden.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a005a0933025eee014b9e253fe0a9ff49210b048. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->