### PR TITLE
Ignore screen recording apps in mic detection

### DIFF
--- a/plugins/detect/src/policy.rs
+++ b/plugins/detect/src/policy.rs
@@ -53,9 +53,21 @@ impl AppCategory {
             ],
             Self::ScreenRecording => &[
                 "so.cap.desktop",
+                "so.cap.desktop.dev",
                 "com.timpler.screenstudio",
                 "com.loom.desktop",
                 "com.obsproject.obs-studio",
+                "pl.maketheweb.cleanshotx",
+                "com.getcleanshot.app-setapp",
+                "com.wulkano.kap",
+                "com.wulkano.kap.helper",
+                "net.telestream.screenflow10",
+                "com.techsmith.camtasia",
+                "com.techsmith.camtasia2024",
+                "com.TechSmith.Snagit",
+                "com.TechSmith.Snagit2024",
+                "com.apple.QuickTimePlayerX",
+                "com.apple.screenshot.launcher",
             ],
             Self::AIAssistant => &[
                 "com.openai.chat",
@@ -226,6 +238,14 @@ mod tests {
         );
         assert_eq!(
             AppCategory::find_category("so.cap.desktop"),
+            Some(AppCategory::ScreenRecording)
+        );
+        assert_eq!(
+            AppCategory::find_category("pl.maketheweb.cleanshotx"),
+            Some(AppCategory::ScreenRecording)
+        );
+        assert_eq!(
+            AppCategory::find_category("com.apple.QuickTimePlayerX"),
             Some(AppCategory::ScreenRecording)
         );
         assert_eq!(

--- a/plugins/detect/tests/mic_detection.rs
+++ b/plugins/detect/tests/mic_detection.rs
@@ -18,6 +18,20 @@ fn aqua_voice() -> hypr_detect::InstalledApp {
     }
 }
 
+fn screen_studio() -> hypr_detect::InstalledApp {
+    hypr_detect::InstalledApp {
+        id: "com.timpler.screenstudio".to_string(),
+        name: "Screen Studio".to_string(),
+    }
+}
+
+fn snagit_2024() -> hypr_detect::InstalledApp {
+    hypr_detect::InstalledApp {
+        id: "com.TechSmith.Snagit2024".to_string(),
+        name: "Snagit 2024".to_string(),
+    }
+}
+
 fn slack() -> hypr_detect::InstalledApp {
     hypr_detect::InstalledApp {
         id: "com.tinyspeck.slackmacgap".to_string(),
@@ -107,6 +121,25 @@ async fn test_filtered_app_no_event() {
         h.take_events().is_empty(),
         "categorized app should not emit MicDetected"
     );
+}
+
+#[tokio::test(start_paused = true)]
+async fn test_screen_recording_app_no_event() {
+    for app in [screen_studio(), snagit_2024()] {
+        let h = Harness::new();
+
+        h.mic_started(app);
+        assert!(
+            h.take_events().is_empty(),
+            "screen recording app should not start a timer"
+        );
+
+        h.advance_secs(15).await;
+        assert!(
+            h.take_events().is_empty(),
+            "screen recording app should not emit MicDetected"
+        );
+    }
 }
 
 #[tokio::test(start_paused = true)]


### PR DESCRIPTION
Expand the default ignored bundle IDs for screen recording tools and cover Screen Studio with a mic detection test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Allowlist-only change to mic-detection filtering with matching tests; no auth, data, or core pipeline logic altered.
> 
> **Overview**
> Mic detection will no longer start timers or emit **MicDetected** for a wider set of macOS screen-capture tools by growing the **`ScreenRecording`** bundle-ID allowlist.
> 
> **Newly ignored IDs** include Cap dev, CleanShot X (direct and Setapp), Kap (+ helper), ScreenFlow 10, Camtasia/Snagit (2024 variants), QuickTime Player X, and the screenshot launcher—alongside existing entries like Screen Studio, Loom, and OBS.
> 
> Coverage adds **`AppCategory`** unit assertions for CleanShot and QuickTime, plus an integration test that **Screen Studio** and **Snagit 2024** never schedule or fire mic-detection events.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c3b97154b798405dfea4b008f5566d80d858ba36. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->