### PR TITLE
Keep chat FAB during listening

### DIFF
--- a/apps/desktop/src/session/components/floating/index.test.tsx
+++ b/apps/desktop/src/session/components/floating/index.test.tsx
@@ -455,32 +455,20 @@ describe("FloatingActionButton", () => {
     expect(hoisted.stopTranscription).toHaveBeenCalledWith("session-1");
   });
 
-  it("shows a stop listening FAB while live recording is active", () => {
+  it("keeps the chat FAB on active transcript views", () => {
     hoisted.currentTab = { type: "transcript" };
     hoisted.sessionMode = "active";
 
     renderFloatingActionButton({ audioExists: true });
 
-    fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
-
-    expect(hoisted.stopListening).toHaveBeenCalledTimes(1);
-    expect(hoisted.requestMainListenerControl).not.toHaveBeenCalled();
-  });
-
-  it("delegates live recording stop from standalone windows", () => {
-    hoisted.currentTab = { type: "transcript" };
-    hoisted.sessionMode = "active";
-    hoisted.isMainWebviewWindow = false;
-
-    renderFloatingActionButton({ audioExists: true });
-
-    fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
-
-    expect(hoisted.requestMainListenerControl).toHaveBeenCalledWith(
-      "stop",
-      "session-1",
+    fireEvent.click(
+      screen.getByRole("button", { name: "Ask Anarlog anything" }),
     );
+
+    expect(screen.queryByRole("button", { name: "Stop listening" })).toBeNull();
+    expect(hoisted.sendEvent).toHaveBeenCalledWith({ type: "OPEN" });
     expect(hoisted.stopListening).not.toHaveBeenCalled();
+    expect(hoisted.requestMainListenerControl).not.toHaveBeenCalled();
   });
 
   it("hides the regenerate transcript FAB when audio is missing", () => {

--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -24,10 +24,6 @@ import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { useTabs } from "~/store/zustand/tabs";
 import type { EditorView, Tab } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
-import {
-  isMainWebviewWindow,
-  requestMainListenerControl,
-} from "~/stt/window-control";
 
 export function FloatingActionButton({
   allowListening = true,
@@ -60,18 +56,9 @@ export function FloatingActionButton({
     main.STORE_ID,
   );
   const regenerateTranscript = useRegenerateTranscript(tab.id);
-  const { stop, stopTranscription } = useListener((state) => ({
-    stop: state.stop,
+  const { stopTranscription } = useListener((state) => ({
     stopTranscription: state.stopTranscription,
   }));
-  const handleStopLiveSession = useCallback(() => {
-    if (!isMainWebviewWindow()) {
-      void requestMainListenerControl("stop", tab.id);
-      return;
-    }
-
-    stop();
-  }, [stop, tab.id]);
   const handleStopTranscription = useCallback(() => {
     void stopTranscription(tab.id);
   }, [stopTranscription, tab.id]);
@@ -83,7 +70,6 @@ export function FloatingActionButton({
   const transcriptAction = getTranscriptFloatingAction({
     audioExists,
     currentView,
-    handleStopLiveSession,
     handleStopTranscription,
     regenerateTranscript,
     sessionMode,
@@ -229,15 +215,13 @@ function TranscriptActionButton({
   action,
   onClick,
 }: {
-  action: "regenerate" | "stop-live" | "stop-transcription";
+  action: "regenerate" | "stop-transcription";
   onClick: () => void;
 }) {
   const label =
-    action === "stop-live"
-      ? "Stop listening"
-      : action === "stop-transcription"
-        ? "Stop transcription"
-        : "Regenerate transcript";
+    action === "stop-transcription"
+      ? "Stop transcription"
+      : "Regenerate transcript";
   const Icon = action === "regenerate" ? RefreshCwIcon : SquareIcon;
 
   return (
@@ -304,27 +288,18 @@ function GenerateSummaryButton({
 function getTranscriptFloatingAction({
   audioExists,
   currentView,
-  handleStopLiveSession,
   handleStopTranscription,
   regenerateTranscript,
   sessionMode,
 }: {
   audioExists: boolean;
   currentView: EditorView;
-  handleStopLiveSession: () => void;
   handleStopTranscription: () => void;
   regenerateTranscript: () => void;
   sessionMode: string;
 }) {
   if (currentView.type !== "transcript") {
     return null;
-  }
-
-  if (sessionMode === "active") {
-    return {
-      type: "stop-live" as const,
-      onClick: handleStopLiveSession,
-    };
   }
 
   if (sessionMode === "running_batch") {


### PR DESCRIPTION
Remove the active transcript stop-listening FAB override so live sessions keep showing the chat action.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI-only change to FAB priority with existing stop controls elsewhere (e.g. transcript tab); no auth or data path changes.
> 
> **Overview**
> **Removes the floating “Stop listening” override** on the transcript view while a live session is **active**, so the bottom FAB stays the **chat CTA** (same as other active-meeting surfaces) instead of switching to stop recording.
> 
> `getTranscriptFloatingAction` no longer returns a `stop-live` action for `sessionMode === "active"`; **batch stop transcription** and **regenerate transcript** (inactive + audio) are unchanged. Related listener/window-control wiring (`stop`, `requestMainListenerControl`) is dropped from the floating component only.
> 
> Tests now assert that on an active transcript view the chat button opens chat and **no** “Stop listening” FAB appears.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bedc10790e7e45a16b72b84ec927fb0f08b3cccc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5956
- <kbd>&nbsp;1&nbsp;</kbd> #5951 👈 
<!-- GitButler Footer Boundary Bottom -->