### PR TITLE
Highlight pro pricing card

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -496,10 +496,10 @@ function PricingCard({ plan }: { plan: MarketingPlanData }) {
   return (
     <article
       className={cn([
-        "flex min-h-[30rem] flex-col rounded-[3px] border bg-white p-6 shadow-[0_16px_46px_rgba(24,22,19,0.08)]",
+        "flex min-h-[30rem] flex-col rounded-[3px] border bg-white p-6 transition-all duration-200",
         plan.popular
-          ? "border-neutral-200"
-          : "border-neutral-200 shadow-[0_10px_32px_rgba(24,22,19,0.05)]",
+          ? "border-[#181613]/30 shadow-[0_22px_60px_rgba(24,22,19,0.14)] ring-1 ring-[#181613]/10"
+          : "border-neutral-200 opacity-[0.58] shadow-[0_10px_32px_rgba(24,22,19,0.05)] focus-within:opacity-100 focus-within:shadow-[0_16px_46px_rgba(24,22,19,0.08)] hover:opacity-100 hover:shadow-[0_16px_46px_rgba(24,22,19,0.08)]",
       ])}
     >
       <div className="flex items-start">


### PR DESCRIPTION
Dim the free pricing card by default and restore emphasis on hover or focus.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only Tailwind class changes on the marketing homepage pricing section; no pricing logic or checkout behavior.
> 
> **Overview**
> Updates **`PricingCard`** styling on the landing page so the **Pro** tier (`plan.popular`) reads as the primary option with a stronger border, deeper shadow, and a subtle ring.
> 
> The **non-popular** (free) card is **dimmed by default** (`opacity-[0.58]`) and returns to full emphasis on **hover** or **focus-within**, with shared `transition-all duration-200` for the visual change.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b248aaa502fe943da024dd99987f4355bee1ce9d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->