### PR TITLE
Hide transcript batch loading toast

### DIFF
--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   updateSettingsTabState: vi.fn(),
   clearDevtoolsPreview: vi.fn(),
   setToastActionTarget: vi.fn(),
+  sessionMode: "inactive",
 }));
 
 vi.mock("~/auth", () => ({
@@ -68,6 +69,12 @@ vi.mock("~/store/zustand/toast-action", () => ({
   ) => selector({ setTarget: mocks.setToastActionTarget }),
 }));
 
+vi.mock("~/stt/contexts", () => ({
+  useListener: (
+    selector: (state: { getSessionMode: () => string }) => unknown,
+  ) => selector({ getSessionMode: () => mocks.sessionMode }),
+}));
+
 vi.mock("./useDismissedToasts", () => ({
   useDismissedToasts: () => ({
     dismissToast: mocks.dismissToast,
@@ -87,6 +94,7 @@ describe("ToastArea", () => {
     mocks.updateSettingsTabState.mockClear();
     mocks.clearDevtoolsPreview.mockClear();
     mocks.setToastActionTarget.mockClear();
+    mocks.sessionMode = "inactive";
     useTransientToast.getState().clearToast();
   });
 

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -24,6 +24,7 @@ import {
   isConfiguredSttModel,
   isHyprnoteCloudSttModel,
 } from "~/stt/capabilities";
+import { useListener } from "~/stt/contexts";
 
 type ToastAreaPlacement = "default" | "left-sidebar";
 type ToastAreaPosition = {
@@ -97,6 +98,16 @@ export function ToastArea({
     currentTab.state?.tab === "transcription";
   const isAiIntelligenceTabActive =
     currentTab?.type === "settings" && currentTab.state?.tab === "intelligence";
+  const activeTranscriptSessionId =
+    currentTab?.type === "sessions" &&
+    currentTab.state.view?.type === "transcript"
+      ? currentTab.id
+      : null;
+  const isBatchTranscribingInActiveTranscriptTab = useListener((state) =>
+    activeTranscriptSessionId
+      ? state.getSessionMode(activeTranscriptSessionId) === "running_batch"
+      : false,
+  );
 
   const openNew = useTabs((state) => state.openNew);
   const updateSettingsTabState = useTabs(
@@ -139,6 +150,7 @@ export function ToastArea({
         hasProLlmConfigured,
         isAiTranscriptionTabActive,
         isAiIntelligenceTabActive,
+        isBatchTranscribingInActiveTranscriptTab,
         hasActiveDownload,
         downloadProgress,
         downloadingModel,
@@ -158,6 +170,7 @@ export function ToastArea({
       hasProLlmConfigured,
       isAiTranscriptionTabActive,
       isAiIntelligenceTabActive,
+      isBatchTranscribingInActiveTranscriptTab,
       hasActiveDownload,
       downloadProgress,
       downloadingModel,

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -15,6 +15,7 @@ const baseParams = {
   hasProLlmConfigured: false,
   isAiTranscriptionTabActive: false,
   isAiIntelligenceTabActive: false,
+  isBatchTranscribingInActiveTranscriptTab: false,
   hasActiveDownload: false,
   downloadProgress: null,
   downloadingModel: null,
@@ -53,6 +54,34 @@ describe("sidebar toast registry", () => {
     expect(toast?.id).toBe("missing-stt");
     expect(toast?.description).toBe("Transcription model needed");
     expect(toast?.primaryAction?.label).toBe("Add");
+  });
+
+  it("hides local STT loading while the active transcript tab shows batch progress", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        localSttStatus: "loading",
+        isLocalSttModel: true,
+        isBatchTranscribingInActiveTranscriptTab: true,
+      }),
+      () => false,
+    );
+
+    expect(toast).toBeNull();
+  });
+
+  it("shows local STT loading outside active transcript batch progress", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        localSttStatus: "loading",
+        isLocalSttModel: true,
+      }),
+      () => false,
+    );
+
+    expect(toast?.id).toBe("local-stt-loading");
+    expect(toast?.description).toBe("Starting transcription...");
   });
 
   it("renders the pro upgrade toast without an icon", () => {

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -20,6 +20,7 @@ type ToastRegistryParams = {
   hasProLlmConfigured: boolean;
   isAiTranscriptionTabActive: boolean;
   isAiIntelligenceTabActive: boolean;
+  isBatchTranscribingInActiveTranscriptTab: boolean;
   hasActiveDownload: boolean;
   downloadProgress: number | null;
   downloadingModel: string | null;
@@ -47,6 +48,7 @@ export function createToastRegistry({
   hasProLlmConfigured,
   isAiTranscriptionTabActive,
   isAiIntelligenceTabActive,
+  isBatchTranscribingInActiveTranscriptTab,
   hasActiveDownload,
   downloadProgress,
   downloadingModel,
@@ -82,7 +84,10 @@ export function createToastRegistry({
         dismissible: false,
       },
       condition: () =>
-        isLocalSttModel && localSttStatus === "loading" && !hasActiveDownload,
+        isLocalSttModel &&
+        localSttStatus === "loading" &&
+        !hasActiveDownload &&
+        !isBatchTranscribingInActiveTranscriptTab,
     },
     {
       toast: {


### PR DESCRIPTION
Suppress the local STT loading toast while the active transcript tab already shows batch transcription progress.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI/toast gating change with no auth or data-path impact; behavior is covered by new unit tests.
> 
> **Overview**
> **Suppresses the “Starting transcription…” sidebar toast** when the user is already on a session’s transcript view and that session is in **`running_batch`** mode, so batch progress in the tab isn’t duplicated by the global toast.
> 
> `ToastArea` now derives the active transcript session from the current tab and reads session mode via **`useListener`**, then passes **`isBatchTranscribingInActiveTranscriptTab`** into the toast registry. The **`local-stt-loading`** entry only shows when local STT is loading and that flag is false (unchanged behavior elsewhere). Registry and `ToastArea` tests cover hide vs show cases.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f1da5a9988eecf6ace33c226e75d7e3cf832a39. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->