### PR TITLE
Thicken popover outer border

### DIFF
--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -37,7 +37,7 @@ const PopoverContent = React.forwardRef<
         className={cn([
           "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
           variant === "app"
-            ? appFloatingContentClassName
+            ? cn([appFloatingContentClassName, "border-[3px]"])
             : "bg-popover rounded-2xl border p-4 shadow-md",
           className,
         ])}


### PR DESCRIPTION
Set app popover content to use a 3px outer border.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change scoped to app-variant popovers only.
> 
> **Overview**
> **App-variant popovers** now render with a **3px outer border** by layering `border-[3px]` onto the existing `appFloatingContentClassName` styles in `PopoverContent`.
> 
> The default popover variant is unchanged; only `variant="app"` popovers get the thicker border.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2e79816efe4fedb969ee55b6601670f1cf039432. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->