### PR TITLE
Remove blog image borders

### DIFF
--- a/apps/web/src/components/mdx-components.tsx
+++ b/apps/web/src/components/mdx-components.tsx
@@ -13,7 +13,7 @@ function Image({
     <img
       src={src}
       alt={alt ?? ""}
-      className="my-6 w-full rounded-md border border-neutral-200"
+      className="my-6 w-full rounded-md"
       {...rest}
     />
   );


### PR DESCRIPTION
Drops the default MDX image border so blog screenshots render without a frame.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-class styling change on MDX images only; no logic, data, or security impact.
> 
> **Overview**
> Blog and other MDX content will render **inline images without a neutral border frame**.
> 
> The shared MDX `Image` / `img` component drops `border border-neutral-200` from its Tailwind classes while keeping spacing, full width, and rounded corners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10c9a51be08e989c35b6d3132c7988a86ef4fdba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->