### PR TITLE
Preserve CJK IME typing

### DIFF
--- a/apps/desktop/src/session/components/title-input.test.tsx
+++ b/apps/desktop/src/session/components/title-input.test.tsx
@@ -8,6 +8,7 @@ import { TitleInput } from "./title-input";
 
 const hoisted = vi.hoisted(() => ({
   clearLiveTitle: vi.fn(),
+  setStoreTitle: vi.fn(),
   setLiveTitle: vi.fn(),
   storeTitle: "Untitled" as string | undefined,
   store: {
@@ -27,7 +28,7 @@ vi.mock("~/store/tinybase/store/main", () => ({
   STORE_ID: "main",
   UI: {
     useCell: () => hoisted.storeTitle,
-    useSetPartialRowCallback: () => vi.fn(),
+    useSetPartialRowCallback: () => hoisted.setStoreTitle,
     useStore: () => hoisted.store,
   },
 }));
@@ -83,6 +84,28 @@ describe("TitleInput", () => {
     });
 
     expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+  });
+
+  it("does not handle IME confirmation keys as title navigation", () => {
+    const onTransferContentToEditor = vi.fn();
+    const onFocusEditorAtStart = vi.fn();
+    renderTitleInput({
+      onFocusEditorAtStart,
+      onTransferContentToEditor,
+    });
+
+    const input = screen.getByPlaceholderText("Untitled");
+    fireEvent.focus(input);
+    fireEvent.change(input, { target: { value: "안" } });
+    fireEvent.keyDown(input, {
+      key: "Enter",
+      keyCode: 229,
+    });
+
+    expect(hoisted.setStoreTitle).not.toHaveBeenCalled();
+    expect(hoisted.clearLiveTitle).not.toHaveBeenCalled();
+    expect(onTransferContentToEditor).not.toHaveBeenCalled();
+    expect(onFocusEditorAtStart).not.toHaveBeenCalled();
   });
 
   it("left-aligns the empty title field without a generate button", () => {

--- a/apps/desktop/src/session/components/title-input.tsx
+++ b/apps/desktop/src/session/components/title-input.tsx
@@ -309,6 +309,10 @@ const TitleInputInner = memo(
       );
 
       const handleKeyDown = (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (isComposingKeyEvent(e)) {
+          return;
+        }
+
         if (e.key === "ArrowUp") {
           e.preventDefault();
           return;
@@ -446,6 +450,14 @@ const TitleInputInner = memo(
     },
   ),
 );
+
+function isComposingKeyEvent(event: React.KeyboardEvent<HTMLInputElement>) {
+  return (
+    event.nativeEvent.isComposing ||
+    event.key === "Process" ||
+    event.keyCode === 229
+  );
+}
 
 function getTitleFadeMask({
   showStartFade,

--- a/packages/editor/src/note/index.test.ts
+++ b/packages/editor/src/note/index.test.ts
@@ -1,7 +1,10 @@
-import { describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import type { JSONContent } from "./index";
-import { shouldReplaceEditorContent } from "./index";
+import {
+  getEditorCompositionWaitMs,
+  shouldReplaceEditorContent,
+} from "./index";
 
 const baseDoc: JSONContent = {
   type: "doc",
@@ -12,6 +15,10 @@ const nextDoc: JSONContent = {
   type: "doc",
   content: [{ type: "paragraph", content: [{ type: "text", text: "new" }] }],
 };
+
+afterEach(() => {
+  vi.useRealTimers();
+});
 
 describe("shouldReplaceEditorContent", () => {
   it("does not replace content while IME composition is active", () => {
@@ -36,5 +43,49 @@ describe("shouldReplaceEditorContent", () => {
         syncContentWhenFocused: true,
       }),
     ).toBe(true);
+  });
+});
+
+describe("getEditorCompositionWaitMs", () => {
+  it("waits through active IME composition", () => {
+    expect(
+      getEditorCompositionWaitMs(
+        { composing: false },
+        { active: true, endedAt: 0 },
+      ),
+    ).toBe(500);
+  });
+
+  it("returns the remaining post-composition grace window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    expect(
+      getEditorCompositionWaitMs(
+        { composing: false },
+        { active: false, endedAt: 600 },
+      ),
+    ).toBe(100);
+  });
+
+  it("returns zero after the post-composition grace window", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(1000);
+
+    expect(
+      getEditorCompositionWaitMs(
+        { composing: false },
+        { active: false, endedAt: 499 },
+      ),
+    ).toBe(0);
+  });
+
+  it("returns zero for a reset inactive composition state", () => {
+    expect(
+      getEditorCompositionWaitMs(
+        { composing: false },
+        { active: false, endedAt: 0 },
+      ),
+    ).toBe(0);
   });
 });

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -182,6 +182,13 @@ const baseNodeViews = {
   }),
 };
 
+const COMPOSITION_SYNC_GRACE_MS = 500;
+
+export type CompositionState = {
+  active: boolean;
+  endedAt: number;
+};
+
 function isSameContent(
   left: JSONContent | undefined,
   right: JSONContent | undefined,
@@ -231,6 +238,44 @@ function wrapNodeViewComponents(nodeViews?: NodeViewComponents) {
       }),
     ]),
   ) as NodeViewComponents;
+}
+
+export function getEditorCompositionWaitMs(
+  view: Pick<EditorView, "composing">,
+  compositionState: CompositionState,
+) {
+  if (view.composing || compositionState.active) {
+    return COMPOSITION_SYNC_GRACE_MS;
+  }
+
+  return Math.max(
+    COMPOSITION_SYNC_GRACE_MS - (Date.now() - compositionState.endedAt),
+    0,
+  );
+}
+
+function createCompositionStatePlugin(
+  setCompositionActive: (active: boolean) => void,
+) {
+  return new Plugin({
+    key: new PluginKey("imeCompositionState"),
+    props: {
+      handleDOMEvents: {
+        compositionstart() {
+          setCompositionActive(true);
+          return false;
+        },
+        compositionupdate() {
+          setCompositionActive(true);
+          return false;
+        },
+        compositionend() {
+          setCompositionActive(false);
+          return false;
+        },
+      },
+    },
+  });
 }
 
 function createSessionMentionDropPlugin(config: SessionMentionDropConfig) {
@@ -531,6 +576,10 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     );
     const viewRef = useRef<EditorView | null>(null);
     const commandsRef = useRef<EditorCommands>(noopCommands);
+    const compositionStateRef = useRef<CompositionState>({
+      active: false,
+      endedAt: 0,
+    });
 
     useImperativeHandle(
       ref,
@@ -580,9 +629,17 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     const onUpdateRef = useRef(onUpdate);
     onUpdateRef.current = onUpdate;
 
+    const setCompositionActive = useCallback((active: boolean) => {
+      compositionStateRef.current = {
+        active,
+        endedAt: active ? 0 : Date.now(),
+      };
+    }, []);
+
     const plugins = useMemo(
       () => [
         reactKeys(),
+        createCompositionStatePlugin(setCompositionActive),
         docChangeListenerPlugin((view) =>
           onUpdateRef.current(view.state.doc.toJSON() as JSONContent),
         ),
@@ -619,6 +676,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         onNavigateToTitle,
         onLinkOpen,
         enforceTitleHeading,
+        setCompositionActive,
       ],
     );
     const nodeViews = useMemo(
@@ -647,50 +705,71 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     }, [reconciledInitialContent, plugins, enforceTitleHeading]);
 
     useEffect(() => {
-      const view = viewRef.current;
-      if (!view) return;
-      if (previousContentRef.current === reconciledInitialContent) return;
+      let retryTimeout: ReturnType<typeof setTimeout> | undefined;
 
-      if (
-        !reconciledInitialContent ||
-        reconciledInitialContent.type !== "doc"
-      ) {
-        return;
-      }
+      const syncContent = () => {
+        const view = viewRef.current;
+        if (!view) return;
+        if (previousContentRef.current === reconciledInitialContent) return;
 
-      const currentContent = view.state.doc.toJSON() as JSONContent;
-      if (isSameContent(currentContent, reconciledInitialContent)) {
-        previousContentRef.current = reconciledInitialContent;
-        return;
-      }
-
-      if (
-        !shouldReplaceEditorContent({
-          currentContent,
-          nextContent: reconciledInitialContent,
-          hasFocus: view.hasFocus(),
-          isComposing: view.composing,
-          syncContentWhenFocused,
-        })
-      ) {
-        return;
-      }
-
-      try {
-        let doc = PMNode.fromJSON(schema, reconciledInitialContent);
-        if (enforceTitleHeading) {
-          doc = normalizeTitleHeadingDoc(doc);
+        if (
+          !reconciledInitialContent ||
+          reconciledInitialContent.type !== "doc"
+        ) {
+          return;
         }
-        const state = EditorState.create({
-          doc,
-          plugins: view.state.plugins,
-        });
-        onUpdate.cancel();
-        view.updateState(state);
-        previousContentRef.current = reconciledInitialContent;
-      } catch {
-        // invalid content
-      }
+
+        const currentContent = view.state.doc.toJSON() as JSONContent;
+        if (isSameContent(currentContent, reconciledInitialContent)) {
+          previousContentRef.current = reconciledInitialContent;
+          return;
+        }
+
+        const compositionWaitMs = getEditorCompositionWaitMs(
+          view,
+          compositionStateRef.current,
+        );
+        if (compositionWaitMs > 0) {
+          retryTimeout = setTimeout(syncContent, compositionWaitMs);
+          return;
+        }
+
+        if (
+          !shouldReplaceEditorContent({
+            currentContent,
+            nextContent: reconciledInitialContent,
+            hasFocus: view.hasFocus(),
+            isComposing: false,
+            syncContentWhenFocused,
+          })
+        ) {
+          return;
+        }
+
+        try {
+          let doc = PMNode.fromJSON(schema, reconciledInitialContent);
+          if (enforceTitleHeading) {
+            doc = normalizeTitleHeadingDoc(doc);
+          }
+          const state = EditorState.create({
+            doc,
+            plugins: view.state.plugins,
+          });
+          onUpdate.cancel();
+          view.updateState(state);
+          previousContentRef.current = reconciledInitialContent;
+        } catch {
+          // invalid content
+        }
+      };
+
+      syncContent();
+
+      return () => {
+        if (retryTimeout) {
+          clearTimeout(retryTimeout);
+        }
+      };
     }, [
       reconciledInitialContent,
       syncContentWhenFocused,
@@ -704,6 +783,17 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
         syncTasks(view.state.doc.toJSON() as JSONContent);
       },
       [onViewReadyProp, syncTasks],
+    );
+
+    const handleViewDisposed = useCallback(
+      (view: EditorView) => {
+        compositionStateRef.current = {
+          active: false,
+          endedAt: 0,
+        };
+        onViewDisposed?.(view);
+      },
+      [onViewDisposed],
     );
 
     return (
@@ -734,7 +824,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
               <ViewCapture
                 viewRef={viewRef}
                 onViewReady={onViewReady}
-                onViewDisposed={onViewDisposed}
+                onViewDisposed={handleViewDisposed}
               />
               <EditorCommandsBridge commandsRef={commandsRef} />
               {showFormatToolbar && <FormatToolbar />}


### PR DESCRIPTION
Skip title navigation while composition is active and protect rich-editor content sync around IME composition.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches focused-session title navigation and ProseMirror content replacement timing; wrong composition detection could delay sync or leave stale content, but scope is narrow and covered by new tests.
> 
> **Overview**
> Fixes **CJK/IME typing** being interrupted when composition keys (e.g. Enter with `keyCode` 229) were treated as title navigation or when external note content sync ran mid-composition.
> 
> **Session title:** `TitleInput` now bails out of `handleKeyDown` during composition (`isComposing`, `Process`, `keyCode` 229), so confirming IME text no longer commits the title or jumps to the editor.
> 
> **Note editor:** Adds composition tracking via a ProseMirror plugin, `getEditorCompositionWaitMs` (500ms active + post-composition grace), and deferred `syncContent` retries so `reconciledInitialContent` updates do not replace the document while IME is active or immediately after it ends. Composition state resets on view dispose. Unit tests cover title IME Enter and the wait-window helper.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39cbe4dea83c24f6faf0fdcc4caeb5703b340c91. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->