### PR TITLE
Remove memo-only tab shadow

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -472,6 +472,8 @@ describe("Header", () => {
     expect(memoTab.className).toContain("h-7");
     expect(memoTab.className).toContain("bg-white");
     expect(memoTab.className).toContain("border");
+    expect(memoTab.className).toContain("shadow-none");
+    expect(memoTab.className).not.toContain("shadow-xs");
     expect(memoTab.className).not.toContain("bg-foreground/10");
   });
 

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -294,7 +294,7 @@ function HeaderViewRawButton({
       onClick={onClick}
       onContextMenu={onContextMenu}
       size={standalone ? "standalone" : "tray"}
-      className={standalone ? "border-border/70 border shadow-xs" : undefined}
+      className={standalone ? "border-border/70 border shadow-none" : undefined}
     />
   );
 }


### PR DESCRIPTION
Use shadow-none for standalone memo tab chrome and assert raw-only tabs stay shadowless.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on the memo tab header with a matching test update only.
> 
> **Overview**
> When the session header shows **only** the Memos tab (no summary/transcript switcher), the tab’s standalone chrome no longer uses **`shadow-xs`**; it now applies **`shadow-none`** alongside the existing border styling in `HeaderViewRawButton`.
> 
> The **raw-only memo** test was updated to expect **`shadow-none`** and to reject **`shadow-xs`**, so the flat look stays enforced for that layout. Grouped multi-tab headers are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e95ad5895ab8a9f0c12f988f529d1d74934effa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->