### PR TITLE
[ANLG-113] Refresh meeting minutes software post

### DIFF
--- a/apps/web/content/articles/meeting-minutes-software.mdx
+++ b/apps/web/content/articles/meeting-minutes-software.mdx
@@ -1,29 +1,47 @@
 ---
 meta_title: "Best Meeting Minutes Software in 2026"
-meta_description: "Compare the best meeting minutes software for 2026. We tested AI and manual tools to find the top solutions for note-taking, collaboration, and governance."
+meta_description: "Compare the best meeting minutes software for 2026, including AI notetakers, board portals, transcript search, privacy-first workflows, and team collaboration tools."
 author: "Harshika"
 featured: false
 category: "Comparisons"
-date: "2026-01-10"
+date: "2026-07-07"
 ---
 
-If you're worried about missing important details while taking minutes of the meeting, here are some tools you'll find useful. 
+Meeting minutes software now covers a wide range of jobs: AI summaries, formal board minutes, searchable transcript archives, CRM follow-up, collaborative agendas, and private local note-taking.
+
+The best choice depends less on "which AI writes the prettiest summary" and more on the workflow around the meeting. Do you need a bot in every call? Do minutes need approval? Will recordings contain sensitive customer or board information? Does your team need a searchable archive, or do you just need clean minutes that can live as files?
+
+This guide compares the strongest options for 2026 and calls out where Anarlog fits for teams that want AI meeting minutes without giving up control over their data.
+
+![Private meeting minutes workflow](/api/assets/blog/articles/meeting-minutes-software/meeting-minutes-workflow.png)
+
+## How to choose meeting minutes software
+
+Before comparing tools, decide which workflow you are buying:
+
+- **Private AI minutes** if meetings include sensitive internal, customer, legal, or product conversations.
+- **Collaborative agendas** if the real problem is preparation, recurring meeting structure, and action-item accountability.
+- **Board or governance minutes** if approvals, voting, audit trails, and document control matter more than AI summaries.
+- **Sales or customer-call notes** if CRM sync, clips, and revenue-team workflows are the priority.
+- **Searchable archives** if the main value is finding what someone said months later.
+
+For sensitive teams, privacy architecture matters as much as features. A tool that joins as a cloud bot and stores every transcript remotely is a very different product from a local-first tool that records system audio without joining the meeting.
 
 ## Meeting minutes software comparison
 
-| &nbsp;         | &nbsp;                         | &nbsp;                      |
-| -------------- | ------------------------------ | --------------------------- |
-| **Tool**       | **Best For**                   | **Starting Price**          |
-| Anarlog           | Control over data and AI stack | Free. $25/month for Pro     |
-| Fellow         | Remote Teams                   | $7/user/mo                  |
-| MeetGeek       | Sales Teams                    | $19/user/mo                 |
-| Diligent       | Board Meetings                 | Custom                      |
-| Fireflies.ai   | Transcription                  | $10/user/mo                 |
-| Beenote        | Structured Meetings            | $552/yr (10 users)          |
-| MeetingBooster | Enterprise                     | Custom                      |
-| Fathom         | CRM Integration                | Free. $20/month for Premium |
-| tl;dv          | Video recordings               | Free. $18/month for Pro     |
+| Tool | Best for | Recording style | Starting price |
+| --- | --- | --- | --- |
+| Anarlog | Private AI minutes and local-first workflows | No bot; desktop system-audio capture | Free; Pro is $15/month or $150/year |
+| Fellow | Collaborative agendas and team meeting workflows | Meeting assistant plus workspace workflow | Free; Team starts at $7/user/month billed annually |
+| MeetGeek | Conversation intelligence and sales/team analytics | Meeting bot plus browser/desktop recording options | Free; Pro starts at $9.99/user/month |
+| Diligent | Board meetings and governance | Board portal workflow | Custom |
+| Fireflies.ai | Searchable transcription archive | Bot-based recording plus desktop/mobile apps | Free; Pro starts at $10/seat/month billed annually |
+| Beenote | Structured agendas and manual minutes | Collaborative meeting-management workflow | $552/year for 10 users |
+| MeetingBooster | Formal enterprise meeting management | Structured agenda/minutes workflow | Custom |
+| Fathom | Sales calls and CRM follow-up | Bot-based recording | Free; Premium starts at $16/user/month billed annually |
+| tl;dv | Video recordings, clips, and call libraries | Bot-based video recording | Free; paid plans available |
 
+Prices change often, so treat this table as a planning snapshot and verify vendor pricing before buying.
 
 ## Detailed reviews of meeting minutes software
 
@@ -37,7 +55,9 @@ You decide if your audio, transcripts, or notes ever leave your device. You pick
 
 #### How it works
 
-Anarlog captures system audio without joining meetings as a bot. During meetings, it transcribes conversations in real-time and combines any notes you've taken with transcripts to create a summary when the meeting ends.
+Anarlog captures system audio without joining meetings as a bot. During meetings, it transcribes conversations in real time and combines any notes you've taken with the transcript to create a summary when the meeting ends.
+
+That makes it useful for calls where a visible recording bot would be awkward: executive conversations, internal planning, product reviews, customer calls, or any meeting where you want AI help without changing the room.
 
 #### Key Features
 
@@ -59,13 +79,13 @@ Anarlog captures system audio without joining meetings as a bot. During meetings
 
 #### Cons
 
-- macOS only currently; Windows and Linux versions coming in Q2 2026
+- Mac-first today, so cross-platform teams should confirm device coverage before rollout
 - No video recordings 
 - No built-in CRM integrations (though files export to anything)
 
 #### Pricing
 
-Unlimited free plan with local transcription or bring-your-own-key. Pro is $25/month for managed cloud service.
+Free plan with local transcription and bring-your-own-key workflows. Pro is $15/month or $150/year for hosted transcription, hosted AI models, calendar connections, speaker identification, and advanced workflow features.
 
 ### 2. Fellow - for remote teams
 
@@ -90,19 +110,19 @@ Unlike tools that focus only on transcription, Fellow handles collaborative meet
 - Strong collaborative features with shared agendas and real-time editing
 - Enterprise-grade security (SOC 2, GDPR, HIPAA compliance)
 - Excellent for recurring meetings with templates and context continuity
-- 92-language transcription support for global teams
+- Multi-language transcription support for global teams
 
 #### Cons
 
 - Bot-based recording joins as visible participant
 - Cloud-only processing with no on-premises option
-- Free plan limited to 10 AI recordings per month
+- Free plan is useful for trying the workflow, but serious team usage belongs on a paid plan
 - Online meetings only; doesn't work for in-person conversations
 - Internal meeting focus makes it less robust than dedicated sales intelligence tools
 
 #### Pricing
 
-Free plan includes 10 AI recordings per user per month. Paid plans start at $7/user/month (3-user minimum) for Pro, and go up to $25/user/month for Business with full admin controls and HIPAA compliance.
+Free plan is available. Team starts at $7/user/month billed annually, and Business adds org-wide controls at $15/user/month billed annually.
 
 ### 3. MeetGeek - for conversation intelligence and sales teams
 
@@ -118,7 +138,7 @@ It captures data-driven insights into communication patterns, not just meeting n
 - **Team spaces and analytics** organize meetings by department with performance metrics tracking engagement, sentiment, and effectiveness at team and individual levels
 - **Automated workflows** let you set rules to auto-share meeting records with specific teams based on meeting type, pushing summaries to CRMs and task management tools
 - **Custom speech models** on the enterprise tier train the transcription system on your industry-specific terminology for better accuracy
-- **50+ language support** with automatic language detection and 95%+ transcription accuracy
+- **100+ language support** with automatic language detection
 - **Mobile apps** let you record and summarize in-person meetings on iOS and Android, even offline
 
 #### Pros
@@ -127,17 +147,17 @@ It captures data-driven insights into communication patterns, not just meeting n
 - Strong compliance certifications (SOC 2, GDPR, CCPA, HIPAA-ready)
 - Extensive integration ecosystem (7,000+ apps via Zapier)
 - Custom speech models for specialized industries
+- No-bot recording options via browser and desktop app
 
 #### Cons
 
-- Bot-based only, which can feel intrusive in sensitive conversations
-- Aggressive storage limits on lower tiers (free keeps transcripts only 3 months)
-- 100-hour monthly limit on Business tier means high-volume teams need Enterprise
+- Bot-based recording is still part of the default workflow for many teams
+- Hour limits on lower tiers mean heavy meeting teams should model usage before buying
 - Cloud-only processing with no on-premises option
 
 #### Pricing
 
-Free plan includes 5 hours of transcription per month with 3 months of transcript storage and 1 month of audio storage. Paid plans start at $19/user/month for Pro with unlimited transcription.
+Free plan is available. Pro starts at $9.99/user/month and includes 20 hours of transcription per month.
 
 ### 4. Diligent - for board meeting minutes
 
@@ -198,13 +218,13 @@ Diligent offers custom pricing based on organization size and requirements. Cont
 #### Cons
 
 - Bot-based recording joins as visible participant
-- Free tier has restrictive storage limits (transcripts kept only 3 months)
-- 100-hour monthly limit on Business tier
+- Free tier has storage and feature limits compared with paid plans
+- Heavy teams should review storage, credit, and admin limits before rollout
 - Cloud-only processing with no local option
 
 #### Pricing
 
-Free plan includes 800 minutes of storage with 3 months of transcript retention and 1 month of audio storage. Pro plan starts at $10/user/month with unlimited transcription. Business plan at $19/user/month includes advanced analytics. Enterprise pricing is custom.
+Free plan is available. Pro starts at $10/seat/month billed annually, Business starts at $19/seat/month billed annually, and Enterprise is listed at $39/seat/month billed annually.
 
 ### 6. Beenote - for collaborative agenda building and governance
 
@@ -282,7 +302,7 @@ MeetingBooster offers custom pricing based on organization size and needs. They 
 #### Key features
 
 - **Automatic CRM logging** syncs meeting summaries automatically to Salesforce, HubSpot, and Close after every call
-- **Free forever plan** offers unlimited meetings, unlimited transcription, completely free for individuals
+- **Free plan** offers unlimited recordings and transcriptions, with advanced AI summaries limited on the free tier
 - **Instant highlights** let you click a button during meetings to create timestamped highlights of important moments
 - **AI-generated summaries** provide automatic summaries with key points, action items, and next steps
 - **Multi-language support** transcribes meetings in 28 languages
@@ -290,7 +310,7 @@ MeetingBooster offers custom pricing based on organization size and needs. They 
 
 #### Pros
 
-- Completely free for unlimited meetings
+- Strong free plan for individuals
 - Excellent CRM integration eliminates manual data entry
 - Simple, clean interface with minimal setup required
 - Fast AI processing—summaries available within minutes
@@ -304,7 +324,7 @@ MeetingBooster offers custom pricing based on organization size and needs. They 
 
 #### Pricing
 
-Free forever for individuals with unlimited meetings and transcription. Team plans available with additional collaboration features and admin controls.
+Free plan is available. Premium starts at $16/user/month billed annually, and Team starts at $15/user/month billed annually with a two-user minimum.
 
 ### 9. tl;dv - free meeting recorder with AI summaries
 
@@ -326,18 +346,18 @@ Free forever for individuals with unlimited meetings and transcription. Team pla
 - Truly unlimited recordings on free plan (no monthly hour caps)
 - Video clip feature makes it easy to share key moments
 - Simple, intuitive interface with minimal setup
-- Works well for both Zoom and Google Meet
+- Works well for major video-meeting tools
 
 #### Cons
 
 - Bot-based recording joins as visible participant
-- Limited to Zoom and Google Meet only
+- Platform support is strongest for the major video-meeting tools
 - Advanced features like custom vocabulary require paid plans
 - Cloud-only processing with no local option
 
 #### Pricing
 
-Free plan includes unlimited recordings and AI summaries. Pro plan starts at $18/user/month with additional features like speaker insights, custom branding, and advanced integrations.
+Free plan includes unlimited meetings and AI notes. Paid plans add more advanced collaboration, coaching, and integration features.
 
 ## Key features that matter in meeting minutes software
 
@@ -405,6 +425,8 @@ The difference between a searchable meeting archive and 100 unsearchable documen
 
 ## Our top recommendation
 
-If you value both functionality and control, Anarlog is worth a look. You get AI-powered features without giving up ownership of your data, and you can export everything as plain markdown with zero lock-in.
+If you value both functionality and control, Anarlog is worth a look. You get AI-powered meeting minutes without giving up ownership of your data, and you can export everything as plain markdown with zero lock-in.
 
-You can try the tool out for free. If it's not for you, export everything and walk away.
+That privacy tradeoff matters more as meeting notes become a long-term company memory. If you are comparing bot-based tools, also read our guide to [local AI privacy tools](/blog/local-ai-privacy-tools) and our breakdown of whether [Fireflies.ai is safe](/blog/is-fireflies-ai-safe).
+
+You can try Anarlog for free. If it is not for you, export everything and walk away.


### PR DESCRIPTION
## Summary
- Refreshes the meeting-minutes-software article intro, selection criteria, comparison table, and CTA.
- Updates stale Anarlog pricing to Free plus Pro at $15/month or $150/year.
- Adds the Supabase-hosted Napkin workflow figure to the post.
- Keeps existing section images and verifies all body image URLs resolve.

## SEO signal
- Primary keyword: meeting minutes software.
- Semrush: volume 1000, KD 39, Anarlog around position 11.
- SERP check showed Anarlog just outside page-one upper results, so this is a refresh-for-top-5 candidate.

## Validation
- dprint check --config dprint.json apps/web/content/articles/meeting-minutes-software.mdx
- pnpm --dir apps/web typecheck
- Infisical prod env + pnpm --dir apps/web build
- Verified all 10 body image URLs return 200 image/png through the production asset proxy.

Notes: local build without Infisical failed at prerender because required prod env vars were missing; rerunning with Infisical prod env passed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only MDX changes with no app logic; main risk is outdated third-party pricing or claims if vendors change plans.
> 
> **Overview**
> **SEO and content refresh** for the `meeting-minutes-software` comparison post: updated meta description, publication date (`2026-07-07`), and a workflow-first intro that frames tool choice around bots, governance, sensitivity, and archives—not just AI polish.
> 
> Adds a **“How to choose meeting minutes software”** section (private AI, agendas, board/governance, sales/CRM, searchable archives) and a **workflow figure** (`meeting-minutes-workflow.png`). The comparison table now includes **recording style** and refreshed **starting prices** for all nine tools, plus a disclaimer to verify vendor pricing.
> 
> **Anarlog** copy is updated: Pro **$15/month or $150/year** (was $25/month), expanded “how it works” and Mac-first caveat, and richer Pro feature list. Competitor sections get **revised pricing** (e.g. MeetGeek, Fellow, Fireflies, Fathom) and toned-down/limit-focused cons where specifics were stale.
> 
> The closing CTA adds **internal links** to local AI privacy and Fireflies safety articles.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33657e60163b454eefa9376240654ee1c02be8df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->