### PR TITLE
Resolve live transcript speaker names

### DIFF
--- a/apps/desktop/src/meeting-float/host.test.ts
+++ b/apps/desktop/src/meeting-float/host.test.ts
@@ -12,6 +12,7 @@ import {
 } from "./host";
 
 import { createListenerStore } from "~/store/zustand/listener";
+import type { RenderLabelContext } from "~/stt/live-segment";
 
 type ListenerLiveState = ReturnType<
   ReturnType<typeof createListenerStore>["getState"]
@@ -293,20 +294,54 @@ describe("getFloatingTranscriptBubbles", () => {
     ]);
   });
 
+  it("labels remote bubbles as the unique other participant", () => {
+    const ctx: RenderLabelContext = {
+      getSelfHumanId: () => "self",
+      getHumanName: (id) => (id === "remote" ? "Artem" : undefined),
+      getParticipantHumanIds: () => ["self", "remote"],
+    };
+    const bubbles = getFloatingTranscriptBubbles(
+      [
+        createSegment({
+          id: "remote",
+          key: {
+            channel: "RemoteParty",
+            speaker_index: 0,
+            speaker_human_id: null,
+          },
+          start_ms: 0,
+          text: "hello",
+          words: [{ text: "hello" }],
+        }),
+      ],
+      ctx,
+    );
+
+    expect(bubbles[0]?.speakerLabel).toBe("Artem");
+  });
+
   it("labels assigned direct-mic bubbles as self", () => {
-    const bubbles = getFloatingTranscriptBubbles([
-      createSegment({
-        id: "assigned-mic",
-        key: {
-          channel: "DirectMic",
-          speaker_index: 1,
-          speaker_human_id: "participant-1",
-        },
-        start_ms: 0,
-        text: "hello",
-        words: [{ text: "hello" }],
-      }),
-    ]);
+    const ctx: RenderLabelContext = {
+      getSelfHumanId: () => "self",
+      getHumanName: (id) => (id === "participant-1" ? "Artem" : undefined),
+      getParticipantHumanIds: () => ["self", "participant-1"],
+    };
+    const bubbles = getFloatingTranscriptBubbles(
+      [
+        createSegment({
+          id: "assigned-mic",
+          key: {
+            channel: "DirectMic",
+            speaker_index: 1,
+            speaker_human_id: "participant-1",
+          },
+          start_ms: 0,
+          text: "hello",
+          words: [{ text: "hello" }],
+        }),
+      ],
+      ctx,
+    );
 
     expect(bubbles).toEqual([
       {

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -11,6 +11,8 @@ import { useConfigValue } from "~/shared/config";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import * as settingsStore from "~/store/tinybase/store/settings";
 import { listenerStore } from "~/store/zustand/listener/instance";
+import { SegmentKeyUtils, type RenderLabelContext } from "~/stt/live-segment";
+import { defaultRenderLabelContext } from "~/stt/segment/shared";
 
 type ListenerState = ReturnType<typeof listenerStore.getState>;
 export type SettingsStore = NonNullable<
@@ -303,6 +305,17 @@ function FloatingMeetingWindowSync({
       routeState = nextRouteState;
       scheduleSync();
     };
+    const refreshCurrentRouteState = () => {
+      updateRouteState(
+        getCurrentFloatingRouteState(
+          listenerStore.getState(),
+          undefined,
+          settings,
+          getFloatingLiveCaptionToggleVisible(listenerStore.getState(), store),
+          main,
+        ),
+      );
+    };
 
     const sync = async () => {
       if (!shouldContinue()) {
@@ -386,6 +399,7 @@ function FloatingMeetingWindowSync({
           store,
         ),
         sessionTitle: getFloatingSessionTitle(state, main),
+        speakerLabelContext: getFloatingSpeakerLabelContext(state, main),
       });
       const previousRouteState = getFloatingRouteState(previousState, {
         colorScheme,
@@ -395,6 +409,10 @@ function FloatingMeetingWindowSync({
           store,
         ),
         sessionTitle: getFloatingSessionTitle(previousState, main),
+        speakerLabelContext: getFloatingSpeakerLabelContext(
+          previousState,
+          main,
+        ),
       });
 
       if (!isSameFloatingRouteState(nextRouteState, previousRouteState)) {
@@ -423,32 +441,19 @@ function FloatingMeetingWindowSync({
       "sessions",
       null,
       "title",
-      () => {
-        updateRouteState(
-          getCurrentFloatingRouteState(
-            listenerStore.getState(),
-            undefined,
-            settings,
-            getFloatingLiveCaptionToggleVisible(
-              listenerStore.getState(),
-              store,
-            ),
-            main,
-          ),
-        );
-      },
+      refreshCurrentRouteState,
+    );
+    const participantListenerId = main?.addTableListener(
+      "mapping_session_participant",
+      refreshCurrentRouteState,
+    );
+    const humanListenerId = main?.addTableListener(
+      "humans",
+      refreshCurrentRouteState,
     );
 
     const unsubscribeAppliedTheme = subscribeToAppliedTheme(() => {
-      const nextRouteState = getCurrentFloatingRouteState(
-        listenerStore.getState(),
-        undefined,
-        settings,
-        getFloatingLiveCaptionToggleVisible(listenerStore.getState(), store),
-        main,
-      );
-
-      updateRouteState(nextRouteState);
+      refreshCurrentRouteState();
     });
 
     return () => {
@@ -458,6 +463,12 @@ function FloatingMeetingWindowSync({
       removeSettingsListeners(store, settingsListenerIds);
       if (sessionTitleListenerId) {
         main?.delListener(sessionTitleListenerId);
+      }
+      if (participantListenerId) {
+        main?.delListener(participantListenerId);
+      }
+      if (humanListenerId) {
+        main?.delListener(humanListenerId);
       }
       unlisteners.forEach((unlisten) => unlisten());
       void hideFloatingMeetingPanel();
@@ -475,12 +486,14 @@ export function getFloatingRouteState(
     settings = DEFAULT_FLOATING_OVERLAY_SETTINGS,
     liveCaptionToggleVisible = false,
     sessionTitle,
+    speakerLabelContext,
   }: {
     sessionId?: string;
     colorScheme?: FloatingBarColorScheme;
     settings?: FloatingOverlaySettings;
     liveCaptionToggleVisible?: boolean;
     sessionTitle?: string | null;
+    speakerLabelContext?: RenderLabelContext;
   } = {},
 ): FloatingRouteState | null {
   if (state.live.status !== "active") {
@@ -511,7 +524,10 @@ export function getFloatingRouteState(
     liveCaptionPosition: settings.liveCaptionPosition,
     liveCaptionMinimized: settings.liveCaptionMinimized,
     liveCaptionToggleVisible,
-    transcriptBubbles: getFloatingTranscriptBubbles(state.liveSegments),
+    transcriptBubbles: getFloatingTranscriptBubbles(
+      state.liveSegments,
+      speakerLabelContext,
+    ),
   };
 }
 
@@ -528,6 +544,7 @@ function getCurrentFloatingRouteState(
     settings,
     liveCaptionToggleVisible,
     sessionTitle: getFloatingSessionTitle(state, main),
+    speakerLabelContext: getFloatingSpeakerLabelContext(state, main),
   });
 }
 
@@ -551,6 +568,7 @@ function getFloatingTitle(title: string | null | undefined) {
 
 export function getFloatingTranscriptBubbles(
   segments: ListenerState["liveSegments"],
+  speakerLabelContext?: RenderLabelContext,
 ): FloatingTranscriptBubble[] {
   const bubbles = segments
     .slice()
@@ -568,7 +586,7 @@ export function getFloatingTranscriptBubbles(
 
       return {
         id: segment.id,
-        speakerLabel: getFloatingSpeakerLabel(segment.key),
+        speakerLabel: getFloatingSpeakerLabel(segment.key, speakerLabelContext),
         text,
         isSelf: isFloatingSelfSpeaker(segment.key),
         isFinal: segment.words.every((word) => word.is_final),
@@ -605,9 +623,14 @@ function getFloatingSegmentText(
 
 function getFloatingSpeakerLabel(
   key: ListenerState["liveSegments"][number]["key"],
+  ctx?: RenderLabelContext,
 ) {
   if (isFloatingSelfSpeaker(key)) {
     return "You";
+  }
+
+  if (ctx) {
+    return SegmentKeyUtils.renderLabel(key, ctx);
   }
 
   if (key.speaker_index != null) {
@@ -619,6 +642,17 @@ function getFloatingSpeakerLabel(
   }
 
   return "Audio";
+}
+
+function getFloatingSpeakerLabelContext(
+  state: ListenerState,
+  main: MeetingFloatMainStore | undefined,
+): RenderLabelContext | undefined {
+  if (!main || !state.live.sessionId) {
+    return undefined;
+  }
+
+  return defaultRenderLabelContext(main, state.live.sessionId);
 }
 
 function isFloatingSelfSpeaker(

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.test.tsx
@@ -5,9 +5,13 @@ import { SegmentHeader } from "./segment-header";
 
 import type { Segment } from "~/stt/live-segment";
 
-const { useStoreMock } = vi.hoisted(() => ({
-  useStoreMock: vi.fn(),
-}));
+const { useStoreMock, useValueMock, useSliceRowIdsMock, useTableMock } =
+  vi.hoisted(() => ({
+    useStoreMock: vi.fn(),
+    useValueMock: vi.fn(),
+    useSliceRowIdsMock: vi.fn(),
+    useTableMock: vi.fn(),
+  }));
 
 vi.mock("./speaker-assign", () => ({
   SpeakerAssignPopover: ({ label }: { label: string }) => (
@@ -16,9 +20,15 @@ vi.mock("./speaker-assign", () => ({
 }));
 
 vi.mock("~/store/tinybase/store/main", () => ({
+  INDEXES: {
+    sessionParticipantsBySession: "sessionParticipantsBySession",
+  },
   STORE_ID: "main",
   UI: {
+    useSliceRowIds: useSliceRowIdsMock,
     useStore: useStoreMock,
+    useTable: useTableMock,
+    useValue: useValueMock,
   },
 }));
 
@@ -26,6 +36,9 @@ beforeEach(() => {
   cleanup();
   vi.clearAllMocks();
   useStoreMock.mockReturnValue(undefined);
+  useValueMock.mockReturnValue(undefined);
+  useSliceRowIdsMock.mockReturnValue([]);
+  useTableMock.mockReturnValue(undefined);
 });
 
 describe("SegmentHeader", () => {
@@ -69,5 +82,208 @@ describe("SegmentHeader", () => {
 
     expect(screen.getByRole("button", { name: "Speaker 3" })).toBeTruthy();
     expect(screen.queryByText("00:12 - 00:18")).toBeNull();
+  });
+
+  it("labels remote live segments as the unique other participant", () => {
+    useValueMock.mockReturnValue("self");
+    useSliceRowIdsMock.mockReturnValue(["mapping-self", "mapping-remote"]);
+    useTableMock.mockImplementation((table: string) => {
+      if (table === "mapping_session_participant") {
+        return {
+          "mapping-remote": { human_id: "remote", session_id: "session-1" },
+          "mapping-self": { human_id: "self", session_id: "session-1" },
+        };
+      }
+
+      if (table === "humans") {
+        return {
+          remote: { name: "Artem" },
+          self: { name: "John" },
+        };
+      }
+    });
+    useStoreMock.mockReturnValue({
+      getCell: (table: string, rowId: string, cell: string) => {
+        if (
+          table === "transcripts" &&
+          rowId === "transcript-1" &&
+          cell === "session_id"
+        ) {
+          return "session-1";
+        }
+
+        if (
+          table === "mapping_session_participant" &&
+          rowId === "mapping-self" &&
+          cell === "session_id"
+        ) {
+          return "session-1";
+        }
+
+        if (
+          table === "mapping_session_participant" &&
+          rowId === "mapping-self" &&
+          cell === "human_id"
+        ) {
+          return "self";
+        }
+
+        if (
+          table === "mapping_session_participant" &&
+          rowId === "mapping-remote" &&
+          cell === "session_id"
+        ) {
+          return "session-1";
+        }
+
+        if (
+          table === "mapping_session_participant" &&
+          rowId === "mapping-remote" &&
+          cell === "human_id"
+        ) {
+          return "remote";
+        }
+
+        return undefined;
+      },
+      getValue: (key: string) => (key === "user_id" ? "self" : undefined),
+      getRow: (_table: string, rowId: string) => ({
+        name: rowId === "self" ? "John" : rowId === "remote" ? "Artem" : "",
+      }),
+      forEachRow: (_table: string, callback: (rowId: string) => void) => {
+        callback("mapping-self");
+        callback("mapping-remote");
+      },
+    });
+
+    render(
+      <SegmentHeader
+        transcriptId="transcript-1"
+        segment={
+          {
+            id: "segment-1",
+            key: {
+              channel: "RemoteParty",
+              speaker_index: 0,
+              speaker_human_id: null,
+            },
+            start_ms: 12_000,
+            end_ms: 18_000,
+            text: "hello world",
+            words: [
+              {
+                id: "word-1",
+                text: "hello",
+                start_ms: 12_000,
+                end_ms: 13_000,
+                channel: "RemoteParty",
+                is_final: true,
+              },
+            ],
+          } as Segment
+        }
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Artem" })).toBeTruthy();
+  });
+
+  it("updates cached remote labels when session participants change", () => {
+    let participantMappingIds = ["mapping-self", "mapping-remote"];
+    let mappingTable: Record<string, { human_id: string; session_id: string }> =
+      {
+        "mapping-remote": { human_id: "remote", session_id: "session-1" },
+        "mapping-self": { human_id: "self", session_id: "session-1" },
+      };
+    let humansTable: Record<string, { name: string }> = {
+      remote: { name: "Artem" },
+      self: { name: "John" },
+    };
+    const store = {
+      getCell: (table: string, rowId: string, cell: string) => {
+        if (
+          table === "transcripts" &&
+          rowId === "transcript-1" &&
+          cell === "session_id"
+        ) {
+          return "session-1";
+        }
+
+        if (table === "mapping_session_participant") {
+          return mappingTable[rowId]?.[
+            cell as keyof (typeof mappingTable)[string]
+          ];
+        }
+
+        return undefined;
+      },
+      getValue: (key: string) => (key === "user_id" ? "self" : undefined),
+      getRow: (_table: string, rowId: string) => {
+        return humansTable[rowId] ?? { name: "" };
+      },
+      forEachRow: (_table: string, callback: (rowId: string) => void) => {
+        participantMappingIds.forEach(callback);
+      },
+    };
+    useStoreMock.mockReturnValue(store);
+    useValueMock.mockReturnValue("self");
+    useSliceRowIdsMock.mockImplementation(() => participantMappingIds);
+    useTableMock.mockImplementation((table: string) => {
+      if (table === "mapping_session_participant") {
+        return mappingTable;
+      }
+
+      if (table === "humans") {
+        return humansTable;
+      }
+    });
+    const segment = {
+      id: "segment-1",
+      key: {
+        channel: "RemoteParty",
+        speaker_index: 0,
+        speaker_human_id: null,
+      },
+      start_ms: 12_000,
+      end_ms: 18_000,
+      text: "hello world",
+      words: [
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 12_000,
+          end_ms: 13_000,
+          channel: "RemoteParty",
+          is_final: true,
+        },
+      ],
+    } as Segment;
+
+    const { rerender } = render(
+      <SegmentHeader transcriptId="transcript-1" segment={segment} />,
+    );
+
+    expect(screen.getByRole("button", { name: "Artem" })).toBeTruthy();
+
+    participantMappingIds = [
+      "mapping-self",
+      "mapping-remote",
+      "mapping-remote-2",
+    ];
+    mappingTable = {
+      ...mappingTable,
+      "mapping-remote-2": {
+        human_id: "remote-2",
+        session_id: "session-1",
+      },
+    };
+    humansTable = {
+      ...humansTable,
+      "remote-2": { name: "Taylor" },
+    };
+
+    rerender(<SegmentHeader transcriptId="transcript-1" segment={segment} />);
+
+    expect(screen.getByRole("button", { name: "Speaker 1" })).toBeTruthy();
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/segment-header.tsx
@@ -3,6 +3,7 @@ import { useMemo } from "react";
 import { cn } from "@hypr/utils";
 
 import { SpeakerAssignPopover } from "./speaker-assign";
+import { useSpeakerLabelContextVersion } from "./speaker-label-context";
 import { useSegmentColorVars } from "./utils";
 
 import * as main from "~/store/tinybase/store/main";
@@ -20,7 +21,7 @@ export function SegmentHeader({
   speakerLabelManager?: SpeakerLabelManager;
 }) {
   const colorVars = useSegmentColorVars(segment.key);
-  const label = useSpeakerLabel(segment.key, speakerLabelManager);
+  const label = useSpeakerLabel(segment.key, transcriptId, speakerLabelManager);
   const headerClassName = cn([
     "bg-card sticky top-0 z-20",
     "-mx-3 px-3 py-1",
@@ -42,14 +43,25 @@ export function SegmentHeader({
   );
 }
 
-function useSpeakerLabel(key: Segment["key"], manager?: SpeakerLabelManager) {
+function useSpeakerLabel(
+  key: Segment["key"],
+  transcriptId: string,
+  manager?: SpeakerLabelManager,
+) {
   const store = main.UI.useStore(main.STORE_ID);
+  const sessionId = store?.getCell("transcripts", transcriptId, "session_id");
+  const contextVersion = useSpeakerLabelContextVersion(
+    typeof sessionId === "string" ? sessionId : null,
+  );
 
   return useMemo(() => {
     if (!store) {
       return SegmentKeyUtils.renderLabel(key, undefined, manager);
     }
-    const ctx = defaultRenderLabelContext(store);
+    const ctx = defaultRenderLabelContext(
+      store,
+      typeof sessionId === "string" ? sessionId : null,
+    );
     return SegmentKeyUtils.renderLabel(key, ctx, manager);
-  }, [key, manager, store]);
+  }, [contextVersion, key, manager, sessionId, store]);
 }

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-label-context.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/speaker-label-context.ts
@@ -1,0 +1,36 @@
+import { useMemo } from "react";
+
+import * as main from "~/store/tinybase/store/main";
+
+export function useSpeakerLabelContextVersion(
+  sessionId: string | null | undefined,
+) {
+  const userId = main.UI.useValue("user_id", main.STORE_ID);
+  const mappingIds = main.UI.useSliceRowIds(
+    main.INDEXES.sessionParticipantsBySession,
+    sessionId ?? "",
+    main.STORE_ID,
+  ) as string[];
+  const mappingTable = main.UI.useTable(
+    "mapping_session_participant",
+    main.STORE_ID,
+  );
+  const humansTable = main.UI.useTable("humans", main.STORE_ID);
+
+  return useMemo(() => {
+    const participantHumanIds = mappingIds
+      .map((mappingId) => mappingTable?.[mappingId]?.human_id)
+      .filter(
+        (humanId): humanId is string =>
+          typeof humanId === "string" && humanId.length > 0,
+      );
+
+    return JSON.stringify({
+      participants: [...new Set(participantHumanIds)].map((humanId) => [
+        humanId,
+        humansTable?.[humanId]?.name ?? null,
+      ]),
+      userId: typeof userId === "string" ? userId : null,
+    });
+  }, [humansTable, mappingIds, mappingTable, userId]);
+}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/transcript.tsx
@@ -14,6 +14,7 @@ import {
   segmentsShallowEqual,
   useStableSegments,
 } from "./segment-hooks";
+import { useSpeakerLabelContextVersion } from "./speaker-label-context";
 
 import * as main from "~/store/tinybase/store/main";
 import {
@@ -102,14 +103,21 @@ const SegmentsList = memo(
     maxSpeakerNumber?: number;
   }) => {
     const store = main.UI.useStore(main.STORE_ID);
+    const sessionId = store?.getCell("transcripts", transcriptId, "session_id");
+    const contextVersion = useSpeakerLabelContextVersion(
+      typeof sessionId === "string" ? sessionId : null,
+    );
     const search = useSearch();
     const speakerLabelManager = useMemo(() => {
       if (!store) {
         return new SpeakerLabelManager();
       }
-      const ctx = defaultRenderLabelContext(store);
+      const ctx = defaultRenderLabelContext(
+        store,
+        typeof sessionId === "string" ? sessionId : null,
+      );
       return SpeakerLabelManager.fromSegments(segments, ctx, maxSpeakerNumber);
-    }, [maxSpeakerNumber, segments, store]);
+    }, [contextVersion, maxSpeakerNumber, segments, sessionId, store]);
     const transcriptSearch = useMemo<TranscriptSearchRenderState>(() => {
       const query = search?.query.trim() ?? "";
       if (!search?.isVisible || !query) {

--- a/apps/desktop/src/stt/live-segment.test.ts
+++ b/apps/desktop/src/stt/live-segment.test.ts
@@ -12,6 +12,12 @@ const ctx: RenderLabelContext = {
   getSelfHumanId: () => "self",
   getHumanName: (id) => (id === "self" ? "Me" : undefined),
 };
+const twoPersonCtx: RenderLabelContext = {
+  getSelfHumanId: () => "self",
+  getHumanName: (id) =>
+    id === "self" ? "Me" : id === "remote" ? "Artem" : undefined,
+  getParticipantHumanIds: () => ["self", "remote"],
+};
 
 describe("SegmentKeyUtils", () => {
   it("treats diarized direct-mic segments as self", () => {
@@ -62,6 +68,17 @@ describe("SegmentKeyUtils", () => {
     expect(
       SegmentKeyUtils.renderLabel(segments[2]!.key, undefined, manager),
     ).toBe("Speaker 2");
+  });
+
+  it("labels remote-party segments as the unique other participant", () => {
+    const key: Parameters<typeof SegmentKeyUtils.renderLabel>[0] = {
+      channel: "RemoteParty",
+      speaker_index: 0,
+      speaker_human_id: null,
+    };
+
+    expect(SegmentKeyUtils.isKnownSpeaker(key, twoPersonCtx)).toBe(true);
+    expect(SegmentKeyUtils.renderLabel(key, twoPersonCtx)).toBe("Artem");
   });
 
   it("derives max speaker number from distinct participants plus self", () => {

--- a/apps/desktop/src/stt/live-segment.ts
+++ b/apps/desktop/src/stt/live-segment.ts
@@ -41,6 +41,7 @@ export type RuntimeSpeakerHint = {
 export type RenderLabelContext = {
   getSelfHumanId: () => string | undefined;
   getHumanName: (id: string) => string | undefined;
+  getParticipantHumanIds?: () => string[];
 };
 
 export type SegmentKey = BoundSegmentKey;
@@ -113,6 +114,10 @@ export const SegmentKeyUtils = {
       return Boolean(ctx.getSelfHumanId());
     }
 
+    if (ctx && key.channel === "RemoteParty") {
+      return Boolean(getUniqueRemoteParticipantHumanId(ctx));
+    }
+
     return false;
   },
 
@@ -138,6 +143,13 @@ export const SegmentKeyUtils = {
       }
     }
 
+    if (ctx && key.channel === "RemoteParty" && assignedHumanId == null) {
+      const remoteHumanId = getUniqueRemoteParticipantHumanId(ctx);
+      if (remoteHumanId) {
+        return ctx.getHumanName(remoteHumanId) || remoteHumanId;
+      }
+    }
+
     if (manager) {
       const speakerNumber = manager.getUnknownSpeakerNumber(key);
       return `Speaker ${speakerNumber}`;
@@ -155,6 +167,22 @@ export const SegmentKeyUtils = {
       : `Speaker ${channelLabel}`;
   },
 };
+
+function getUniqueRemoteParticipantHumanId(
+  ctx: RenderLabelContext,
+): string | undefined {
+  const selfHumanId = ctx.getSelfHumanId();
+  const participantHumanIds = ctx.getParticipantHumanIds?.() ?? [];
+  const remoteHumanIds = [
+    ...new Set(
+      participantHumanIds.filter(
+        (humanId) => humanId && humanId !== selfHumanId,
+      ),
+    ),
+  ];
+
+  return remoteHumanIds.length === 1 ? remoteHumanIds[0] : undefined;
+}
 
 export function getMaxSpeakerNumberForParticipants(
   participantHumanIds: readonly string[],

--- a/apps/desktop/src/stt/segment/shared.ts
+++ b/apps/desktop/src/stt/segment/shared.ts
@@ -15,7 +15,8 @@ export {
 export const ChannelProfileSchema = Schema.Enums(ChannelProfile);
 
 export const defaultRenderLabelContext = (
-  store: Pick<Store, "getValue" | "getRow">,
+  store: Pick<Store, "getValue" | "getRow" | "forEachRow" | "getCell">,
+  sessionId?: string | null,
 ): RenderLabelContext => {
   return {
     getSelfHumanId: () => {
@@ -25,6 +26,37 @@ export const defaultRenderLabelContext = (
     getHumanName: (id: string) => {
       const human = store.getRow("humans", id);
       return typeof human.name === "string" ? human.name : undefined;
+    },
+    getParticipantHumanIds: () => {
+      if (!sessionId) {
+        return [];
+      }
+
+      const humanIds: string[] = [];
+      store.forEachRow(
+        "mapping_session_participant",
+        (mappingId, _forEachCell) => {
+          const mappingSessionId = store.getCell(
+            "mapping_session_participant",
+            mappingId,
+            "session_id",
+          );
+          if (mappingSessionId !== sessionId) {
+            return;
+          }
+
+          const humanId = store.getCell(
+            "mapping_session_participant",
+            mappingId,
+            "human_id",
+          );
+          if (typeof humanId === "string" && humanId) {
+            humanIds.push(humanId);
+          }
+        },
+      );
+
+      return [...new Set(humanIds)];
     },
   };
 };

--- a/plugins/windows/swift-lib/src/FloatingBarView.swift
+++ b/plugins/windows/swift-lib/src/FloatingBarView.swift
@@ -206,16 +206,18 @@ struct FloatingBarView: View {
               .frame(maxWidth: .infinity, maxHeight: .infinity)
               .onChange(of: model.transcriptBubbles.last?.id) { _, bubbleId in
                 if bubbleId != nil, shouldAutoScrollTranscript {
-                  proxy.scrollTo(transcriptBottomAnchorId, anchor: .bottom)
+                  scrollTranscriptToBottom(proxy)
                 }
+              }
+              .onAppear {
+                shouldAutoScrollTranscript = true
+                scrollTranscriptToBottom(proxy)
               }
 
               if !shouldAutoScrollTranscript, model.transcriptBubbles.last?.id != nil {
                 transcriptBottomChip {
                   performClick {
-                    withAnimation(.easeOut(duration: 0.16)) {
-                      proxy.scrollTo(transcriptBottomAnchorId, anchor: .bottom)
-                    }
+                    scrollTranscriptToBottom(proxy, animated: true)
                     shouldAutoScrollTranscript = true
                   }
                 }
@@ -472,6 +474,18 @@ struct FloatingBarView: View {
     let previousBubble = model.transcriptBubbles[index - 1]
     return bubble.speakerLabel != previousBubble.speakerLabel
       || bubble.isSelf != previousBubble.isSelf
+  }
+
+  private func scrollTranscriptToBottom(_ proxy: ScrollViewProxy, animated: Bool = false) {
+    DispatchQueue.main.async {
+      if animated {
+        withAnimation(.easeOut(duration: 0.16)) {
+          proxy.scrollTo(transcriptBottomAnchorId, anchor: .bottom)
+        }
+      } else {
+        proxy.scrollTo(transcriptBottomAnchorId, anchor: .bottom)
+      }
+    }
   }
 
   private func transcriptBottomChip(action: @escaping () -> Void) -> some View {


### PR DESCRIPTION
Use session participant context when rendering live transcript labels so two-person remote speakers display by name in transcript and floating panels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI labeling and scroll behavior only; logic is covered by unit tests and falls back to numbered speakers when multiple remotes exist.
> 
> **Overview**
> Live transcript and floating-bar bubbles now resolve **remote** speaker labels from session participants when there is exactly one non-self attendee, instead of generic `Speaker N` text.
> 
> `RenderLabelContext` gains optional `getParticipantHumanIds`; `SegmentKeyUtils` uses that for unassigned `RemoteParty` segments. `defaultRenderLabelContext` is scoped by `sessionId` via `mapping_session_participant` and `humans`. The note transcript (`SegmentHeader`, `RenderTranscript`) and meeting float host pass that context and **recompute labels** when participants or names change (`useSpeakerLabelContextVersion`, TinyBase listeners on participants/humans).
> 
> macOS **FloatingBarView** scrolls the expanded transcript to the bottom on appear and defers scroll-to-bottom through a small helper for more reliable auto-follow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 02327b4d02e1d5c33e75cdcd4426cf11f27eff15. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->