### PR TITLE
Update desktop 1.1.10 changelog

### DIFF
--- a/packages/changelog/content/1.1.10.md
+++ b/packages/changelog/content/1.1.10.md
@@ -1,0 +1,15 @@
+---
+date: "2026-07-08"
+summary: "Anarlog improves live transcript controls, speaker labels, and dictionary search feedback."
+---
+
+## Transcripts
+
+- Live transcript speaker names stay more consistent between the main note and floating meeting panel
+- The transcript floating button can now stop an active recording directly
+- Anarlog shows clearer finalizing feedback after listening stops
+- Batch transcription no longer shows an unnecessary loading toast while the transcript view already has progress
+
+## Settings
+
+- Personalization dictionary search now shows a clear empty state when no terms match


### PR DESCRIPTION
Summary:
- Adds the user-facing desktop changelog entry for version 1.1.10.
- Covers the desktop transcript and dictionary search changes shipping since desktop_v1.1.9.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog entry with no application or infrastructure code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.10.md`**, the user-facing desktop changelog for **1.1.10** (dated 2026-07-08), using the same frontmatter and section layout as prior entries like **1.1.9**.
> 
> **Transcripts** documents consistency fixes for live speaker names across the main note and floating panel, stop-recording from the transcript floating button, clearer post-listen finalizing feedback, and removing a redundant batch-transcription loading toast when progress is already shown.
> 
> **Settings** documents a clear empty state when personalization dictionary search has no matches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b9206f2069be5a0301931e1dd059bc7d25507553. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->