### PR TITLE
Tighten sidebar timeline top spacing

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -287,10 +287,10 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-11");
+    ).toContain("top-8");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-18");
+    ).toContain("h-14");
     expect(queryTopOccluder(container)?.className).toContain("h-12");
 
     fireEvent.click(calendarButton);
@@ -317,7 +317,7 @@ describe("TimelineView", () => {
     );
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
-    expect(topSpacer?.className).toContain("h-18");
+    expect(topSpacer?.className).toContain("h-14");
 
     Object.defineProperty(scroller, "clientHeight", {
       configurable: true,
@@ -331,7 +331,7 @@ describe("TimelineView", () => {
     fireEvent.scroll(scroller!);
 
     expect(screen.queryByRole("button", { name: "Open calendar" })).toBeNull();
-    expect(topSpacer?.className).toContain("h-18");
+    expect(topSpacer?.className).toContain("h-14");
     expect(queryTopFade(container)).toBeNull();
     expect(queryTopOccluder(container)?.className).toContain("bg-background");
   });
@@ -456,10 +456,10 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-5");
+    ).toContain("top-2");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
-    ).toContain("h-10");
+    ).toContain("h-8");
 
     fireEvent.click(calendarButton);
 
@@ -738,7 +738,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-11");
+    ).toContain("top-8");
     expect(screen.queryByText("Now")).toBeNull();
 
     fireEvent.click(chip!);
@@ -894,7 +894,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-11");
+    ).toContain("top-8");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-12");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -196,12 +196,12 @@ export const TimelineView = memo(function TimelineView({
     !showUpcomingMeetingChip && !isTodayVisible && isScrolledPastToday;
   const topSpacerClassName = topChromeInset
     ? reserveOpenCalendarChipSpace
-      ? "h-18"
+      ? "h-14"
       : "h-12"
-    : "h-10";
+    : "h-8";
   const bucketHeaderTopClassName = topChromeInset
     ? showOpenCalendarChip
-      ? "top-18"
+      ? "top-14"
       : "top-12"
     : "top-0";
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
@@ -584,7 +584,7 @@ export const TimelineView = memo(function TimelineView({
           data-sidebar-timeline-top-chip-stack
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
-            topChromeInset ? "top-11" : "top-5",
+            topChromeInset ? "top-8" : "top-2",
           ])}
         >
           {showOpenCalendarChip && (


### PR DESCRIPTION
Reduce the floating chip spacer and update timeline tests so the first bucket sits closer to the sidebar chrome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only Tailwind spacing tweaks in the sidebar timeline with matching test updates; no logic, data, or security impact.
> 
> **Overview**
> Reduces vertical padding at the top of the **sidebar timeline** so the first bucket and floating chips sit closer to the chrome.
> 
> In `TimelineView`, **top spacer** heights shrink (`h-18`→`h-14` with chrome + open-calendar reserve, `h-10`→`h-8` without chrome). **Sticky bucket headers** when the open-calendar chip is shown move from `top-18` to `top-14`. The **top chip stack** (`Open calendar`, meeting, Now) moves up (`top-11`→`top-8` with `topChromeInset`, `top-5`→`top-2` without).
> 
> Tests in `index.test.tsx` are updated to match the new Tailwind classes; layout behavior (occluder `h-12`, default `h-12` spacers when not reserving calendar space) is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a719b0185b78477cb89881c467a730990d4dd3c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->