### PR TITLE
Enable live recording stop from transcript FAB

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -31,7 +31,10 @@ const hoisted = vi.hoisted(() => ({
   regenerateSummary: vi.fn(),
   cancelSummary: vi.fn(),
   regenerateTranscript: vi.fn(),
+  stopListening: vi.fn(),
   stopTranscription: vi.fn(),
+  requestMainListenerControl: vi.fn(),
+  isMainWebviewWindow: true,
   updateSessionTabState: vi.fn(),
 }));
 
@@ -128,13 +131,20 @@ vi.mock("~/stt/contexts", () => ({
   useListener: (
     selector: (state: {
       getSessionMode: () => string;
+      stop: () => void;
       stopTranscription: (sessionId: string) => void;
     }) => unknown,
   ) =>
     selector({
       getSessionMode: () => hoisted.sessionMode,
+      stop: hoisted.stopListening,
       stopTranscription: hoisted.stopTranscription,
     }),
+}));
+
+vi.mock("~/stt/window-control", () => ({
+  isMainWebviewWindow: () => hoisted.isMainWebviewWindow,
+  requestMainListenerControl: hoisted.requestMainListenerControl,
 }));
 
 describe("FloatingActionButton", () => {
@@ -175,7 +185,10 @@ describe("FloatingActionButton", () => {
     hoisted.regenerateSummary.mockReset();
     hoisted.cancelSummary.mockReset();
     hoisted.regenerateTranscript.mockReset();
+    hoisted.stopListening.mockReset();
     hoisted.stopTranscription.mockReset();
+    hoisted.requestMainListenerControl.mockReset();
+    hoisted.isMainWebviewWindow = true;
     hoisted.updateSessionTabState.mockClear();
   });
 
@@ -440,6 +453,34 @@ describe("FloatingActionButton", () => {
     fireEvent.click(screen.getByRole("button", { name: "Stop transcription" }));
 
     expect(hoisted.stopTranscription).toHaveBeenCalledWith("session-1");
+  });
+
+  it("shows a stop listening FAB while live recording is active", () => {
+    hoisted.currentTab = { type: "transcript" };
+    hoisted.sessionMode = "active";
+
+    renderFloatingActionButton({ audioExists: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
+
+    expect(hoisted.stopListening).toHaveBeenCalledTimes(1);
+    expect(hoisted.requestMainListenerControl).not.toHaveBeenCalled();
+  });
+
+  it("delegates live recording stop from standalone windows", () => {
+    hoisted.currentTab = { type: "transcript" };
+    hoisted.sessionMode = "active";
+    hoisted.isMainWebviewWindow = false;
+
+    renderFloatingActionButton({ audioExists: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
+
+    expect(hoisted.requestMainListenerControl).toHaveBeenCalledWith(
+      "stop",
+      "session-1",
+    );
+    expect(hoisted.stopListening).not.toHaveBeenCalled();
   });
 
   it("hides the regenerate transcript FAB when audio is missing", () => {

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -24,6 +24,10 @@ import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { useTabs } from "~/store/zustand/tabs";
 import type { EditorView, Tab } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
+import {
+  isMainWebviewWindow,
+  requestMainListenerControl,
+} from "~/stt/window-control";
 
 export function FloatingActionButton({
   allowListening = true,
@@ -56,7 +60,18 @@ export function FloatingActionButton({
     main.STORE_ID,
   );
   const regenerateTranscript = useRegenerateTranscript(tab.id);
-  const stopTranscription = useListener((state) => state.stopTranscription);
+  const { stop, stopTranscription } = useListener((state) => ({
+    stop: state.stop,
+    stopTranscription: state.stopTranscription,
+  }));
+  const handleStopLiveSession = useCallback(() => {
+    if (!isMainWebviewWindow()) {
+      void requestMainListenerControl("stop", tab.id);
+      return;
+    }
+
+    stop();
+  }, [stop, tab.id]);
   const handleStopTranscription = useCallback(() => {
     void stopTranscription(tab.id);
   }, [stopTranscription, tab.id]);
@@ -68,6 +83,7 @@ export function FloatingActionButton({
   const transcriptAction = getTranscriptFloatingAction({
     audioExists,
     currentView,
+    handleStopLiveSession,
     handleStopTranscription,
     regenerateTranscript,
     sessionMode,
@@ -213,12 +229,16 @@ function TranscriptActionButton({
   action,
   onClick,
 }: {
-  action: "regenerate" | "stop";
+  action: "regenerate" | "stop-live" | "stop-transcription";
   onClick: () => void;
 }) {
   const label =
-    action === "stop" ? "Stop transcription" : "Regenerate transcript";
-  const Icon = action === "stop" ? SquareIcon : RefreshCwIcon;
+    action === "stop-live"
+      ? "Stop listening"
+      : action === "stop-transcription"
+        ? "Stop transcription"
+        : "Regenerate transcript";
+  const Icon = action === "regenerate" ? RefreshCwIcon : SquareIcon;
 
   return (
     <FloatingButton
@@ -229,7 +249,7 @@ function TranscriptActionButton({
         <Icon
           className={cn([
             "size-3.5",
-            action === "stop" ? "fill-current" : null,
+            action !== "regenerate" ? "fill-current" : null,
           ])}
         />{" "}
         {label}
@@ -284,12 +304,14 @@ function GenerateSummaryButton({
 function getTranscriptFloatingAction({
   audioExists,
   currentView,
+  handleStopLiveSession,
   handleStopTranscription,
   regenerateTranscript,
   sessionMode,
 }: {
   audioExists: boolean;
   currentView: EditorView;
+  handleStopLiveSession: () => void;
   handleStopTranscription: () => void;
   regenerateTranscript: () => void;
   sessionMode: string;
@@ -298,9 +320,16 @@ function getTranscriptFloatingAction({
     return null;
   }
 
+  if (sessionMode === "active") {
+    return {
+      type: "stop-live" as const,
+      onClick: handleStopLiveSession,
+    };
+  }
+
   if (sessionMode === "running_batch") {
     return {
-      type: "stop" as const,
+      type: "stop-transcription" as const,
       onClick: handleStopTranscription,
     };
   }


### PR DESCRIPTION
Summary:
- Adds a live recording stop action to the transcript floating button.
- Routes standalone-window stop clicks through the main listener bridge.
- Covers main-window and standalone-window behavior in focused tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized FAB and listener-routing changes with tests; live stop still goes through existing listener and main-window bridge APIs.
> 
> **Overview**
> On the **transcript** view, the floating action button now shows **Stop listening** while `sessionMode` is **active**, so users can end live capture without leaving that tab.
> 
> Stop handling is split from batch transcription: **active** sessions call the listener **`stop()`** in the main webview, while **standalone** windows forward **`requestMainListenerControl("stop", sessionId)`** instead of stopping locally. **`running_batch`** still shows **Stop transcription** via `stopTranscription`; the FAB action types are **`stop-live`**, **`stop-transcription`**, and **`regenerate`** with matching labels.
> 
> Tests mock **`window-control`** and assert main-window vs standalone stop behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 13b1edbdb5ff74cd49df08d3a137b15a0fcc3449. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->