### PR TITLE
Remove meeting control separator

### DIFF
--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -181,7 +181,7 @@ function HeaderMeetingJoinButton({
             aria-label={metadataLabel}
             title={metadataLabel}
             className={cn([
-              "border-border text-muted-foreground flex h-full w-[26px] shrink-0 items-center justify-start border-l pl-[5px]",
+              "text-muted-foreground flex h-full w-[26px] shrink-0 items-center justify-start pl-[5px]",
               "hover:bg-accent hover:text-foreground transition-colors",
               open && "bg-accent text-foreground",
             ])}


### PR DESCRIPTION
Drop the left border between the meeting join button and metadata menu trigger.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic class change on a header button with no logic, data, or security impact.
> 
> **Overview**
> Removes the **left border** on the metadata menu chevron in the session header’s meeting join control (`HeaderMeetingJoinButton`), so the join action and metadata trigger read as one pill without a vertical divider.
> 
> Only the trigger’s Tailwind classes change (`border-border` / `border-l` dropped); layout and behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df46fb7699a03d350da1def469b9e325cf5fdc4f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->