### PR TITLE
Remove blog image borders

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -105,7 +105,7 @@ function Component() {
           </aside>
         )}
 
-        <article className="blog-prose prose prose-stone prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md prose-img:border prose-img:border-[#eee8df] max-w-none">
+        <article className="blog-prose prose prose-stone prose-headings:font-hand prose-headings:font-semibold prose-headings:text-[#756b5d] prose-p:text-[#363029] prose-a:text-[#181613] prose-a:underline hover:prose-a:text-[#4f4940] prose-strong:text-[#181613] prose-li:text-[#363029] prose-img:rounded-md max-w-none">
           <MDXContent code={article.mdx} components={blogMdxComponents} />
         </article>
 


### PR DESCRIPTION
Drop the article prose image border styling while keeping rounded image corners.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on blog article images only; no logic, data, or security impact.
> 
> **Overview**
> Blog post article prose no longer applies a border to inline images in MDX content.
> 
> The `article` wrapper in `apps/web/src/routes/blog/$slug.tsx` drops the Tailwind `prose-img:border` and `prose-img:border-[#eee8df]` utilities while **keeping** `prose-img:rounded-md`, so images stay rounded but without the light frame.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71f1f2ce2773e805e36353cc1b317b94495a035f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->