### PR TITLE
[codex] Fix blog OG images and media URLs

### DIFF
--- a/apps/web/content/articles/ai-meeting-summary-tools.mdx
+++ b/apps/web/content/articles/ai-meeting-summary-tools.mdx
@@ -4,7 +4,6 @@ display_title: "Best AI Meeting Summary Tools in 2026"
 meta_description: "Find the best AI meeting summary tool for your team. Compare 9 top solutions, including free options, bot-free tools, and enterprise platforms."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/ai-meeting-summary-tools/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-06"

--- a/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
+++ b/apps/web/content/articles/best-ai-meeting-assistant-for-taking-notes.mdx
@@ -2,7 +2,6 @@
 meta_title: "7 Best AI Meeting Assistants for Taking Notes in 2026"
 meta_description: "Discover the best AI meeting assistants for automated note-taking in 2026. Compare privacy, features & pricing to choose the right tool for your needs."
 author: "Harshika"
-coverImage: "/api/assets/blog/best-ai-meeting-assistant-for-taking-notes/cover.png"
 category: "Comparisons"
 date: "2025-08-04"
 ---

--- a/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-in-person-meetings.mdx
@@ -3,7 +3,6 @@ meta_title: "7 Best AI Notetakers for In-person Meetings"
 meta_description: "Compare the top AI notetakers for in-person meetings. Find tools with mobile apps, offline recording, speaker ID, and real-time transcription features"
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/best-ai-notetaker-for-in-person-meetings/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-03"

--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -3,7 +3,6 @@ meta_title: "7 Best AI Notetakers for Microsoft Teams in 2026"
 meta_description: "Looking for the best AI notetaker for Microsoft Teams? Compare the top 7 solutions, including native and third-party options."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/best-ai-notetaker-for-microsoft-teams/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-09"

--- a/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-zoom.mdx
@@ -2,7 +2,6 @@
 meta_title: "Best AI Notetaker for Zoom: Top 10 Options"
 meta_description: "Find the best AI notetaker for Zoom with our 2026 guide. Compare real-time transcription, privacy options, CRM integrations, and pricing plans."
 author: "Harshika"
-coverImage: "/api/assets/blog/best-ai-notetaker-for-zoom/cover.png"
 category: "Comparisons"
 date: "2025-09-06"
 ---

--- a/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
+++ b/apps/web/content/articles/best-ai-notetakers-google-meet.mdx
@@ -2,7 +2,6 @@
 meta_title: "7 Best AI Notetakers for Google Meet in 2026"
 meta_description: "Google's native AI notes falling short? Find the right alternative by comparing the 7 best AI notetakers for Google Meet in 2026. Free & paid options included."
 author: "John Jeong"
-coverImage: "/api/assets/blog/best-ai-notetakers-google-meet/cover.png"
 featured: false
 category: "Comparisons"
 date: "2026-02-11"

--- a/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
+++ b/apps/web/content/articles/bot-free-ai-meeting-assistants.mdx
@@ -2,7 +2,6 @@
 meta_title: "2026's Best Bot-Free AI Meeting Assistants"
 meta_description: "Want AI meeting notes without bots joining your call? Here's a list of the best bot-free AI meeting assistants for secure, distraction-free note-taking."
 author: "John Jeong"
-coverImage: "/api/assets/blog/bot-free-ai-meeting-assistants/cover.png"
 category: "Comparisons"
 date: "2025-08-27"
 ---

--- a/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
+++ b/apps/web/content/articles/can-you-transcribe-meetings-without-sending-data-to-cloud.mdx
@@ -3,7 +3,6 @@ meta_title: "Can You Transcribe Meetings Without Sending Data to the Cloud?"
 meta_description: "Learn how to transcribe meetings without sending data to the cloud. Discover local AI tools like Anarlog that keep conversations on-device and completely private."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/can-you-transcribe-meetings-without-sending-data-to-cloud/cover.png"
 featured: false
 category: "Guides"
 date: "2025-08-22"

--- a/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
+++ b/apps/web/content/articles/enterprise-ai-notetaking-tools.mdx
@@ -4,7 +4,6 @@ display_title: "AI Notetaking Tools for Enterprises: 5 Solutions Compared"
 meta_description: "Compare enterprise AI notetaking solutions on security, compliance, deployment options, and limitations. A practical guide for organizations with strict data policies."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/enterprise-ai-notetaking-tools/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-02"

--- a/apps/web/content/articles/fathom-ai-alternatives.mdx
+++ b/apps/web/content/articles/fathom-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "5 Best Fathom AI Alternatives in 2026"
 meta_description: "Discover the 5 best alternatives to Fathom AI in 2026. Get better conversation insights, stronger security, and truly unlimited note-taking."
 author: "John Jeong"
-coverImage: "/api/assets/blog/fathom-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-10-15"
 ---

--- a/apps/web/content/articles/fireflies-ai-alternatives.mdx
+++ b/apps/web/content/articles/fireflies-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "9 Best Fireflies.ai Alternatives in 2026"
 meta_description: "Complete Fireflies.ai review plus 9 alternative comparisons. Compare AI meeting assistants by features, pricing, privacy, and platform support."
 author: "Harshika"
-coverImage: "/api/assets/blog/fireflies-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-09-23"
 ---

--- a/apps/web/content/articles/free-ai-notetakers.mdx
+++ b/apps/web/content/articles/free-ai-notetakers.mdx
@@ -3,7 +3,6 @@ meta_title: "9 Best Free AI Notetakers with Forever-Free Plans in 2026"
 meta_description: "Review of 9 genuinely free AI meeting assistants that provide transcription, summaries, and note-taking without expiration dates or payment pressure."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/free-ai-notetakers/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-08-07"
@@ -48,7 +47,7 @@ Anyone who wants enterprise-grade AI note-taking without vendor lock-in, cloud d
 
 #### When Will You Need to Pay?
 
-![Anarlog pricing](/api/assets/blog/Screenshot-2026-03-04-at-9.01.49-PM.png)
+![Anarlog pricing](/api/assets/blog/articles/free-ai-notetakers/screenshot-2026-03-04-at-9-01-49-pm.png)
 
 Anarlog is free forever for local transcription, BYOK, and all core features. The managed cloud service ($25/month) adds the easiest setup without managing API keys. Enterprise is relevant when your organization needs on-premises deployment, SSO integration, or custom branding for compliance requirements.
 

--- a/apps/web/content/articles/free-transcription-software.mdx
+++ b/apps/web/content/articles/free-transcription-software.mdx
@@ -4,7 +4,6 @@ display_title: "Best Free Transcription Software in 2026"
 meta_description: "Find truly free transcription solutions in 2026 that offer real usability, privacy, and accuracy for all your speech-to-text needs. No surprises or limits."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/free-transcription-software/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-08"
@@ -98,7 +97,7 @@ Zero lock-in means you can switch AI providers anytime and your files work with 
 
 #### When will you need to pay?
 
-![Anarlog pricing](/api/assets/blog/Screenshot-2026-03-04-at-9.01.49-PM.png)
+![Anarlog pricing](/api/assets/blog/articles/free-transcription-software/screenshot-2026-03-04-at-9-01-49-pm.png)
 
 Free forever for local transcription, BYOK, and all core features. The managed cloud service ($25/month) adds the easiest setup without managing API keys.
 

--- a/apps/web/content/articles/google-gemini-meeting-notes.mdx
+++ b/apps/web/content/articles/google-gemini-meeting-notes.mdx
@@ -3,7 +3,6 @@ meta_title: "I Tested Google Gemini Meeting Notes So You Don't Have To"
 meta_description: "Can Google Gemini take meeting notes? Yes, but only in Google Meet with paid plans. If you use Teams or Zoom, then you'll need workarounds. Know more."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/google-gemini-meeting-notes/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-24"

--- a/apps/web/content/articles/granola-ai-alternatives.mdx
+++ b/apps/web/content/articles/granola-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "6 Best Granola AI Alternatives in 2026"
 meta_description: "Looking for Granola AI alternatives? Compare top meeting assistants with better privacy, platform support, integrations & pricing."
 author: "John Jeong"
-coverImage: "/api/assets/blog/granola-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-08-15"
 ---

--- a/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
+++ b/apps/web/content/articles/how-to-have-productive-one-on-one-meetings.mdx
@@ -3,7 +3,6 @@ meta_title: "How to Run Productive One-on-One Meetings as a Manager"
 display_title: "How to Have Productive One-on-One Meetings: A Guide for Managers"
 meta_description: "Stop wasting time on status updates disguised as 1:1s. Learn how to run one-on-one meetings that actually develop your team without burning you out."
 author: "John Jeong"
-coverImage: "/api/assets/blog/how-to-have-productive-one-on-one-meetings/cover.png"
 category: "Guides"
 date: "2025-11-10"
 ---

--- a/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
+++ b/apps/web/content/articles/how-to-participate-in-meetings-effectively.mdx
@@ -3,7 +3,6 @@ meta_title: "Top 5 Strategies to Participate in Meetings Effectively"
 display_title: "How to Participate in Meetings Effectively?"
 meta_description: "Learn how to contribute meaningfully in meetings without exhausting your brain. Strategies for speaking strategically, building on context, and following through."
 author: "John Jeong"
-coverImage: "/api/assets/blog/how-to-participate-in-meetings-effectively/cover.png"
 featured: false
 category: "Guides"
 date: "2025-11-07"

--- a/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
+++ b/apps/web/content/articles/how-to-reduce-meeting-fatigue.mdx
@@ -2,7 +2,6 @@
 meta_title: "How to Reduce Meeting Fatigue When Meetings Are Your Job"
 meta_description: "Can't cut meetings? Learn how AI note-taking and smart systems reduce meeting fatigue for sales, consulting, and customer-facing roles."
 author: "John Jeong"
-coverImage: "/api/assets/blog/how-to-reduce-meeting-fatigue/cover.png"
 category: "Guides"
 date: "2025-10-31"
 ---

--- a/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
+++ b/apps/web/content/articles/how-to-transcribe-zoom-calls.mdx
@@ -2,7 +2,6 @@
 meta_title: "How to Transcribe Zoom Calls Automatically?"
 meta_description: "Learn how to automatically transcribe Zoom calls using Zoom's built-in feature or powerful third-party AI tools. Step-by-step guide with accuracy comparisons."
 author: "Harshika"
-coverImage: "/api/assets/blog/how-to-transcribe-zoom-calls/cover.png"
 category: "Guides"
 date: "2025-09-16"
 ---

--- a/apps/web/content/articles/is-ai-notetaking-legal.mdx
+++ b/apps/web/content/articles/is-ai-notetaking-legal.mdx
@@ -3,7 +3,6 @@ meta_title: "Is AI note-taking legal? Everything You Need to Know"
 meta_description: "AI note-taking is legal, but selecting the wrong tool or missing compliance requirements can expose you to privacy and compliance risks. Learn more."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/is-ai-notetaking-legal/cover.png"
 featured: false
 category: "Guides"
 date: "2025-08-26"

--- a/apps/web/content/articles/is-fireflies-ai-safe.mdx
+++ b/apps/web/content/articles/is-fireflies-ai-safe.mdx
@@ -3,7 +3,6 @@ meta_title: "Is Fireflies AI Safe? The No BS Truth"
 meta_description: "Thinking about using Fireflies AI? We dug into their data collection practices and found some red flags you should know about."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/is-fireflies-ai-safe/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-23"

--- a/apps/web/content/articles/is-otter-ai-safe.mdx
+++ b/apps/web/content/articles/is-otter-ai-safe.mdx
@@ -2,7 +2,6 @@
 meta_title: "Is Otter AI Safe: What You Need to Know"
 meta_description: "Otter AI faces a class-action lawsuit over privacy violations and secret recordings. Is it safe to use? Discover user complaints, data risks, and alternatives."
 author: "John Jeong"
-coverImage: "/api/assets/blog/is-otter-ai-safe/cover.png"
 category: "Comparisons"
 date: "2025-08-18"
 ---

--- a/apps/web/content/articles/local-ai-meeting-notes.mdx
+++ b/apps/web/content/articles/local-ai-meeting-notes.mdx
@@ -32,7 +32,7 @@ I tested five tools that take different positions on this spectrum. For each one
 
 ### 1. Anarlog
 
-![](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+![](/api/assets/blog/articles/local-ai-meeting-notes/char-summary.png "char-editor-width=80")
 
 [Anarlog](https://anarlog.so) is an open-source AI notepad for meetings, built for people who want complete control over their data and AI stack. It captures system audio from any meeting platform without joining your call and without requiring calendar permissions. 
 
@@ -62,7 +62,7 @@ Free for unlimited loacl transcription and AI. A lite plan at $8/month with Anar
 
 ### 2. Meetily
 
-![meetily review](/api/assets/blog/blog/image-20.png "char-editor-width=80")
+![meetily review](/api/assets/blog/articles/local-ai-meeting-notes/image-20.png "char-editor-width=80")
 
 [Meetily](https://meetily.ai) is an open-source meeting assistant (MIT license) that runs transcription entirely on your device using Whisper or Parakeet models. 
 
@@ -92,7 +92,7 @@ Community Edition is free forever. Pro is at $10/month, billed annually, include
 
 ### 3. Shadow
 
-![shadow.do review](/api/assets/blog/blog/Screenshot-2026-04-10-at-7.43.38-PM.png "char-editor-width=80")
+![shadow.do review](/api/assets/blog/articles/local-ai-meeting-notes/screenshot-2026-04-10-at-7-43-38-pm.png "char-editor-width=80")
 
 [Shadow](https://shadow.do) captures both channels of a meeting: what is said and what is shown on screen. It runs on macOS, records system audio without a bot, and automatically takes timestamped screenshots of whatever is displayed during your call: slides, code, dashboards, design mockups. Those screenshots are embedded directly in your notes alongside the transcript.
 
@@ -120,7 +120,7 @@ Free for unlimited transcription and 25 lifetime meetings for AI features. Plus,
 
 ### 4. Talat
 
-![talat notetaker review](/api/assets/blog/blog/image-25.png "char-editor-width=80")
+![talat notetaker review](/api/assets/blog/articles/local-ai-meeting-notes/image-25.png "char-editor-width=80")
 
 [Talat](https://talat.app) runs transcription and summarization entirely on your Mac's Neural Engine. It captures both sides of your call (system audio and microphone), transcribes in real time with speaker identification, and generates summaries using a local LLM (Qwen3-4B-4bit by default). The whole app is 20 MB. It detects when a conferencing app grabs your microphone and starts recording in the background.
 
@@ -148,7 +148,7 @@ $49 one-time purchase (pre-release price). $99 at version 1.0. 10 hours of free 
 
 ### 5. Screenpipe
 
-![screenpipe review](/api/assets/blog/blog/image-26.png "char-editor-width=80")
+![screenpipe review](/api/assets/blog/articles/local-ai-meeting-notes/image-26.png "char-editor-width=80")
 
 [Screenpipe](https://screenpi.pe) records your screen and audio 24/7, transcribes everything locally with Whisper, and indexes it in a searchable local database. 
 

--- a/apps/web/content/articles/local-ai-privacy-tools.mdx
+++ b/apps/web/content/articles/local-ai-privacy-tools.mdx
@@ -2,7 +2,6 @@
 meta_title: "The Rise of Local AI: How the Next Wave of Privacy Tools Will Be Built"
 meta_description: "From DuckDuckGo to Proton, privacy-first apps have earned user trust. Now, local AI is carrying that vision forward."
 author: "John Jeong"
-coverImage: "/api/assets/blog/local-ai-privacy-tools/cover.png"
 category: "Engineering"
 date: "2025-07-28"
 ---

--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -2,7 +2,6 @@
 meta_title: "Best Meeting Minutes Software in 2026"
 meta_description: "Compare the best meeting minutes software for 2026. We tested AI and manual tools to find the top solutions for note-taking, collaboration, and governance."
 author: "Harshika"
-coverImage: "/api/assets/blog/meeting-minutes-software/cover.png"
 featured: false
 category: "Comparisons"
 date: "2026-01-10"
@@ -30,7 +29,7 @@ If you're worried about missing important details while taking minutes of the me
 
 ### 1. Anarlog - control over your data and AI stack
 
-![Anarlog](/api/assets/blog/blog/char-summary.png)
+![Anarlog](/api/assets/blog/articles/meeting-minutes-software/char-summary.png)
 
 **[Anarlog](https://anarlog.so)** is an open-source AI note-taker that stores your data locally and gives you complete control over the AI stack.
 

--- a/apps/web/content/articles/meeting-preparation-checklist.mdx
+++ b/apps/web/content/articles/meeting-preparation-checklist.mdx
@@ -3,7 +3,6 @@ meta_title: "My Go-to Meeting Preparation Checklist"
 display_title: "Meeting Preparation Checklist: 7 Steps to Run More Productive Meetings"
 meta_description: "Use this meeting preparation checklist to walk into every call with clarity and confidence. Build a repeatable system to have productive meetings."
 author: "John Jeong"
-coverImage: "/api/assets/blog/meeting-preparation-checklist/cover.png"
 featured: false
 category: "Guides"
 date: "2025-11-03"

--- a/apps/web/content/articles/open-source-meeting-transcription-software.mdx
+++ b/apps/web/content/articles/open-source-meeting-transcription-software.mdx
@@ -4,7 +4,6 @@ display_title: "Open Source Alternatives to Otter AI and Fireflies"
 meta_description: "Review of the best open source meeting transcription tools you can fork, self-host, and customize. Compare features, pricing, and deployment options."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/open-source-meeting-transcription-software/cover.png"
 featured: true
 category: "Comparisons"
 date: "2025-10-23"

--- a/apps/web/content/articles/otter-ai-alternatives.mdx
+++ b/apps/web/content/articles/otter-ai-alternatives.mdx
@@ -2,7 +2,6 @@
 meta_title: "14 Best Otter.ai Alternatives & Competitors in 2026"
 meta_description: "Discover 14 Otter AI alternatives that solve privacy, language, and accuracy issues. Compare features and pricing to find your perfect meeting assistant."
 author: "John Jeong"
-coverImage: "/api/assets/blog/otter-ai-alternatives/cover.png"
 category: "Comparisons"
 date: "2025-08-11"
 ---

--- a/apps/web/content/articles/otter-ai-review.mdx
+++ b/apps/web/content/articles/otter-ai-review.mdx
@@ -2,7 +2,6 @@
 meta_title: "Otter AI Review: Is It Worth It in 2026?"
 meta_description: "Complete Otter AI review covering features, pricing, security concerns, and user feedback. Compare alternatives and find the best AI notetaker for your needs."
 author: "Harshika"
-coverImage: "/api/assets/blog/otter-ai-review/cover.png"
 featured: false
 category: "Comparisons"
 ready_for_review: true

--- a/apps/web/content/articles/plaud-ai-alternatives.mdx
+++ b/apps/web/content/articles/plaud-ai-alternatives.mdx
@@ -4,7 +4,6 @@ display_title: "6 Plaud AI Alternatives Worth Considering in 2026"
 meta_description: "Looking beyond Plaud? Compare 6 AI voice recorder alternatives. Hardware, software & specialized AI recorders reviewed."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/plaud-ai-alternatives/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-27"

--- a/apps/web/content/articles/read-ai-alternatives.mdx
+++ b/apps/web/content/articles/read-ai-alternatives.mdx
@@ -34,7 +34,7 @@ The first four are bot-free meeting tools for people whose primary use was trans
 
 ### 1. Anarlog
 
-![Anarlog vs Read AI](/api/assets/blog/Char%20pros%20and%20cons "char-editor-width=80")
+![Anarlog vs Read AI](/api/assets/blog/articles/read-ai-alternatives/char-pros-and-cons.png "char-editor-width=80")
 
 [Anarlog](https://anarlog.so) is open-source and approaches the problem differently from everything else here. It captures system audio without joining your call or requesting calendar permissions. There's no OAuth grant that can propagate through your organization. Everything is stored  on your device, which means your notes are readable by any tool you already use: Obsidian, VS Code, Notion, a plain text editor.
 
@@ -48,7 +48,7 @@ It runs on macOS and Linux. Windows support isn't here yet, and there's no mobil
 
 ### 2. Jamie
 
-![jamie vs read ai](/api/assets/blog/Jamie%20pros%20and%20cons "char-editor-width=80")
+![jamie vs read ai](/api/assets/blog/articles/read-ai-alternatives/jamie-pros-and-cons.png "char-editor-width=80")
 
 Where Anarlog gives you raw ownership and flexibility, [Jamie](https://meetjamie.ai/) packages the bot-free experience into a more conventional product. It's a desktop app for Mac and Windows (plus an iOS app) that captures audio from your device and generates summaries with speaker recognition, action items, and custom templates. 
 
@@ -62,7 +62,7 @@ For companies in Europe where Read AI's US-based data handling was the dealbreak
 
 ### 3. Tactiq
 
-![Tactiq vs Read AI](/api/assets/blog/Tactiq%20pros%20and%20cons "char-editor-width=80")
+![Tactiq vs Read AI](/api/assets/blog/articles/read-ai-alternatives/tactiq-pros-and-cons.png "char-editor-width=80")
 
 Anarlog and Jamie are desktop apps. [Tactiq](https://tactiq.com/) lives entirely in the browser as a Chrome extension, which changes the dynamic. 
 
@@ -76,7 +76,7 @@ The limitation is that it only works in the browser. If your team uses native de
 
 ### 4. Granola
 
-![Granola vs read ai](/api/assets/blog/Granola%20pros%20and%20cons "char-editor-width=80")
+![Granola vs read ai](/api/assets/blog/articles/read-ai-alternatives/granola-pros-and-cons.png "char-editor-width=80")
 
 [Granola](https://www.granola.ai/) shares the same core mechanic as Anarlog's notepad mode: you type rough notes during the call while it captures audio in the background, and the AI merges both into structured output when the meeting ends. 
 
@@ -88,7 +88,7 @@ Speaker identification is weak in multi-person calls and there's no audio playba
 
 ### 5. Microsoft 365 Copilot
 
-![Copilot vs read ai](/api/assets/blog/Copilot%20pros%20and%20cons "char-editor-width=80")
+![Copilot vs read ai](/api/assets/blog/articles/read-ai-alternatives/copilot-pros-and-cons.png "char-editor-width=80")
 
 [Microsoft 365 Copilot](https://www.microsoft.com/en-us/microsoft-365/copilot/pricing) is the closest full-scope alternative to Read AI. It operates across Microsoft's entire suite, which means if your organization already runs M365, most of what Read AI does is available without adding another vendor's bot to your meetings.
 
@@ -100,7 +100,7 @@ If your organization doesn't already run Microsoft 365, this isn't a realistic o
 
 ### 6. Slack AI
 
-![slack vs read ai](/api/assets/blog/Slack%20ai%20pros%20and%20cons "char-editor-width=80")
+![slack vs read ai](/api/assets/blog/articles/read-ai-alternatives/slack-ai-pros-and-cons.png "char-editor-width=80")
 
 If your team uses Slack and you were paying Read AI mainly for the messaging summaries or cross-channel search, check what your Slack plan already includes. 
 

--- a/apps/web/content/articles/see-zoom-meeting-history.mdx
+++ b/apps/web/content/articles/see-zoom-meeting-history.mdx
@@ -3,7 +3,6 @@ meta_title: "How to View Zoom Meeting History (Updated 2026)"
 display_title: "How to See Your Zoom Meeting History (And Actually Make It Useful)"
 meta_description: "Step-by-step guide to viewing Zoom meeting history. See what Zoom shows (and what it doesn't), plus how to make your meeting history actually searchable."
 author: "John Jeong"
-coverImage: "/api/assets/blog/see-zoom-meeting-history/cover.png"
 category: "Guides"
 date: "2025-11-05"
 ---

--- a/apps/web/content/articles/selfhosted-ai-notetakers.mdx
+++ b/apps/web/content/articles/selfhosted-ai-notetakers.mdx
@@ -28,7 +28,7 @@ If you don't want your meeting audio on someone else's servers, these are your o
 
 ### 1. Anarlog
 
-![Anarlog review](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+![Anarlog review](/api/assets/blog/articles/selfhosted-ai-notetakers/char-summary.png "char-editor-width=80")
 
 [Anarlog](https://anarlog.so/) is the only tool on this list that handles the full meeting workflow in one app — capture, transcription, note-taking, summarization, and structured export. 
 
@@ -88,7 +88,7 @@ Free and open source (MIT) for the Community Edition. Pro is $120/year ($10/mont
 
 ### 3. Scriberr
 
-![scribber review](/api/assets/blog/blog/telegram-cloud-photo-size-5-6282995305728905641-w.jpg "char-editor-width=80")
+![scribber review](/api/assets/blog/articles/selfhosted-ai-notetakers/telegram-cloud-photo-size-5-6282995305728905641-w.jpg "char-editor-width=80")
 
 [Scriberr](https://github.com/rishikanthc/Scriberr) is a team transcription service you deploy with Docker. Upload recordings through the browser, get transcripts back from Whisper.cpp on your server. Optional Ollama sidecar for summarization. 
 
@@ -115,7 +115,7 @@ Free and open-source (MIT). Self-host only.
 
 ### 4. Vibe
 
-![vibe review](/api/assets/blog/blog/telegram-cloud-photo-size-5-6282995305728905642-y.jpg "char-editor-width=80")
+![vibe review](/api/assets/blog/articles/selfhosted-ai-notetakers/telegram-cloud-photo-size-5-6282995305728905642-y.jpg "char-editor-width=80")
 
 [Vibe](https://thewh1teagle.github.io/vibe/) does one thing: transcribe audio and video files using Whisper.cpp. Cross-platform desktop app with a clean UI. It also exposes a local API, which makes it useful as a transcription backend you can wire into other tools. 
 
@@ -140,7 +140,7 @@ Free and open-source (MIT).
 
 ### 5. Whishper
 
-![](/api/assets/blog/blog/Screenshot-2026-04-20-at-1.55.51-PM.png "char-editor-width=80")
+![](/api/assets/blog/articles/selfhosted-ai-notetakers/screenshot-2026-04-20-at-1-55-51-pm.png "char-editor-width=80")
 
 [Whishper](https://github.com/pluja/whishper) is another Docker-deployed web UI for Whisper with drag-and-drop upload and subtitle generation (SRT, VTT). 
 
@@ -167,7 +167,7 @@ Free and open-source (MIT). Self-host only.
 
 ### 6. WhisperX
 
-![whisperx review](/api/assets/blog/blog/Screenshot-2026-04-20-at-12.53.00-PM-1.png "char-editor-width=80")
+![whisperx review](/api/assets/blog/articles/selfhosted-ai-notetakers/screenshot-2026-04-20-at-12-53-00-pm-1.png "char-editor-width=80")
 
 [WhisperX](https://github.com/m-bain/whisperX) is a research-grade transcription pipeline. It extends Whisper with forced alignment (word-level timestamps via wav2vec2) and speaker diarization (pyannote.audio). 
 

--- a/apps/web/content/articles/tactiq-alternatives.mdx
+++ b/apps/web/content/articles/tactiq-alternatives.mdx
@@ -33,7 +33,7 @@ I spent weeks testing alternatives that remove that ceiling in different ways. H
 
 ### 1. Anarlog
 
-![Anarlog vs Tactiq](/api/assets/blog/blog/char-summary.png "char-editor-width=80")
+![Anarlog vs Tactiq](/api/assets/blog/articles/tactiq-alternatives/char-summary.png "char-editor-width=80")
 
 [Anarlog](https://anarlog.so) is an open-source AI notepad for meetings, built for people who want to own their data. 
 
@@ -85,7 +85,7 @@ Free (300 min/mo, 30-min cap); Pro $16.99/month ($8.33 annually); Business $30/u
 
 ### 3. Granola
 
-![Granola vs tactiq](/api/assets/blog/blog/image-13.png "char-editor-width=80")
+![Granola vs tactiq](/api/assets/blog/articles/tactiq-alternatives/image-13.png "char-editor-width=80")
 
 [Granola](granola.ai) is a desktop app that, like Anarlog, captures system audio and skips the bot. You take notes during the meeting in Granola's notepad, and the AI fills in everything you missed using the transcript. The calendar sync works out of the box, and the note quality is consistently strong.
 
@@ -110,7 +110,7 @@ Business plan at ~$14/month; requires a Google account to sign up.
 
 ### 4. Fathom
 
-![Fathom vs tactiq](/api/assets/blog/blog/image-14.png "char-editor-width=80")
+![Fathom vs tactiq](/api/assets/blog/articles/tactiq-alternatives/image-14.png "char-editor-width=80")
 
 [Fathom](fathom.ai) has disrupted the pricing model of this entire category by offering unlimited free transcription for individual users. No credit card, no time limits, no catch. 
 
@@ -138,7 +138,7 @@ Free (unlimited individual); Team Standard $32/user/month, Team Pro $39/user/mon
 
 ### 5. Fireflies.ai
 
-![Fireflies vs tactiq](/api/assets/blog/blog/image-15.png "char-editor-width=80")
+![Fireflies vs tactiq](/api/assets/blog/articles/tactiq-alternatives/image-15.png "char-editor-width=80")
 
 [Fireflies](fireflies.ai) is built for revenue teams. Where other tools stop at transcription, Fireflies layers on conversation analytics: talk-to-listen ratios, sentiment analysis, topic tracking, and custom vocabulary for industry-specific terminology. 
 
@@ -164,7 +164,7 @@ Free (800 min/mo storage); Pro $10/user/month; Business $19/user/month.
 
 ### 6. tl;dv
 
-![tl;dv vs tactiq](/api/assets/blog/blog/image-16.png "char-editor-width=80")
+![tl;dv vs tactiq](/api/assets/blog/articles/tactiq-alternatives/image-16.png "char-editor-width=80")
 
 [tl;dv](tldv.io) takes a different angle than the other tools on this list. The core idea is that most people do not need a full transcript or even a summary. They need the one moment that matters, packaged in a way they can send to someone who was not on the call. 
 
@@ -190,7 +190,7 @@ Free (unlimited recordings and transcriptions); Pro $29/user/month.
 
 ### 7. Notta
 
-![Notta vs tactiq](/api/assets/blog/blog/image-18.png "char-editor-width=80")
+![Notta vs tactiq](/api/assets/blog/articles/tactiq-alternatives/image-18.png "char-editor-width=80")
 
 [Notta's](notta.ai) strongest card is language coverage. It supports 58 languages for transcription and real-time translation for over 50, which is more than any other tool on this list. Tactiq claims 60+ languages for captions, but accuracy drops noticeably with accents and non-native speakers in practice. 
 

--- a/apps/web/content/articles/tldv-review.mdx
+++ b/apps/web/content/articles/tldv-review.mdx
@@ -3,7 +3,6 @@ meta_title: "tl;dv meeting notes software review 2026"
 display_title: "I Tested tl;dv So You Don't Have To [2026 Review]"
 meta_description: "Is tl;dv worth it? Complete 2026 review with pricing, feature tests, user complaints, and honest pros & cons to help you decide."
 author: "Harshika"
-coverImage: "/api/assets/blog/tldv-review/cover.png"
 category: "Comparisons"
 date: "2025-10-17"
 ---

--- a/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
+++ b/apps/web/content/articles/what-makes-reliable-ai-note-taker.mdx
@@ -4,7 +4,6 @@ display_title: "The Reliable AI Note-Taker Checklist"
 meta_description: "How to choose an AI notetaker? Use this guide to assess the 5 dependency risks in any AI note-taker before you commit to a platform."
 author:
   - "John Jeong"
-coverImage: "/api/assets/blog/what-makes-reliable-ai-note-taker/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-10-25"

--- a/apps/web/content/articles/zoom-ai-companion-review.mdx
+++ b/apps/web/content/articles/zoom-ai-companion-review.mdx
@@ -3,7 +3,6 @@ meta_title: "Zoom AI Companion Review: Is It Worth It in 2026?"
 meta_description: "Zoom AI Companion 2026 review: We tested features, analyzed user feedback, and compared costs. Find out when it works and when you should look for an alternative."
 author:
   - "Harshika"
-coverImage: "/api/assets/blog/zoom-ai-companion-review/cover.png"
 featured: false
 category: "Comparisons"
 date: "2025-09-19"

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -72,6 +72,7 @@
     "rehype-slug": "^6.0.0",
     "remark-gfm": "^4.0.1",
     "semver": "7.6.3",
+    "sharp": "^0.34.5",
     "shiki": "^3.23.0",
     "streamdown": "^2.5.0",
     "stripe": "^20.4.1",

--- a/apps/web/src/lib/og-image.ts
+++ b/apps/web/src/lib/og-image.ts
@@ -1,0 +1,128 @@
+import sharp from "sharp";
+
+const OG_WIDTH = 1200;
+const OG_HEIGHT = 630;
+const CACHE_CONTROL =
+  "public, max-age=0, s-maxage=86400, stale-while-revalidate=604800";
+
+type BlogOgImageInput = {
+  title: string;
+  description?: string;
+  date?: string;
+  author?: string;
+};
+
+function clampText(value: string | undefined, maxLength: number) {
+  if (!value) return "";
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (normalized.length <= maxLength) return normalized;
+  return `${normalized.slice(0, maxLength - 1).trimEnd()}...`;
+}
+
+function escapeXml(value: string) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&#39;");
+}
+
+function wrapText(value: string, maxChars: number, maxLines: number) {
+  const words = value.split(/\s+/).filter(Boolean);
+  const lines: string[] = [];
+  let current = "";
+
+  for (const word of words) {
+    const next = current ? `${current} ${word}` : word;
+    if (next.length <= maxChars) {
+      current = next;
+      continue;
+    }
+
+    if (current) lines.push(current);
+    current = word;
+
+    if (lines.length === maxLines) break;
+  }
+
+  if (current && lines.length < maxLines) {
+    lines.push(current);
+  }
+
+  if (
+    lines.length === maxLines &&
+    words.join(" ").length > lines.join(" ").length
+  ) {
+    lines[lines.length - 1] =
+      `${lines[lines.length - 1].replace(/\.+$/, "")}...`;
+  }
+
+  return lines;
+}
+
+function formatDate(date: string | undefined) {
+  if (!date) return "";
+  const parsed = new Date(date);
+  if (Number.isNaN(parsed.getTime())) return date;
+  return parsed.toLocaleDateString("en-US", {
+    month: "long",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function createBlogOgSvg(input: BlogOgImageInput) {
+  const title = wrapText(clampText(input.title, 96), 25, 3);
+  const description = wrapText(clampText(input.description, 150), 55, 2);
+  const meta = [input.author, formatDate(input.date)]
+    .filter(Boolean)
+    .join(" - ");
+  const titleStartY = title.length === 1 ? 266 : title.length === 2 ? 226 : 190;
+  const descriptionStartY = titleStartY + title.length * 86 + 36;
+
+  return `<?xml version="1.0" encoding="UTF-8"?>
+<svg width="${OG_WIDTH}" height="${OG_HEIGHT}" viewBox="0 0 ${OG_WIDTH} ${OG_HEIGHT}" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect width="${OG_WIDTH}" height="${OG_HEIGHT}" fill="#f2f1ef"/>
+  <rect x="44" y="44" width="1112" height="542" rx="0" fill="#ffffff"/>
+  <path d="M86 126 H1114" stroke="#d8d1c8" stroke-width="2"/>
+  <path d="M86 504 H1114" stroke="#d8d1c8" stroke-width="2"/>
+  <g opacity="0.22">
+    ${Array.from({ length: 18 }, (_, index) => {
+      const x = 92 + index * 60;
+      return `<path d="M${x} 86 V544" stroke="#c5bbb0" stroke-width="1"/>`;
+    }).join("")}
+    ${Array.from({ length: 8 }, (_, index) => {
+      const y = 94 + index * 56;
+      return `<path d="M86 ${y} H1114" stroke="#c5bbb0" stroke-width="1"/>`;
+    }).join("")}
+  </g>
+  <text x="86" y="100" fill="#57534e" font-family="Arial, Helvetica, sans-serif" font-size="34" font-weight="700">Anarlog</text>
+  <text x="1114" y="100" fill="#756b5d" font-family="Arial, Helvetica, sans-serif" font-size="24" text-anchor="end">Blog</text>
+  ${title
+    .map(
+      (line, index) =>
+        `<text x="86" y="${titleStartY + index * 86}" fill="#181613" font-family="Georgia, 'Times New Roman', serif" font-size="76" font-weight="700">${escapeXml(line)}</text>`,
+    )
+    .join("")}
+  ${description
+    .map(
+      (line, index) =>
+        `<text x="90" y="${descriptionStartY + index * 42}" fill="#57534e" font-family="Arial, Helvetica, sans-serif" font-size="32" font-weight="500">${escapeXml(line)}</text>`,
+    )
+    .join("")}
+  <text x="86" y="552" fill="#756b5d" font-family="Arial, Helvetica, sans-serif" font-size="26" font-weight="600">${escapeXml(meta || "anarlog.so")}</text>
+</svg>`;
+}
+
+export async function renderBlogOgImage(input: BlogOgImageInput) {
+  const svg = createBlogOgSvg(input);
+  const png = await sharp(Buffer.from(svg)).png().toBuffer();
+
+  return new Response(new Uint8Array(png), {
+    headers: {
+      "Cache-Control": CACHE_CONTROL,
+      "Content-Type": "image/png",
+    },
+  });
+}

--- a/apps/web/src/lib/seo.ts
+++ b/apps/web/src/lib/seo.ts
@@ -6,6 +6,10 @@ export const ROOT_DESCRIPTION =
 export const ROOT_KEYWORDS =
   "private meeting notes, bot-free AI notes, local transcription, AI meeting notes, AI notetaker, meeting transcription, meeting summaries, BYOK AI, open source note taking, local AI";
 
+export function getBlogOgImageUrl(slug: string) {
+  return `${ANARLOG_SITE_URL}/api/og/blog/${encodeURIComponent(slug)}`;
+}
+
 type StructuredDataNode = Record<string, unknown>;
 
 export function getStructuredDataGraph(nodes: StructuredDataNode[]) {

--- a/apps/web/src/routeTree.gen.ts
+++ b/apps/web/src/routeTree.gen.ts
@@ -45,6 +45,7 @@ import { Route as ViewAppPortalRouteImport } from './routes/_view/app/portal'
 import { Route as ViewAppIntegrationRouteImport } from './routes/_view/app/integration'
 import { Route as ViewAppCheckoutRouteImport } from './routes/_view/app/checkout'
 import { Route as ViewAppAccountRouteImport } from './routes/_view/app/account'
+import { Route as ApiOgBlogSlugRouteImport } from './routes/api/og/blog/$slug'
 import { Route as ApiAdminStarsResearchRouteImport } from './routes/api/admin/stars/research'
 import { Route as ApiAdminStarsPipelineRouteImport } from './routes/api/admin/stars/pipeline'
 import { Route as ApiAdminStarsLeadsRouteImport } from './routes/api/admin/stars/leads'
@@ -257,6 +258,11 @@ const ViewAppAccountRoute = ViewAppAccountRouteImport.update({
   id: '/account',
   path: '/account',
   getParentRoute: () => ViewAppRouteRoute,
+} as any)
+const ApiOgBlogSlugRoute = ApiOgBlogSlugRouteImport.update({
+  id: '/api/og/blog/$slug',
+  path: '/api/og/blog/$slug',
+  getParentRoute: () => rootRouteImport,
 } as any)
 const ApiAdminStarsResearchRoute = ApiAdminStarsResearchRouteImport.update({
   id: '/api/admin/stars/research',
@@ -480,6 +486,7 @@ export interface FileRoutesByFullPath {
   '/api/admin/stars/leads': typeof ApiAdminStarsLeadsRoute
   '/api/admin/stars/pipeline': typeof ApiAdminStarsPipelineRoute
   '/api/admin/stars/research': typeof ApiAdminStarsResearchRoute
+  '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
 }
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
@@ -546,6 +553,7 @@ export interface FileRoutesByTo {
   '/api/admin/stars/leads': typeof ApiAdminStarsLeadsRoute
   '/api/admin/stars/pipeline': typeof ApiAdminStarsPipelineRoute
   '/api/admin/stars/research': typeof ApiAdminStarsResearchRoute
+  '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
 }
 export interface FileRoutesById {
   __root__: typeof rootRouteImport
@@ -615,6 +623,7 @@ export interface FileRoutesById {
   '/api/admin/stars/leads': typeof ApiAdminStarsLeadsRoute
   '/api/admin/stars/pipeline': typeof ApiAdminStarsPipelineRoute
   '/api/admin/stars/research': typeof ApiAdminStarsResearchRoute
+  '/api/og/blog/$slug': typeof ApiOgBlogSlugRoute
 }
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
@@ -684,6 +693,7 @@ export interface FileRouteTypes {
     | '/api/admin/stars/leads'
     | '/api/admin/stars/pipeline'
     | '/api/admin/stars/research'
+    | '/api/og/blog/$slug'
   fileRoutesByTo: FileRoutesByTo
   to:
     | '/'
@@ -750,6 +760,7 @@ export interface FileRouteTypes {
     | '/api/admin/stars/leads'
     | '/api/admin/stars/pipeline'
     | '/api/admin/stars/research'
+    | '/api/og/blog/$slug'
   id:
     | '__root__'
     | '/'
@@ -818,6 +829,7 @@ export interface FileRouteTypes {
     | '/api/admin/stars/leads'
     | '/api/admin/stars/pipeline'
     | '/api/admin/stars/research'
+    | '/api/og/blog/$slug'
   fileRoutesById: FileRoutesById
 }
 export interface RootRouteChildren {
@@ -869,6 +881,7 @@ export interface RootRouteChildren {
   ApiAdminStarsLeadsRoute: typeof ApiAdminStarsLeadsRoute
   ApiAdminStarsPipelineRoute: typeof ApiAdminStarsPipelineRoute
   ApiAdminStarsResearchRoute: typeof ApiAdminStarsResearchRoute
+  ApiOgBlogSlugRoute: typeof ApiOgBlogSlugRoute
 }
 
 declare module '@tanstack/react-router' {
@@ -1124,6 +1137,13 @@ declare module '@tanstack/react-router' {
       fullPath: '/app/account'
       preLoaderRoute: typeof ViewAppAccountRouteImport
       parentRoute: typeof ViewAppRouteRoute
+    }
+    '/api/og/blog/$slug': {
+      id: '/api/og/blog/$slug'
+      path: '/api/og/blog/$slug'
+      fullPath: '/api/og/blog/$slug'
+      preLoaderRoute: typeof ApiOgBlogSlugRouteImport
+      parentRoute: typeof rootRouteImport
     }
     '/api/admin/stars/research': {
       id: '/api/admin/stars/research'
@@ -1443,6 +1463,7 @@ const rootRouteChildren: RootRouteChildren = {
   ApiAdminStarsLeadsRoute: ApiAdminStarsLeadsRoute,
   ApiAdminStarsPipelineRoute: ApiAdminStarsPipelineRoute,
   ApiAdminStarsResearchRoute: ApiAdminStarsResearchRoute,
+  ApiOgBlogSlugRoute: ApiOgBlogSlugRoute,
 }
 export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)

--- a/apps/web/src/routes/api/og/blog/$slug.ts
+++ b/apps/web/src/routes/api/og/blog/$slug.ts
@@ -1,0 +1,29 @@
+import { createFileRoute } from "@tanstack/react-router";
+import { type Article, allArticles } from "content-collections";
+
+import { renderBlogOgImage } from "@/lib/og-image";
+
+export const Route = createFileRoute("/api/og/blog/$slug")({
+  server: {
+    handlers: {
+      GET: async ({ params }) => {
+        const article = allArticles.find(
+          (a: Article) => a.slug === params.slug,
+        );
+
+        if (!article) {
+          return new Response("Not found", { status: 404 });
+        }
+
+        return renderBlogOgImage({
+          title: article.meta_title || article.title,
+          description: article.meta_description,
+          date: article.date,
+          author: Array.isArray(article.author)
+            ? article.author.join(", ")
+            : article.author,
+        });
+      },
+    },
+  },
+});

--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -6,7 +6,7 @@ import type { ComponentProps } from "react";
 
 import { mdxComponents } from "@/components/mdx-components";
 import { SiteFooter } from "@/components/site-footer";
-import { ANARLOG_SITE_URL } from "@/lib/seo";
+import { ANARLOG_SITE_URL, getBlogOgImageUrl } from "@/lib/seo";
 
 const blogMdxComponents = {
   ...mdxComponents,
@@ -26,6 +26,7 @@ export const Route = createFileRoute("/blog/$slug")({
     const article = loaderData?.article;
     if (!article) return {};
     const url = `${ANARLOG_SITE_URL}/blog/${article.slug}`;
+    const imageUrl = getBlogOgImageUrl(article.slug);
     return {
       links: [{ rel: "canonical", href: url }],
       meta: [
@@ -38,6 +39,13 @@ export const Route = createFileRoute("/blog/$slug")({
         { property: "og:description", content: article.meta_description },
         { property: "og:url", content: url },
         { property: "og:type", content: "article" },
+        { property: "og:image", content: imageUrl },
+        { property: "og:image:width", content: "1200" },
+        { property: "og:image:height", content: "630" },
+        { name: "twitter:card", content: "summary_large_image" },
+        { name: "twitter:title", content: article.meta_title || article.title },
+        { name: "twitter:description", content: article.meta_description },
+        { name: "twitter:image", content: imageUrl },
       ],
     };
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -653,6 +653,9 @@ importers:
       semver:
         specifier: 7.6.3
         version: 7.6.3
+      sharp:
+        specifier: ^0.34.5
+        version: 0.34.5
       shiki:
         specifier: ^3.23.0
         version: 3.23.0
@@ -6606,8 +6609,8 @@ packages:
       react: '>=16.9.0'
       react-dom: '>=16.9.0'
 
-  '@react-grab/cli@0.1.47':
-    resolution: {integrity: sha512-Cc7d8mSwvoV8gpeTQbE8dMPdeXIyO6w+yIhzgi3jY06i03WLNhb/6jIxNBNF1cVRI7ujnFQXZA66BbnBNTpBSw==}
+  '@react-grab/cli@0.1.48':
+    resolution: {integrity: sha512-KXRZFN0b78BeVa4Tq1FC9kiXPpC5lS4pQp/mvQ1azy9dZUJ3zfc7Ei84+yvGh+WoYdceMCFxXfBp6qhU/G056g==}
     hasBin: true
 
   '@rolldown/binding-android-arm64@1.0.0-rc.15':
@@ -8653,6 +8656,11 @@ packages:
     peerDependencies:
       react: '>=17.0.1'
 
+  bippy@0.5.43:
+    resolution: {integrity: sha512-Tvu7b1M7+d8b9/YHaCeODEsi2CgbuoBql+dWSBrNnCuqJ1gMUeY3i0r+319hvjjl5GVBP6FFWxrKnq3fhZER0w==}
+    peerDependencies:
+      react: '>=17.0.1'
+
   bl@4.1.0:
     resolution: {integrity: sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==}
 
@@ -9580,8 +9588,8 @@ packages:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
     engines: {node: '>=6'}
 
-  deslop-js@0.6.2:
-    resolution: {integrity: sha512-3+wV56jJd4zx6Mob2nQ4B8nIF4J12Xc2iCagNE9kdVTzMbNEIe99vwfaxrgdFC+RQ1NHXfjUkR3C4HVYnLLSfg==}
+  deslop-js@0.7.1:
+    resolution: {integrity: sha512-HsEoRI/bzuD0o2OVczYz42SXTCl5of3ax6eiojZbC/7gJsPNxxjPRvBysP88LXsHujYrIGJnGtFRnHwCmKWuxQ==}
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
@@ -12877,8 +12885,8 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
 
-  oxlint-plugin-react-doctor@0.6.2:
-    resolution: {integrity: sha512-8+YU8hwSPmS2dglPxLGRTSpaSHA5A2L0x7zU/7G+dp9V779jrpHiYMhJ5Ga9JUa0VtECHfpY+xUOYSt1IEP3YA==}
+  oxlint-plugin-react-doctor@0.7.1:
+    resolution: {integrity: sha512-fvARsCESDZYvDIlhuB/JlDeUhTOLHYstoDJCKm0pzh4HQQJVVV6gcrQajBjYo/hdHC1ukl7btKTK3rk4uZwuew==}
     engines: {node: ^20.19.0 || >=22.13.0}
 
   oxlint-tsgolint@0.21.1:
@@ -13661,8 +13669,8 @@ packages:
       react: '>=16.8.0'
       react-dom: '>=16.8.0'
 
-  react-doctor@0.6.2:
-    resolution: {integrity: sha512-uPFyoWhRvAG6vc7uLVbf2wg7ox0R8y+SgOAhAfAcs1soP4sIPwl4gEuWCNbAir/QIGcb5xrwFJvCM30WmgmeUg==}
+  react-doctor@0.7.1:
+    resolution: {integrity: sha512-Gmty7Enyrh6GPlz6Paq+UoL2O7YkTzNeHdflbqdp6fspX1UbUem5ejPyIUgo1jf77D6kB+INqsi2K+Mk/K8uBQ==}
     engines: {node: ^20.19.0 || >=22.13.0}
     hasBin: true
 
@@ -13691,8 +13699,8 @@ packages:
   react-fast-compare@3.2.2:
     resolution: {integrity: sha512-nsO+KSNgo1SbJqJEYRE9ERzo7YtYbou/OqjSQKxV7jcKox7+usiUVZOAC+XnDOABXggQTno0Y1CpVnuWEc1boQ==}
 
-  react-grab@0.1.47:
-    resolution: {integrity: sha512-1GNy24KMJ4CY1IxorYO9mydItGi0L1HkQB19uYU3t0BMsJB0K+D/QYiaBz+rugRynyY8LzmXIuOcon1TykLlCg==}
+  react-grab@0.1.48:
+    resolution: {integrity: sha512-p3WnmK9LLvXE/c4ITPLlXcP1fkXo2VFEQqK94tIfcHIWKNdqdhYYFyNVioO50HR+uyHIwT63Z4txZDqJlVcD/Q==}
     hasBin: true
     peerDependencies:
       react: '>=17.0.0'
@@ -16150,7 +16158,7 @@ snapshots:
   '@apm-js-collab/tracing-hooks@0.10.1':
     dependencies:
       '@apm-js-collab/code-transformer': 0.15.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -16208,7 +16216,7 @@ snapshots:
       '@babel/types': 7.29.0
       '@jridgewell/remapping': 2.3.5
       convert-source-map: 2.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       gensync: 1.0.0-beta.2
       json5: 2.2.3
       semver: 6.3.1
@@ -16300,7 +16308,7 @@ snapshots:
       '@babel/parser': 7.29.2
       '@babel/template': 7.28.6
       '@babel/types': 7.29.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -16878,7 +16886,7 @@ snapshots:
   '@esbuild-plugins/node-resolve@0.2.2(esbuild@0.25.12)':
     dependencies:
       '@types/resolve': 1.20.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       esbuild: 0.25.12
       escape-string-regexp: 4.0.0
       resolve: 1.22.12
@@ -17273,7 +17281,7 @@ snapshots:
   '@eslint/config-array@0.21.2':
     dependencies:
       '@eslint/object-schema': 2.1.7
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       minimatch: 3.1.5
     transitivePeerDependencies:
       - supports-color
@@ -17289,7 +17297,7 @@ snapshots:
   '@eslint/eslintrc@3.3.5':
     dependencies:
       ajv: 6.14.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       espree: 10.4.0
       globals: 14.0.0
       ignore: 5.3.2
@@ -17614,7 +17622,7 @@ snapshots:
 
   '@img/sharp-wasm32@0.34.5':
     dependencies:
-      '@emnapi/runtime': 1.9.2
+      '@emnapi/runtime': 1.11.1
     optional: true
 
   '@img/sharp-win32-arm64@0.34.5':
@@ -18241,6 +18249,19 @@ snapshots:
 
   '@lukeed/ms@2.0.2': {}
 
+  '@mapbox/node-pre-gyp@2.0.3':
+    dependencies:
+      consola: 3.4.2
+      detect-libc: 2.1.2
+      https-proxy-agent: 7.0.6
+      node-fetch: 2.7.0
+      nopt: 8.1.0
+      semver: 7.6.3
+      tar: 7.5.13
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+
   '@mapbox/node-pre-gyp@2.0.3(supports-color@10.2.2)':
     dependencies:
       consola: 3.4.2
@@ -18413,6 +18434,14 @@ snapshots:
     dependencies:
       '@netlify/dev-utils': 4.3.0
       '@netlify/runtime-utils': 2.2.0
+
+  '@netlify/blobs@10.7.4':
+    dependencies:
+      '@netlify/dev-utils': 4.4.3
+      '@netlify/otel': 5.1.5
+      '@netlify/runtime-utils': 2.3.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@netlify/blobs@10.7.4(supports-color@10.2.2)':
     dependencies:
@@ -18587,7 +18616,7 @@ snapshots:
       image-size: 2.0.2
       js-image-generator: 1.0.4
       parse-gitignore: 2.0.0
-      semver: 7.7.2
+      semver: 7.7.4
       tmp-promise: 3.0.3
       uuid: 11.1.0
       write-file-atomic: 5.0.1
@@ -18631,7 +18660,7 @@ snapshots:
   '@netlify/dev@4.16.5(srvx@0.11.15)':
     dependencies:
       '@netlify/ai': 0.4.1
-      '@netlify/blobs': 10.7.4(supports-color@10.2.2)
+      '@netlify/blobs': 10.7.4
       '@netlify/config': 24.4.4
       '@netlify/db-dev': 0.7.0
       '@netlify/dev-utils': 4.4.3
@@ -18741,10 +18770,10 @@ snapshots:
 
   '@netlify/functions-dev@1.2.5':
     dependencies:
-      '@netlify/blobs': 10.7.4(supports-color@10.2.2)
+      '@netlify/blobs': 10.7.4
       '@netlify/dev-utils': 4.4.3
       '@netlify/functions': 5.2.0
-      '@netlify/zip-it-and-ship-it': 14.5.3(supports-color@10.2.2)
+      '@netlify/zip-it-and-ship-it': 14.5.3
       cron-parser: 4.9.0
       decache: 4.6.2
       extract-zip: 2.0.1
@@ -18915,6 +18944,16 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.8.0
 
+  '@netlify/otel@5.1.5':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/core': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/instrumentation': 0.203.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/resources': 1.30.1(@opentelemetry/api@1.9.0)
+      '@opentelemetry/sdk-trace-node': 1.30.1(@opentelemetry/api@1.9.0)
+    transitivePeerDependencies:
+      - supports-color
+
   '@netlify/otel@5.1.5(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -18959,7 +18998,7 @@ snapshots:
 
   '@netlify/runtime@4.1.20':
     dependencies:
-      '@netlify/blobs': 10.7.4(supports-color@10.2.2)
+      '@netlify/blobs': 10.7.4
       '@netlify/cache': 3.4.4
       '@netlify/runtime-utils': 2.3.0
       '@netlify/types': 2.6.0
@@ -19046,6 +19085,48 @@ snapshots:
       - supports-color
       - uploadthing
 
+  '@netlify/zip-it-and-ship-it@14.3.1':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@netlify/binary-info': 1.0.0
+      '@netlify/serverless-functions-api': 2.14.0
+      '@vercel/nft': 0.29.4
+      archiver: 7.0.1
+      common-path-prefix: 3.0.0
+      copy-file: 11.1.0
+      es-module-lexer: 1.7.0
+      esbuild: 0.27.2
+      execa: 8.0.1
+      fast-glob: 3.3.3
+      filter-obj: 6.1.0
+      find-up: 7.0.0
+      is-path-inside: 4.0.0
+      junk: 4.0.1
+      locate-path: 7.2.0
+      merge-options: 3.0.4
+      minimatch: 9.0.9
+      normalize-path: 3.0.0
+      p-map: 7.0.3
+      path-exists: 5.0.0
+      precinct: 12.2.0
+      require-package-name: 2.0.1
+      resolve: 2.0.0-next.6
+      semver: 7.7.2
+      tmp-promise: 3.0.3
+      toml: 3.0.0
+      unixify: 1.0.0
+      urlpattern-polyfill: 8.0.2
+      yargs: 17.7.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - encoding
+      - react-native-b4a
+      - rollup
+      - supports-color
+
   '@netlify/zip-it-and-ship-it@14.3.1(supports-color@10.2.2)':
     dependencies:
       '@babel/parser': 7.29.2
@@ -19074,6 +19155,48 @@ snapshots:
       require-package-name: 2.0.1
       resolve: 2.0.0-next.6
       semver: 7.7.2
+      tmp-promise: 3.0.3
+      toml: 3.0.0
+      unixify: 1.0.0
+      urlpattern-polyfill: 8.0.2
+      yargs: 17.7.2
+      zod: 3.25.76
+    transitivePeerDependencies:
+      - bare-abort-controller
+      - bare-buffer
+      - encoding
+      - react-native-b4a
+      - rollup
+      - supports-color
+
+  '@netlify/zip-it-and-ship-it@14.5.3':
+    dependencies:
+      '@babel/parser': 7.29.2
+      '@babel/types': 7.29.0
+      '@netlify/binary-info': 1.0.0
+      '@netlify/serverless-functions-api': 2.14.0
+      '@vercel/nft': 0.29.4
+      archiver: 7.0.1
+      common-path-prefix: 3.0.0
+      copy-file: 11.1.0
+      es-module-lexer: 1.7.0
+      esbuild: 0.27.3
+      execa: 8.0.1
+      fast-glob: 3.3.3
+      filter-obj: 6.1.0
+      find-up: 7.0.0
+      is-path-inside: 4.0.0
+      junk: 4.0.1
+      locate-path: 7.2.0
+      merge-options: 3.0.4
+      minimatch: 10.2.5
+      normalize-path: 3.0.0
+      p-map: 7.0.3
+      path-exists: 5.0.0
+      precinct: 12.2.0
+      require-package-name: 2.0.1
+      resolve: 2.0.0-next.6
+      semver: 7.6.3
       tmp-promise: 3.0.3
       toml: 3.0.0
       unixify: 1.0.0
@@ -19565,6 +19688,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api-logs': 0.203.0
+      import-in-the-middle: 1.15.0
+      require-in-the-middle: 7.5.2
+    transitivePeerDependencies:
+      - supports-color
+
   '@opentelemetry/instrumentation@0.203.0(@opentelemetry/api@1.9.0)(supports-color@10.2.2)':
     dependencies:
       '@opentelemetry/api': 1.9.0
@@ -19579,7 +19711,7 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.203.0
       import-in-the-middle: 1.15.0
-      require-in-the-middle: 7.5.2(supports-color@10.2.2)
+      require-in-the-middle: 7.5.2
     transitivePeerDependencies:
       - supports-color
 
@@ -20279,7 +20411,7 @@ snapshots:
 
   '@pnpm/tabtab@0.5.4':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       enquirer: 2.4.1
       minimist: 1.2.8
       untildify: 4.0.0
@@ -20344,7 +20476,7 @@ snapshots:
 
   '@puppeteer/browsers@2.13.0':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -20359,7 +20491,7 @@ snapshots:
 
   '@puppeteer/browsers@2.3.0':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       extract-zip: 2.0.1
       progress: 2.0.3
       proxy-agent: 6.5.0
@@ -21208,7 +21340,7 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  '@react-grab/cli@0.1.47':
+  '@react-grab/cli@0.1.48':
     dependencies:
       agent-install: 0.0.6
       commander: 14.0.3
@@ -22683,9 +22815,9 @@ snapshots:
     dependencies:
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/visitor-keys': 8.58.1
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -22696,6 +22828,15 @@ snapshots:
       '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/types': 8.58.1
       debug: 4.4.3(supports-color@10.2.2)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  '@typescript-eslint/project-service@8.58.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -22712,9 +22853,9 @@ snapshots:
   '@typescript-eslint/type-utils@8.58.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       eslint: 9.39.4(jiti@2.7.0)
       ts-api-utils: 2.5.0(typescript@5.9.3)
       typescript: 5.9.3
@@ -22740,12 +22881,27 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@typescript-eslint/typescript-estree@8.58.1(typescript@5.9.3)':
+    dependencies:
+      '@typescript-eslint/project-service': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/tsconfig-utils': 8.58.1(typescript@5.9.3)
+      '@typescript-eslint/types': 8.58.1
+      '@typescript-eslint/visitor-keys': 8.58.1
+      debug: 4.4.3(supports-color@8.1.1)
+      minimatch: 10.2.5
+      semver: 7.7.4
+      tinyglobby: 0.2.16
+      ts-api-utils: 2.5.0(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   '@typescript-eslint/utils@8.58.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
       '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.58.1
       '@typescript-eslint/types': 8.58.1
-      '@typescript-eslint/typescript-estree': 8.58.1(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -22758,7 +22914,7 @@ snapshots:
 
   '@typescript/vfs@1.6.4(typescript@5.9.3)':
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -22850,6 +23006,25 @@ snapshots:
     dependencies:
       '@use-gesture/core': 10.3.1
       react: 19.2.5
+
+  '@vercel/nft@0.29.4':
+    dependencies:
+      '@mapbox/node-pre-gyp': 2.0.3
+      '@rollup/pluginutils': 5.3.0
+      acorn: 8.16.0
+      acorn-import-attributes: 1.9.5(acorn@8.16.0)
+      async-sema: 3.1.1
+      bindings: 1.5.0
+      estree-walker: 2.0.2
+      glob: 10.5.0
+      graceful-fs: 4.2.11
+      node-gyp-build: 4.8.4
+      picomatch: 4.0.4
+      resolve-from: 5.0.0
+    transitivePeerDependencies:
+      - encoding
+      - rollup
+      - supports-color
 
   '@vercel/nft@0.29.4(supports-color@10.2.2)':
     dependencies:
@@ -23296,7 +23471,7 @@ snapshots:
 
   agent-base@6.0.2:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -23705,6 +23880,10 @@ snapshots:
     dependencies:
       react: 19.2.5
 
+  bippy@0.5.43(react@19.2.5):
+    dependencies:
+      react: 19.2.5
+
   bl@4.1.0:
     dependencies:
       buffer: 5.7.1
@@ -23715,7 +23894,7 @@ snapshots:
     dependencies:
       bytes: 3.1.2
       content-type: 1.0.5
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-errors: 2.0.1
       iconv-lite: 0.7.2
       on-finished: 2.4.1
@@ -24705,7 +24884,7 @@ snapshots:
 
   dequal@2.0.3: {}
 
-  deslop-js@0.6.2:
+  deslop-js@0.7.1:
     dependencies:
       '@oxc-project/types': 0.132.0
       fast-glob: 3.3.3
@@ -24763,6 +24942,15 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  detective-typescript@14.0.0(typescript@5.9.3):
+    dependencies:
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
+      ast-module-types: 6.0.1
+      node-source-walk: 7.0.1
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   detective-vue2@2.2.0(supports-color@10.2.2)(typescript@5.9.3):
     dependencies:
       '@dependents/detective-less': 5.0.1
@@ -24772,6 +24960,19 @@ snapshots:
       detective-scss: 5.0.1
       detective-stylus: 5.0.1
       detective-typescript: 14.0.0(supports-color@10.2.2)(typescript@5.9.3)
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
+  detective-vue2@2.2.0(typescript@5.9.3):
+    dependencies:
+      '@dependents/detective-less': 5.0.1
+      '@vue/compiler-sfc': 3.5.32
+      detective-es6: 5.0.1
+      detective-sass: 6.0.1
+      detective-scss: 5.0.1
+      detective-stylus: 5.0.1
+      detective-typescript: 14.0.0(typescript@5.9.3)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -24901,7 +25102,7 @@ snapshots:
       edge-paths: 3.0.5
       fast-xml-parser: 5.5.11
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       which: 6.0.1
     transitivePeerDependencies:
       - supports-color
@@ -25311,7 +25512,7 @@ snapshots:
       ajv: 6.14.0
       chalk: 4.1.2
       cross-spawn: 7.0.6
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       escape-string-regexp: 4.0.0
       eslint-scope: 8.4.0
       eslint-visitor-keys: 4.2.1
@@ -25518,7 +25719,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 0.7.2
       cookie-signature: 1.2.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       encodeurl: 2.0.0
       escape-html: 1.0.3
@@ -25567,7 +25768,7 @@ snapshots:
 
   extract-zip@2.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       get-stream: 5.2.0
       yauzl: 2.10.0
     optionalDependencies:
@@ -25734,7 +25935,7 @@ snapshots:
 
   finalhandler@2.1.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       on-finished: 2.4.1
@@ -25791,7 +25992,7 @@ snapshots:
 
   follow-redirects@1.15.11(debug@4.4.3):
     optionalDependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
 
   for-each@0.3.5:
     dependencies:
@@ -25872,7 +26073,7 @@ snapshots:
       '@zip.js/zip.js': 2.8.26
       decamelize: 6.0.1
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       modern-tar: 0.7.6
     transitivePeerDependencies:
       - supports-color
@@ -25947,7 +26148,7 @@ snapshots:
     dependencies:
       basic-ftp: 5.2.2
       data-uri-to-buffer: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26416,14 +26617,14 @@ snapshots:
   http-proxy-agent@7.0.2:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
   http-proxy-middleware@3.0.5:
     dependencies:
       '@types/http-proxy': 1.17.17
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy: 1.18.1(debug@4.4.3)
       is-glob: 4.0.3
       is-plain-object: 5.0.0
@@ -26449,7 +26650,14 @@ snapshots:
   https-proxy-agent@5.0.1:
     dependencies:
       agent-base: 6.0.2
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -26463,7 +26671,7 @@ snapshots:
   https-proxy-agent@9.0.0:
     dependencies:
       agent-base: 9.0.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -27045,7 +27253,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 4.0.0
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       nwsapi: 2.2.23
       parse5: 7.3.0
@@ -27075,7 +27283,7 @@ snapshots:
       decimal.js: 10.6.0
       html-encoding-sniffer: 6.0.0(@noble/hashes@1.8.0)
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       is-potential-custom-element-name: 1.0.1
       parse5: 8.0.0
       saxes: 6.0.0
@@ -28488,7 +28696,7 @@ snapshots:
   micromark@3.2.0:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       micromark-core-commonmark: 1.1.0
       micromark-factory-space: 1.1.0
@@ -28511,7 +28719,7 @@ snapshots:
   micromark@4.0.2:
     dependencies:
       '@types/debug': 4.1.13
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       decode-named-character-reference: 1.3.0
       devlop: 1.1.0
       micromark-core-commonmark: 2.0.3
@@ -28731,7 +28939,7 @@ snapshots:
       '@netlify/images': 1.2.5(@netlify/blobs@10.1.0)(srvx@0.11.15)
       '@netlify/local-functions-proxy': 2.0.3
       '@netlify/redirect-parser': 15.0.3
-      '@netlify/zip-it-and-ship-it': 14.3.1(supports-color@10.2.2)
+      '@netlify/zip-it-and-ship-it': 14.3.1
       '@octokit/rest': 22.0.0
       '@opentelemetry/api': 1.8.0
       '@pnpm/tabtab': 0.5.4
@@ -28749,7 +28957,7 @@ snapshots:
       content-type: 1.0.5
       cookie: 1.0.2
       cron-parser: 4.9.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       decache: 4.6.2
       dot-prop: 10.1.0
       dotenv: 17.2.3
@@ -28771,7 +28979,7 @@ snapshots:
       gitconfiglocal: 2.1.0
       http-proxy: 1.18.1(debug@4.4.3)
       http-proxy-middleware: 3.0.5
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       inquirer: 8.2.7(@types/node@22.19.17)
       inquirer-autocomplete-prompt: 1.4.0(inquirer@8.2.7(@types/node@22.19.17))
       is-docker: 3.0.0
@@ -28915,7 +29123,7 @@ snapshots:
   normalize-package-data@6.0.2:
     dependencies:
       hosted-git-info: 7.0.2
-      semver: 7.7.4
+      semver: 7.6.3
       validate-npm-package-license: 3.0.4
 
   normalize-package-data@7.0.1:
@@ -28927,7 +29135,7 @@ snapshots:
   normalize-package-data@8.0.0:
     dependencies:
       hosted-git-info: 9.0.2
-      semver: 7.7.2
+      semver: 7.6.3
       validate-npm-package-license: 3.0.4
 
   normalize-path@2.1.1:
@@ -29212,7 +29420,7 @@ snapshots:
       '@oxfmt/binding-win32-ia32-msvc': 0.45.0
       '@oxfmt/binding-win32-x64-msvc': 0.45.0
 
-  oxlint-plugin-react-doctor@0.6.2:
+  oxlint-plugin-react-doctor@0.7.1:
     dependencies:
       '@typescript-eslint/types': 8.62.1
       eslint-scope: 9.1.2
@@ -29356,10 +29564,10 @@ snapshots:
     dependencies:
       '@tootallnate/quickjs-emscripten': 0.23.0
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       get-uri: 6.0.5
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       pac-resolver: 7.0.1
       socks-proxy-agent: 8.0.5
     transitivePeerDependencies:
@@ -29381,7 +29589,7 @@ snapshots:
       ky: 1.14.3
       registry-auth-token: 5.1.1
       registry-url: 6.0.1
-      semver: 7.7.2
+      semver: 7.6.3
 
   package-manager-detector@1.6.0: {}
 
@@ -29736,6 +29944,26 @@ snapshots:
 
   preact@10.29.1: {}
 
+  precinct@12.2.0:
+    dependencies:
+      '@dependents/detective-less': 5.0.1
+      commander: 12.1.0
+      detective-amd: 6.0.1
+      detective-cjs: 6.1.0
+      detective-es6: 5.0.1
+      detective-postcss: 7.0.1(postcss@8.5.9)
+      detective-sass: 6.0.1
+      detective-scss: 5.0.1
+      detective-stylus: 5.0.1
+      detective-typescript: 14.0.0(typescript@5.9.3)
+      detective-vue2: 2.2.0(typescript@5.9.3)
+      module-definition: 6.0.1
+      node-source-walk: 7.0.1
+      postcss: 8.5.9
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - supports-color
+
   precinct@12.2.0(supports-color@10.2.2):
     dependencies:
       '@dependents/detective-less': 5.0.1
@@ -29931,9 +30159,9 @@ snapshots:
   proxy-agent@6.5.0:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       lru-cache: 7.18.3
       pac-proxy-agent: 7.2.0
       proxy-from-env: 1.1.0
@@ -29971,7 +30199,7 @@ snapshots:
     dependencies:
       '@puppeteer/browsers': 2.3.0
       chromium-bidi: 0.6.3(devtools-protocol@0.0.1312386)
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       devtools-protocol: 0.0.1312386
       ws: 8.20.0
     transitivePeerDependencies:
@@ -30178,19 +30406,19 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  react-doctor@0.6.2(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1):
+  react-doctor@0.7.1(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1):
     dependencies:
       '@babel/code-frame': 7.29.0
       '@sentry/node': 10.63.0(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))
       agent-install: 0.0.5
       conf: 15.1.0
       confbox: 0.2.4
-      deslop-js: 0.6.2
+      deslop-js: 0.7.1
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.4(jiti@2.7.0))
       jiti: 2.7.0
       magicast: 0.5.3
       oxlint: 1.66.0(oxlint-tsgolint@0.21.1)
-      oxlint-plugin-react-doctor: 0.6.2
+      oxlint-plugin-react-doctor: 0.7.1
       prompts: 2.4.2
       typescript: 5.9.3
       vscode-languageserver: 9.0.1
@@ -30229,10 +30457,10 @@ snapshots:
 
   react-fast-compare@3.2.2: {}
 
-  react-grab@0.1.47(react@19.2.5):
+  react-grab@0.1.48(react@19.2.5):
     dependencies:
-      '@react-grab/cli': 0.1.47
-      bippy: 0.5.42(react@19.2.5)
+      '@react-grab/cli': 0.1.48
+      bippy: 0.5.43(react@19.2.5)
     optionalDependencies:
       react: 19.2.5
 
@@ -30331,9 +30559,9 @@ snapshots:
       preact: 10.29.1
       prompts: 2.4.2
       react: 19.2.5
-      react-doctor: 0.6.2(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1)
+      react-doctor: 0.7.1(@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1))(@opentelemetry/exporter-trace-otlp-http@0.203.0(@opentelemetry/api@1.9.1))(eslint@9.39.4(jiti@2.7.0))(oxlint-tsgolint@0.21.1)
       react-dom: 19.2.5(react@19.2.5)
-      react-grab: 0.1.47(react@19.2.5)
+      react-grab: 0.1.48(react@19.2.5)
     optionalDependencies:
       esbuild: 0.27.7
       unplugin: 3.3.0(esbuild@0.27.7)(rolldown@1.0.0-rc.15)(vite@8.0.8(@types/node@24.12.2)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
@@ -30689,6 +30917,14 @@ snapshots:
 
   require-from-string@2.0.2: {}
 
+  require-in-the-middle@7.5.2:
+    dependencies:
+      debug: 4.4.3(supports-color@8.1.1)
+      module-details-from-path: 1.0.4
+      resolve: 1.22.12
+    transitivePeerDependencies:
+      - supports-color
+
   require-in-the-middle@7.5.2(supports-color@10.2.2):
     dependencies:
       debug: 4.4.3(supports-color@10.2.2)
@@ -30699,7 +30935,7 @@ snapshots:
 
   require-in-the-middle@8.0.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       module-details-from-path: 1.0.4
     transitivePeerDependencies:
       - supports-color
@@ -30840,7 +31076,7 @@ snapshots:
 
   router@2.2.0:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       depd: 2.0.0
       is-promise: 4.0.0
       parseurl: 1.3.3
@@ -30951,7 +31187,7 @@ snapshots:
 
   send@1.2.1:
     dependencies:
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       encodeurl: 2.0.0
       escape-html: 1.0.3
       etag: 1.8.1
@@ -31160,7 +31396,7 @@ snapshots:
   socks-proxy-agent@8.0.5:
     dependencies:
       agent-base: 7.1.4
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
       socks: 2.8.7
     transitivePeerDependencies:
       - supports-color
@@ -31825,7 +32061,7 @@ snapshots:
     dependencies:
       '@typescript-eslint/eslint-plugin': 8.58.1(@typescript-eslint/parser@8.58.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       '@typescript-eslint/parser': 8.58.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
-      '@typescript-eslint/typescript-estree': 8.58.1(supports-color@10.2.2)(typescript@5.9.3)
+      '@typescript-eslint/typescript-estree': 8.58.1(typescript@5.9.3)
       '@typescript-eslint/utils': 8.58.1(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
@@ -32039,7 +32275,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
     optionalDependencies:
-      '@netlify/blobs': 10.7.4(supports-color@10.2.2)
+      '@netlify/blobs': 10.7.4
 
   untildify@4.0.0: {}
 
@@ -32391,7 +32627,7 @@ snapshots:
     dependencies:
       chalk: 4.1.2
       commander: 9.5.0
-      debug: 4.4.3(supports-color@10.2.2)
+      debug: 4.4.3(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -32417,7 +32653,7 @@ snapshots:
       '@wdio/types': 9.27.0
       '@wdio/utils': 9.27.0
       deepmerge-ts: 7.1.5
-      https-proxy-agent: 7.0.6(supports-color@10.2.2)
+      https-proxy-agent: 7.0.6
       undici: 6.24.1
       ws: 8.20.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Add dynamic per-article blog OG image generation at `/api/og/blog/$slug` and wire blog metadata to use it for Open Graph and Twitter previews.
- Remove stale `coverImage` frontmatter pointing at missing `cover.png` objects, since covers are now generated dynamically from article metadata.
- Move reachable legacy Supabase blog image references into canonical `articles/<slug>/...` paths and update the affected MDX URLs.

## Why

Several blog posts had missing cover images because old `cover.png` objects were materialized from an older dynamic OG flow and no longer exist in the prod Supabase `blog` bucket. Body images also had a mix of reachable legacy paths and missing legacy slug-root paths. This keeps covers dynamic and leaves the remaining non-cover 404s as a clean replacement queue.

## Validation

- `pnpm --dir apps/web typecheck`
- `pnpm --dir apps/web exec tsx ...renderBlogOgImage smoke test`
- `infisical run --silent --env=prod --projectId=87dad7b5-72a6-4791-9228-b3b86b169db1 --path=/anarlog/web -- pnpm --dir apps/web build`
- Re-ran media audit after stale cover removal: 203 unique non-cover missing images remain across 26 posts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/content and asset URL changes plus a read-only OG image route; no auth, billing, or user data handling changes.
> 
> **Overview**
> Fixes broken blog social previews and stale static cover references by **generating per-post OG images** from article metadata instead of relying on missing `cover.png` assets in Supabase.
> 
> Adds **`/api/og/blog/$slug`** (SVG layout rendered to PNG via **`sharp`**) and wires **`/blog/$slug`** head tags to **`getBlogOgImageUrl`** for Open Graph and Twitter **`summary_large_image`**. Removes **`coverImage`** frontmatter from affected comparison/guide posts so covers are no longer tied to dead bucket paths.
> 
> Updates **inline MDX image URLs** from legacy `/api/assets/blog/...` locations (including shared `blog/` dumps and ad-hoc screenshot paths) to canonical **`/api/assets/blog/articles/<slug>/...`** paths across several long-form articles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 83a91196146280c05887a55858d6b2b855b4ea0c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->