### PR TITLE
Use serif card ranks

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -1033,15 +1033,13 @@ function AiOptionPlayingCard({
   return (
     <div className={cn(["ai-option-card", className])}>
       <span className="ai-option-card-corner ai-option-card-corner-top">
-        <span>{rank}</span>
-        <IconComponent aria-hidden="true" />
+        <span className="ai-option-card-rank">{rank}</span>
       </span>
       <div className="ai-option-card-face">
         <IconComponent aria-hidden="true" />
       </div>
       <span className="ai-option-card-corner ai-option-card-corner-bottom">
-        <span>{rank}</span>
-        <IconComponent aria-hidden="true" />
+        <span className="ai-option-card-rank">{rank}</span>
       </span>
     </div>
   );

--- a/apps/web/src/styles.css
+++ b/apps/web/src/styles.css
@@ -483,20 +483,16 @@
   .ai-option-card-corner {
     position: absolute;
     display: flex;
-    flex-direction: column;
     align-items: center;
-    gap: 0.05rem;
-    font-family: Georgia, "Times New Roman", serif;
     font-size: 0.82rem;
     font-weight: 700;
     line-height: 0.86;
     letter-spacing: 0;
   }
 
-  .ai-option-card-corner svg {
-    width: 0.6rem;
-    height: 0.6rem;
-    stroke-width: 3;
+  .ai-option-card-rank {
+    font-family: Georgia, "Times New Roman", serif;
+    font-weight: 700;
   }
 
   .ai-option-card-corner-top {


### PR DESCRIPTION
Apply serif styling directly to AI option card rank letters and keep only the center card icon.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Landing-page CSS and markup only; no logic, auth, or data paths.
> 
> **Overview**
> **AI option playing cards** in the privacy “bring your own key” visual are simplified: corner marks show only the rank letter (C/K/O), and the Lucide icon stays on the card face.
> 
> Serif styling moves from the whole corner block to a new **`ai-option-card-rank`** class (Georgia), and corner layout drops the stacked rank+mini-icon column plus the tiny corner SVG rules.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb0949c503c54ac5b394d2112964908f4a18fea2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->