### PR TITLE
Polish blog code blocks

### DIFF
--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -734,6 +734,31 @@
 }
 
 .blog-prose
+  :where(pre):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  margin-top: 1.5rem;
+  margin-bottom: 1.5rem;
+  overflow-x: hidden;
+  border-radius: 0.375rem;
+  background: #2b2523;
+  padding: 1rem 1.125rem;
+}
+
+.blog-prose
+  :where(pre code):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
+  display: block;
+  overflow-wrap: anywhere;
+  border-radius: 0;
+  background: transparent;
+  padding: 0;
+  color: #f8f4ef;
+  font-family: var(--font-mono);
+  font-size: 0.9375rem;
+  line-height: 1.65;
+  white-space: pre-wrap;
+  word-break: normal;
+}
+
+.blog-prose
   :where(p, li):not(:where([class~="not-prose"], [class~="not-prose"] *)) {
   font-size: 1.125rem;
   line-height: 1.6;


### PR DESCRIPTION
Render fenced article code as wrapped dark panels instead of inline-code pills inside pre blocks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only CSS scoped to blog prose; no logic, data, or security impact.
> 
> **Overview**
> Blog article fenced code (`pre` / `pre code` under `.blog-prose`) now renders as **dark rounded panels** instead of inheriting generic inline-code pill styling inside `pre` blocks.
> 
> `pre` gets vertical spacing, hidden horizontal overflow, `#2b2523` background, and padding. Nested `code` is block-level with transparent background, light monospace text, and **`pre-wrap`** so long lines wrap in the panel rather than forcing horizontal scroll.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b8f3d5202a72326c0e985f7cf4bff457150c0e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->