### PR TITLE
Tighten blog table rendering

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -2,7 +2,14 @@ import { MDXContent } from "@content-collections/mdx/react";
 import { createFileRoute, Link, notFound } from "@tanstack/react-router";
 import { type Article, allArticles } from "content-collections";
 import { ArrowRight } from "lucide-react";
-import type { ComponentProps } from "react";
+import {
+  Children,
+  cloneElement,
+  isValidElement,
+  type ComponentProps,
+  type ReactElement,
+  type ReactNode,
+} from "react";
 
 import { mdxComponents } from "@/components/mdx-components";
 import { SiteFooter } from "@/components/site-footer";
@@ -119,10 +126,99 @@ function Component() {
 
 function BlogTable({ children, ...props }: ComponentProps<"table">) {
   return (
-    <div className="my-8 overflow-x-auto">
-      <table {...props}>{children}</table>
+    <div className="my-6 overflow-x-auto">
+      <table {...props}>{normalizeTableChildren(children)}</table>
     </div>
   );
+}
+
+type ElementWithChildren = ReactElement<{ children?: ReactNode }>;
+
+function normalizeTableChildren(children: ReactNode) {
+  return Children.toArray(children).map((child) => {
+    const element = getElementWithChildren(child);
+
+    if (!element) {
+      return child;
+    }
+
+    if (element.type === "thead") {
+      const rows = Children.toArray(element.props.children);
+      return rows.length > 0 && rows.every(isBlankTableRow) ? null : child;
+    }
+
+    if (element.type !== "tbody") {
+      return child;
+    }
+
+    const rows = Children.toArray(element.props.children);
+    const visibleRows = rows.filter((row) => !isBlankTableRow(row));
+
+    if (visibleRows.length === rows.length) {
+      return child;
+    }
+
+    return visibleRows.length > 0
+      ? cloneElement(element, undefined, visibleRows)
+      : null;
+  });
+}
+
+function isBlankTableRow(row: ReactNode) {
+  const element = getElementWithChildren(row);
+
+  if (!element || element.type !== "tr") {
+    return false;
+  }
+
+  const cells = Children.toArray(element.props.children);
+  return cells.length > 0 && cells.every(isBlankTableCell);
+}
+
+function isBlankTableCell(cell: ReactNode) {
+  const element = getElementWithChildren(cell);
+
+  if (!element || (element.type !== "td" && element.type !== "th")) {
+    return false;
+  }
+
+  return isBlankNode(element.props.children);
+}
+
+function isBlankNode(node: ReactNode): boolean {
+  if (node === null || node === undefined || typeof node === "boolean") {
+    return true;
+  }
+
+  if (typeof node === "string" || typeof node === "number") {
+    return (
+      String(node)
+        .replace(/\u00a0/g, " ")
+        .trim() === ""
+    );
+  }
+
+  const element = getElementWithChildren(node);
+  if (element) {
+    const { children } = element.props;
+
+    if (
+      children === null ||
+      children === undefined ||
+      typeof children === "boolean"
+    ) {
+      return false;
+    }
+
+    return isBlankNode(children);
+  }
+
+  const children = Children.toArray(node);
+  return children.length === 0 || children.every(isBlankNode);
+}
+
+function getElementWithChildren(node: ReactNode): ElementWithChildren | null {
+  return isValidElement<{ children?: ReactNode }>(node) ? node : null;
 }
 
 function BlogArticleCta() {

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -769,14 +769,14 @@
   min-width: 100%;
   width: max-content;
   border-collapse: separate;
-  border-spacing: 0 0.375rem;
+  border-spacing: 0 0.25rem;
   font-family: var(--font-sans);
   white-space: nowrap;
 }
 
 .blog-prose
   :where(th):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  padding: 0.75rem;
+  padding: 0.625rem 0.75rem;
   background: #eee7db;
   color: #4f4940;
   font-family: var(--font-sans);
@@ -788,7 +788,7 @@
 
 .blog-prose
   :where(td):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
-  padding: 0.875rem 0.75rem;
+  padding: 0.625rem 0.75rem;
   background: #faf7f1;
   color: #363029;
   font-family: var(--font-sans);


### PR DESCRIPTION
Hide fully blank markdown table rows in blog articles and reduce table spacing for a denser article layout.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5929 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5928
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Blog-only presentation and MDX table normalization; no auth, data, or API changes. Edge case: a row with only non-text React content could be misclassified as blank.
> 
> **Overview**
> Blog articles now **strip fully empty markdown table rows** at render time via a custom `BlogTable` MDX component that walks `thead`/`tbody` children and drops rows whose cells are only whitespace (including `&nbsp;`).
> 
> **Layout tweaks:** table wrapper margin goes from `my-8` to `my-6`, and `.blog-prose` table styles use tighter row spacing (`border-spacing` 0.375rem → 0.25rem) and reduced `th`/`td` padding for a denser table look.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6395b6f330e6a140ab349cd2d3e40734339f3953. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->