### PR TITLE
Show finalizing listening indicator

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -35,6 +35,10 @@ const hoisted = vi.hoisted(() => ({
   updateSessionTabState: vi.fn(),
 }));
 
+vi.mock("@hypr/ui/components/ui/spinner", () => ({
+  Spinner: () => <span data-testid="spinner" />,
+}));
+
 vi.mock("./listen", () => ({
   ListenButton: () => <button type="button">Start listening</button>,
 }));
@@ -351,6 +355,22 @@ describe("FloatingActionButton", () => {
     );
 
     expect(hoisted.sendEvent).toHaveBeenCalledWith({ type: "OPEN" });
+  });
+
+  it("shows a finalizing indicator after live listening stops", () => {
+    hoisted.sessionMode = "finalizing";
+
+    renderFloatingActionButton();
+
+    const button = screen.getByRole("button", {
+      name: "Preparing transcript...",
+    });
+
+    expect(button.hasAttribute("disabled")).toBe(true);
+    expect(screen.getByTestId("spinner")).not.toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Ask Anarlog anything" }),
+    ).toBeNull();
   });
 
   it("tucks the listen FAB near the editor caret instead of scroll state", () => {

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -3,6 +3,7 @@ import { AnimatePresence, motion } from "motion/react";
 import type { CSSProperties } from "react";
 import { useCallback } from "react";
 
+import { Spinner } from "@hypr/ui/components/ui/spinner";
 import { cn } from "@hypr/utils";
 
 import { useCaretPosition } from "../caret-position-context";
@@ -89,10 +90,12 @@ export function FloatingActionButton({
   });
   const shouldShowGenerateSummary = generateSummaryNoteId !== null;
   const shouldShowTranscriptAction = transcriptAction !== null;
+  const shouldShowFinalizing = sessionMode === "finalizing";
   const isCaretNearBottom = useCaretPosition()?.isCaretNearBottom ?? false;
   const showSkipReason = !!skipReason;
   const useChatHoverArea =
     !showSkipReason &&
+    !shouldShowFinalizing &&
     !shouldShowTranscriptAction &&
     !shouldShowGenerateSummary &&
     shouldShowChat;
@@ -101,6 +104,7 @@ export function FloatingActionButton({
 
   if (
     !showSkipReason &&
+    !shouldShowFinalizing &&
     !shouldShowListen &&
     !shouldShowTranscriptAction &&
     !shouldShowGenerateSummary &&
@@ -139,13 +143,15 @@ export function FloatingActionButton({
         ) : (
           <motion.div
             key={
-              shouldShowListen
-                ? "listen"
-                : shouldShowTranscriptAction
-                  ? `transcript-${transcriptAction.type}`
-                  : shouldShowGenerateSummary
-                    ? "generate-summary"
-                    : "chat"
+              shouldShowFinalizing
+                ? "finalizing"
+                : shouldShowListen
+                  ? "listen"
+                  : shouldShowTranscriptAction
+                    ? `transcript-${transcriptAction.type}`
+                    : shouldShowGenerateSummary
+                      ? "generate-summary"
+                      : "chat"
             }
             aria-hidden={tuckListenAction}
             initial={{ opacity: 0 }}
@@ -166,7 +172,9 @@ export function FloatingActionButton({
                 : "pointer-events-auto visible",
             ])}
           >
-            {shouldShowListen ? (
+            {shouldShowFinalizing ? (
+              <FinalizingButton />
+            ) : shouldShowListen ? (
               <ListenButton tab={tab} />
             ) : transcriptAction ? (
               <TranscriptActionButton
@@ -185,6 +193,19 @@ export function FloatingActionButton({
         )}
       </AnimatePresence>
     </div>
+  );
+}
+
+function FinalizingButton() {
+  return (
+    <FloatingButton
+      disabled
+      className="w-fit gap-2 px-4 whitespace-nowrap opacity-100"
+    >
+      <span className="flex items-center gap-1.5">
+        <Spinner size={14} /> Preparing transcript...
+      </span>
+    </FloatingButton>
   );
 }
 

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -935,12 +935,16 @@ describe("Header", () => {
         editorTabs={editorTabs}
         currentTab={{ type: "transcript" }}
         handleTabChange={handleTabChange}
+        isTranscribing
       />,
     );
 
     const transcriptTab = screen.getByRole("button", { name: "Transcript" });
 
-    expect(screen.getByTestId("dancing-sticks")).not.toBeNull();
+    expect(
+      transcriptTab.querySelector("[data-testid='view-spinner']"),
+    ).not.toBeNull();
+    expect(screen.queryByTestId("dancing-sticks")).toBeNull();
     expect(transcriptTab.getAttribute("title")).toBeNull();
 
     fireEvent.click(transcriptTab);

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -809,20 +809,19 @@ function useTranscriptLiveViewState(sessionId: string) {
 
     stop();
   }, [sessionId, stop]);
-  const isLiveSession = mode === "active" || mode === "finalizing";
-
   return {
-    live: isLiveSession
-      ? {
-          amplitude: Math.min(Math.hypot(amplitude.mic, amplitude.speaker), 1),
-          degraded: Boolean(degraded),
-          muted,
-        }
-      : undefined,
-    onStopLiveSession:
-      isLiveSession && mode !== "finalizing"
-        ? handleStopLiveSession
+    live:
+      mode === "active"
+        ? {
+            amplitude: Math.min(
+              Math.hypot(amplitude.mic, amplitude.speaker),
+              1,
+            ),
+            degraded: Boolean(degraded),
+            muted,
+          }
         : undefined,
+    onStopLiveSession: mode === "active" ? handleStopLiveSession : undefined,
   };
 }
 


### PR DESCRIPTION
Show an explicit preparing transcript state after auto-stop and keep the transcript tab on the spinner state while finalizing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Session UI and header live-state wiring only; no auth or data-path changes, covered by unit tests.
> 
> **Overview**
> Surfaces a **post-stop “preparing transcript”** phase in the session UI when `sessionMode` is `finalizing`, instead of showing chat or live-listening controls.
> 
> The floating action button takes priority over other FABs with a disabled **“Preparing transcript…”** control and spinner. The note header’s transcript tab no longer treats finalizing as an active live session—live amplitude, dancing sticks, and **stop listening** are limited to `active` only, while transcribing/finalizing keeps the tab on the **spinner** state (tests aligned with `view-spinner` vs dancing sticks).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6754c25fe44ee28423eec31a701161170fef3db0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->