### PR TITLE
Add desktop 1.1.9 changelog

### DIFF
--- a/packages/changelog/content/1.1.9.md
+++ b/packages/changelog/content/1.1.9.md
@@ -1,0 +1,14 @@
+---
+date: "2026-07-07"
+summary: "Anarlog now shows a simpler Free and Pro plan model, with steadier note typing for IME users."
+---
+
+## Plans
+
+- Account and billing screens now show Free and Pro only
+- Existing paid users are treated as Pro, including accounts that were previously on Lite
+- Pro includes hosted transcription, hosted AI, and calendar connections under one plan
+
+## Notes
+
+- Typing with CJK and other IME keyboards stays more stable while editing note titles and content


### PR DESCRIPTION
## Summary
- add the 1.1.9 desktop changelog for the Free/Pro plan cleanup
- mention IME/title typing stability from the release range

## Verification
- pnpm exec dprint fmt
- pnpm -F @hypr/changelog typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no application or billing logic changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.9.md`** for the desktop **1.1.9** release (dated 2026-07-07).
> 
> The entry documents **Plans**: account and billing show **Free** and **Pro** only, existing paid users (including former Lite) map to **Pro**, and Pro bundles hosted transcription, hosted AI, and calendar connections. **Notes** calls out more stable typing for CJK and other IME keyboards in note titles and body.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 668209de726e537b6aa9a7cc072bef77d0ece9f5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->