### PR TITLE
Fix blog CTA card border

### DIFF
--- a/apps/web/src/routes/blog/$slug.tsx
+++ b/apps/web/src/routes/blog/$slug.tsx
@@ -226,7 +226,7 @@ function BlogArticleCta() {
   return (
     <aside
       aria-label="Try Anarlog for free"
-      className="border-color-subtle mt-20 border-y bg-[#faf7f1] px-5 py-8 md:px-7"
+      className="border-color-subtle mt-20 rounded-sm border bg-[#faf7f1] px-5 py-8 md:px-7"
     >
       <div className="flex flex-col gap-5 md:flex-row md:items-center md:justify-between">
         <div>


### PR DESCRIPTION
Add full border and small radius to the blog article CTA card.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single Tailwind class change on a marketing CTA; no logic, routing, or data impact.
> 
> **Overview**
> Updates the **blog article CTA** (`BlogArticleCta`) so the promo aside reads as a contained card instead of a horizontal band.
> 
> The aside **drops** `border-y` (top/bottom only) in favor of a **full** `border` on all sides, and adds **`rounded-sm`** for a slight corner radius. Layout, copy, and download link are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 63188de60565e36ce2c9501894e94c2e347250be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->