### PR TITLE
Polish blog article CTA

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -1,7 +1,7 @@
 import { MDXContent } from "@content-collections/mdx/react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { type Article, allArticles } from "content-collections";
-import { Download } from "lucide-react";
+import { ArrowRight } from "lucide-react";
 import type { ComponentProps } from "react";
 
 import { mdxComponents } from "@/components/mdx-components";
@@ -109,7 +109,7 @@ function Component() {
           <MDXContent code={article.mdx} components={blogMdxComponents} />
         </article>
 
-        <BlogDownloadCta />
+        <BlogArticleCta />
       </div>
 
       <SiteFooter />
@@ -125,11 +125,11 @@ function BlogTable({ children, ...props }: ComponentProps<"table">) {
   );
 }
 
-function BlogDownloadCta() {
+function BlogArticleCta() {
   return (
     <aside
-      aria-label="Download Anarlog"
-      className="mt-20 border-y border-[#eee8df] bg-[#faf7f1] px-5 py-8 md:px-7"
+      aria-label="Try Anarlog for free"
+      className="border-color-subtle mt-20 border-y bg-[#faf7f1] px-5 py-8 md:px-7"
     >
       <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
         <div>
@@ -137,15 +137,15 @@ function BlogDownloadCta() {
             Take notes without inviting a bot
           </p>
           <p className="mt-3 max-w-xl text-base leading-7 text-[#4f4940]">
-            Download Anarlog for private, local-first meeting notes on your Mac.
+            Try Anarlog for private, local-first meeting notes on your Mac.
           </p>
         </div>
         <Link
           to="/download/"
           className="inline-flex h-12 shrink-0 items-center justify-center gap-2 rounded-full bg-[#181613] px-5 text-sm font-semibold text-white transition-colors hover:bg-[#363029]"
         >
-          <Download size={17} strokeWidth={2.2} aria-hidden="true" />
-          Download app
+          Try for free
+          <ArrowRight size={17} strokeWidth={2.2} aria-hidden="true" />
         </Link>
       </div>
     </aside>


### PR DESCRIPTION
Add article CTA horizontal border token styling and switch the download button copy to try for free.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5929
- <kbd>&nbsp;1&nbsp;</kbd> #5928 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blog-only copy, styling, and icon changes with no auth, data, or routing logic changes beyond the same download link.
> 
> **Overview**
> The blog post footer CTA is renamed from **`BlogDownloadCta`** to **`BlogArticleCta`** and reframed around a free trial instead of a download.
> 
> The aside uses the shared **`border-color-subtle`** token instead of a hardcoded border color, and accessibility/copy now say **“Try Anarlog for free”** (including the supporting line). The primary button still links to **`/download/`** but shows **“Try for free”** with an **`ArrowRight`** icon instead of **“Download app”** with a download icon.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7d82c523ddba4efc56d738d198ee51c062d8fd83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->