### PR TITLE
Add Anarlog privacy-to-enterprise narrative

### DIFF
--- a/.agents/specs/seo-competitor-content-analysis.md
+++ b/.agents/specs/seo-competitor-content-analysis.md
@@ -24,6 +24,40 @@ Anarlog should position around the combination of:
 - practical meeting notes that people can actually use,
 - and honest comparisons that do not overclaim.
 
+## Privacy-To-Enterprise Narrative
+
+The acquisition story should start with prosumers and individuals, then grow
+into the enterprise security conversation.
+
+Stage 1: individual privacy.
+
+- "I want AI meeting notes, but I do not want every sensitive conversation
+  handled by a cloud bot."
+- Target readers: founders, operators, consultants, engineers, researchers,
+  executives, and anyone taking sensitive meetings.
+- Content themes: private AI notetaker, local AI meeting notes, bot-free meeting
+  assistant, AI notes for sensitive meetings, data-retention explainers.
+
+Stage 2: team trust.
+
+- "If my own meetings deserve privacy, my team's conversations deserve it too."
+- Target readers: small teams, startups, agencies, product teams, customer
+  teams, and leadership groups.
+- Content themes: shared meeting memory, internal meeting privacy, team meeting
+  notes without bots, access control, workflow ownership.
+
+Stage 3: enterprise security.
+
+- "Our organization cares about data privacy and meeting security; is Anarlog a
+  fit?"
+- Target readers: IT, security, operations, legal, and procurement.
+- Content themes: security posture, data handling, compliance readiness,
+  deployment controls, admin workflows, vendor risk.
+
+Important guardrail: do not overclaim enterprise readiness before the product,
+security posture, and proof assets support it. Use individual privacy and
+team-level trust as the credible path into enterprise demand.
+
 ## Tracked Competitors
 
 | Competitor | Primary angle | Content pattern | Anarlog response |
@@ -82,6 +116,9 @@ The angle should be honest use-case fit:
 - Meeting minutes software
 - AI notetaker for sensitive meetings
 - Best AI notetaker for in-person meetings
+- AI meeting notes for founders
+- AI meeting notes for consultants
+- AI meeting notes for confidential meetings
 
 ### Trust And Privacy Pages
 
@@ -91,6 +128,9 @@ The angle should be honest use-case fit:
 - Is Granola private?
 - AI notetaker consent guide
 - Can you transcribe meetings without sending data to the cloud?
+- Meeting notes data privacy guide
+- AI meeting notetaker security checklist
+- How to evaluate AI meeting tools for sensitive conversations
 
 ## Analysis Checklist
 
@@ -115,6 +155,8 @@ Before writing or refreshing a competitor page:
 - Do not write generic "best AI notetaker" filler; every section should help a
   user decide.
 - Prefer specific use-case fit over generic ranking language.
+- Do not overstate enterprise compliance/security claims before the underlying
+  product and proof points are ready.
 
 ## Research Sources To Recheck
 
@@ -134,4 +176,3 @@ Starting URLs:
 - https://www.plaud.ai/
 - https://www.notta.ai/en
 - https://www.noota.io/
-

--- a/.agents/specs/seo-content-engine.md
+++ b/.agents/specs/seo-content-engine.md
@@ -40,6 +40,31 @@ founder/product/category narrative unless explicitly requested otherwise.
   pages that compare tools while routing readers toward Anarlog's private,
   local-first, bot-free positioning.
 
+## Narrative Arc
+
+Lead with privacy for prosumers and individuals, then bridge that trust into an
+enterprise security narrative.
+
+- Prosumer/individual entry point: "I want useful AI meeting notes without
+  handing every sensitive conversation to a random cloud bot."
+- Team expansion point: "If privacy matters this much for my own meetings, it
+  matters even more for my team's internal discussions."
+- Enterprise bridge: "Anarlog is built for organizations that care about data
+  privacy, meeting security, and user-controlled workflows."
+
+Content should make this progression feel natural:
+
+- Start with user-level privacy, local-first control, bot-free capture, and
+  sensitive meeting use cases.
+- Add team-level workflows around shared meeting memory, controlled access, and
+  less social friction in calls.
+- Later, build enterprise pages around security, data handling, compliance
+  posture, deployment controls, and procurement-ready trust materials.
+
+Do not make enterprise claims before the product and proof points support them.
+Use "privacy-first" and "security-conscious" as the bridge until formal
+enterprise security assets are ready.
+
 ## Keyword Workflow
 
 - Use Semrush as the source for keyword and SERP research. Do not fall back to
@@ -90,6 +115,9 @@ Current pattern from July 2026 research:
   or no-bot messaging, so Anarlog should not rely on "bot-free" alone.
 - Anarlog's sharper angle should combine bot-free capture with privacy,
   local-first/user-controlled workflows, and genuinely useful meeting memory.
+- The acquisition narrative should begin with privacy for individuals and
+  prosumers, then mature into enterprise security and organizational data
+  privacy as teams adopt it.
 - Competitor blogs are publishing a mix of product updates, SEO comparison
   pages, platform/how-to content, privacy/security explainers, and role/workflow
   guides.


### PR DESCRIPTION
## Summary
- document the prosumer privacy -> team trust -> enterprise security narrative
- add content themes for each stage of the narrative
- add guardrails against overclaiming enterprise/security readiness before proof points exist

## Verification
- pnpm exec dprint check --allow-no-files .agents/specs/seo-content-engine.md .agents/specs/seo-competitor-content-analysis.md

## Note
- Linear connector auth was expired in the previous attempt; this lands the repo-side operating spec first.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Spec-only documentation for SEO/content agents; no runtime, product, or security behavior changes.
> 
> **Overview**
> Updates **Anarlog SEO agent specs** so content work follows a staged story: individual privacy → team trust → enterprise security, instead of jumping straight to org-level claims.
> 
> **`seo-content-engine.md`** adds a **Narrative Arc** section (prosumer entry, team expansion, enterprise bridge) and ties competitor-tracking notes to that progression, with language limited to privacy-first / security-conscious until formal enterprise proof exists.
> 
> **`seo-competitor-content-analysis.md`** expands the same model into three stages (audiences, messaging hooks, content themes), adds TOFU and trust/privacy page ideas (founders, consultants, confidential meetings, security checklists), and extends **positioning guardrails** against overstating compliance or enterprise readiness.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111a7d82b7a455cbdf856837828297db2aa9932d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->