### PR TITLE
Update Anarlog SEO cadence and competitor tracking

### DIFF
--- a/.agents/specs/seo-competitor-content-analysis.md
+++ b/.agents/specs/seo-competitor-content-analysis.md
@@ -1,0 +1,137 @@
+# Anarlog SEO Competitor Content Analysis
+
+Last updated: 2026-07-09 KST.
+
+This is the working competitor/content map for Anarlog SEO. Use it before
+writing alternatives pages, platform pages, privacy explainers, or positioning
+copy.
+
+## Summary
+
+Anarlog's competitor set is moving in two directions at once:
+
+- Large meeting-assistant products are expanding from note-taking into AI
+  agents, workflow automation, CRM sync, enterprise search, and meeting
+  intelligence.
+- Bot-free/no-bot messaging is no longer unique. Granola, Jamie, Fathom, Tactiq,
+  and tl;dv all have some variation of it.
+
+Anarlog should position around the combination of:
+
+- private meeting memory,
+- local-first/user-controlled workflows,
+- bot-free capture,
+- practical meeting notes that people can actually use,
+- and honest comparisons that do not overclaim.
+
+## Tracked Competitors
+
+| Competitor | Primary angle | Content pattern | Anarlog response |
+| --- | --- | --- | --- |
+| Otter.ai | AI Meeting Agent, transcripts, chat, follow-ups, integrations | Productivity/how-to, AI assistant education, feature announcements | Compare against agent/bot workflows; emphasize privacy, control, and less meeting friction. |
+| Fireflies.ai | AI assistant for meetings, email, chat, CRM, knowledge base | Blog hub with meetings, remote work, productivity, compliance, tool education | Compare against auto-join bot and workflow automation; emphasize bot-free/private workflows. |
+| Read.ai | AI copilot across meetings, emails, and messages | Product updates, AI assistant launches, best-tool lists, enterprise/search/workflow content | Compare against broad workplace copilot; emphasize focused meeting memory and user control. |
+| tl;dv | AI meeting agents, recording, transcription, CRM/productivity sync | Heavy SEO, honest reviews, competitor comparisons, meeting recording guides | Treat as an aggressive SEO/content competitor; match useful comparisons without copying tone. |
+| Granola | AI notepad, humans in the room not bots, searchable team memory | Product-led essays, launch notes, thought leadership, how-to/ROI guides | Compete on privacy/local-first and durable workflow control; Granola owns polished AI notepad messaging. |
+| Jamie | Bot-free, privacy-first AI notes across online/offline meetings | Tool reviews, alternatives, privacy/security, templates, meeting guides | Very close positioning competitor; Anarlog needs a sharper local-first and file/workflow story. |
+| Fathom | Free AI notetaker, bot or no bot, summaries, enterprise security | Product/content around free notetaking, Chrome/marketplace, sales workflows | Compare against free/unlimited and bot-free claims; emphasize Anarlog's privacy/control depth. |
+| Tactiq | Chrome extension, live transcripts, instant summaries, no bot required | Learn hub with AI, tools, platform/how-to, prompt/workflow content | Compete on richer meeting memory and native/local experience vs extension-first workflow. |
+| Plaud AI | Hardware + AI note-taking for in-person, phone, online meetings | Product/device pages, app-store content, hardware reviews | Treat as hardware/in-person capture competitor; compare software-first workflow vs device dependency. |
+| Notta | AI transcription, summaries, multilingual, visual meeting decisions | Large SEO hub: transcription, meetings, productivity, sales, comparisons, infographics | Compete on privacy/local-first and meeting-specific workflow; watch broad transcription terms. |
+| Noota | Conversation intelligence, AI agents, CRM/email/phone workflows | Team productivity, CRM sync, recruitment/sales content | Treat as sales/recruiting workflow competitor more than pure personal notes competitor. |
+| Meetily | Local/open-source meeting transcription | Open/local comparison angle | Use for local/open-source and self-hosted comparisons; avoid overstating polish. |
+
+## Content Opportunities
+
+### Near-Win Refreshes
+
+- `meeting-minutes-software`
+- `best-ai-notetaker-for-microsoft-teams`
+- `best-ai-notetaker-for-zoom`
+
+These already map to keywords where Anarlog has some ranking traction or a
+relevant existing URL.
+
+### Conversion Pages
+
+- `otter-ai-alternatives`
+- `granola-ai-alternatives`
+- `plaud-ai-alternatives`
+- `fireflies-ai-alternatives`
+- `read-ai-alternatives`
+- `tldv-alternatives`
+- `fathom-ai-alternatives`
+- `tactiq-alternatives`
+- `jamie-ai-alternatives`
+
+The angle should be honest use-case fit:
+
+- choose Anarlog for private, bot-free, local-first/user-controlled meeting
+  memory,
+- choose bot/agent products for workflow automation and enterprise CRM sync,
+- choose hardware products when physical in-person capture is the main need,
+- choose Chrome-extension tools for lightweight browser-only capture.
+
+### Top-Of-Funnel Pages
+
+- Private AI notetaker
+- Bot-free AI meeting assistant
+- Local AI meeting notes
+- Meeting memory software
+- AI meeting notes without a bot
+- Meeting minutes software
+- AI notetaker for sensitive meetings
+- Best AI notetaker for in-person meetings
+
+### Trust And Privacy Pages
+
+- Is Otter.ai safe?
+- Is Fireflies.ai safe?
+- Is Read.ai safe?
+- Is Granola private?
+- AI notetaker consent guide
+- Can you transcribe meetings without sending data to the cloud?
+
+## Analysis Checklist
+
+Before writing or refreshing a competitor page:
+
+1. Pull Semrush keyword metrics and current Anarlog rankings.
+2. Visit competitor homepage and record the current headline/subheadline.
+3. Visit their blog/content hub and classify their content pattern.
+4. Search for their alternatives/comparison pages.
+5. Check privacy/security pages if the post makes trust claims.
+6. Check whether they support bot-free capture, visible bots, or both.
+7. Identify what Anarlog can honestly claim.
+8. Identify what Anarlog should not claim.
+9. Create or update body visuals only with real screenshots or conceptual
+   diagrams.
+
+## Positioning Guardrails
+
+- Do not say Anarlog is the only bot-free product.
+- Do not say a competitor is unsafe without sourced evidence.
+- Do not fake competitor UI screenshots.
+- Do not write generic "best AI notetaker" filler; every section should help a
+  user decide.
+- Prefer specific use-case fit over generic ranking language.
+
+## Research Sources To Recheck
+
+Use Semrush for keyword and SERP data. Use competitor sites for current
+messaging and content examples.
+
+Starting URLs:
+
+- https://otter.ai/
+- https://fireflies.ai/
+- https://www.read.ai/
+- https://tldv.io/
+- https://www.granola.ai/
+- https://www.meetjamie.ai/en
+- https://www.fathom.ai/
+- https://tactiq.io/
+- https://www.plaud.ai/
+- https://www.notta.ai/en
+- https://www.noota.io/
+

--- a/.agents/specs/seo-content-engine.md
+++ b/.agents/specs/seo-content-engine.md
@@ -1,6 +1,6 @@
 # Anarlog SEO Content Engine
 
-Last updated: 2026-07-07 KST.
+Last updated: 2026-07-09 KST.
 
 This is the operating note for autonomous Anarlog blog work. It complements
 `apps/web/content/AGENTS.md`, which remains the source of truth for positioning
@@ -8,23 +8,29 @@ and voice.
 
 ## Goal
 
-Use Anarlog's existing SEO traction to drive acquisition. Ship useful posts on a
-steady cadence, refresh posts that are close to ranking wins, and keep blog media
-clean in Supabase.
+Use Anarlog's existing SEO traction to drive acquisition. Ship genuinely useful
+posts on a steady cadence, refresh posts that are close to ranking wins, and
+keep blog media clean in Supabase.
 
 Anarlog is the SEO-led acquisition product. Char/Charpedia content should remain
 founder/product/category narrative unless explicitly requested otherwise.
 
 ## Cadence
 
-- Publish or refresh about 6 posts per month as the baseline, but prioritize a
-  natural 3-4 day gap over exact monthly arithmetic.
-- Schedule each next post randomly 3 or 4 days after the latest published/dated
+- Publish or refresh on a natural 1-2 day gap when we have something genuinely
+  useful to ship.
+- Schedule each next post randomly 1 or 2 days after the latest published/dated
   post. If the latest post is dated today, count from today.
-- Default monthly mix:
-  - 3 top-of-funnel posts or refreshes.
-  - 2 conversion posts or refreshes.
-  - 1 landing-page-support or strategic refresh post.
+- Do not publish thin, generic, or mechanically padded posts just to hit
+  cadence. If the content is not helpful, skip the slot and reset from the next
+  real publish date.
+- Default rolling mix:
+  - Top-of-funnel posts or refreshes for meeting workflows, privacy, and
+    category education.
+  - Conversion posts or refreshes for competitor alternatives and
+    platform-specific pages.
+  - Landing-page-support or strategic refresh posts when they strengthen
+    conversion paths.
 
 ## Post Types
 
@@ -47,6 +53,56 @@ founder/product/category narrative unless explicitly requested otherwise.
   - Platform pages where Anarlog already has a relevant article.
   - Strategic privacy/local/bot-free terms when they strengthen category
     positioning, even if exact volume is small.
+
+## Competitor Tracking
+
+Track both product competitors and SERP competitors.
+
+Primary product competitors:
+
+- Otter.ai
+- Fireflies.ai
+- tl;dv
+- Read.ai
+- Granola
+- Plaud AI
+- Fathom
+- Tactiq
+- Jamie
+- Notta
+- Noota
+- Meetily
+
+SERP/content competitors to watch opportunistically:
+
+- Zapier
+- Microsoft
+- Zoom
+- Reddit
+- YouTube
+- Product review sites and app marketplaces
+
+Current pattern from July 2026 research:
+
+- Otter, Fireflies, Read, and Fathom increasingly message around AI agents,
+  workflow automation, meeting knowledge, and CRM/productivity integrations.
+- Granola, Jamie, Fathom, Tactiq, and tl;dv now all have some form of bot-free
+  or no-bot messaging, so Anarlog should not rely on "bot-free" alone.
+- Anarlog's sharper angle should combine bot-free capture with privacy,
+  local-first/user-controlled workflows, and genuinely useful meeting memory.
+- Competitor blogs are publishing a mix of product updates, SEO comparison
+  pages, platform/how-to content, privacy/security explainers, and role/workflow
+  guides.
+
+Research each competitor before writing conversion content:
+
+- Homepage positioning and current headline.
+- Blog/content hub categories.
+- Comparison/alternatives pages they already rank with.
+- Privacy/security claims.
+- Bot/no-bot behavior.
+- Integrations and workflow promises.
+- Any recent launch that changes the comparison.
 
 ## Current First-Cycle Targets
 


### PR DESCRIPTION
## Summary
- update SEO publishing cadence from 3-4 days to 1-2 days with an explicit quality gate
- add tracked product and SERP competitor sets
- add a competitor/content analysis spec with messaging patterns, content opportunities, and guardrails

## Research
- Used Semrush snapshot from 2026-07-08 for existing keyword/competitor signals
- Checked current public competitor messaging/content hubs for Otter, Fireflies, Read, tl;dv, Granola, Jamie, Fathom, Tactiq, Plaud, Notta, and Noota

## Verification
- pnpm exec dprint check --allow-no-files .agents/specs/seo-content-engine.md .agents/specs/seo-competitor-content-analysis.md

## Note
- Linear connector auth is currently expired, so this lands the repo-side operating spec first. Linear docs should be synced after re-auth.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes to agent specs; no application code, auth, or data paths.
> 
> **Overview**
> Updates Anarlog’s SEO operating docs: **publishing cadence** moves from a 3–4 day / ~6-posts-per-month model to **1–2 day gaps** with an explicit rule to **skip slots** when content isn’t genuinely useful, and the monthly post mix is reframed as a **rolling mix** of funnel, conversion, and landing-support work.
> 
> **`seo-content-engine.md`** gains a **Competitor Tracking** section (product vs SERP competitors, July 2026 messaging patterns, and a research checklist before conversion content).
> 
> **New `seo-competitor-content-analysis.md`** adds a full competitor/content map: tracked rivals with angles and Anarlog responses, near-win refreshes, conversion and TOFU page targets, trust/privacy topics, analysis checklist, positioning guardrails, and seed research URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0600d33116f41599528de2f5b7c92928a4859839. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->