### PR TITLE
Place meeting countdown beside header action

### DIFF
--- a/apps/desktop/src/session/components/floating/listen.test.tsx
+++ b/apps/desktop/src/session/components/floating/listen.test.tsx
@@ -44,7 +44,7 @@ vi.mock("~/session/hooks/useEventCountdown", () => ({
     if (options?.onExpire) {
       countdownCallbacks.push(options.onExpire);
     }
-    return { label: "meeting starts in 1s" };
+    return { label: "starts in 1s" };
   },
 }));
 
@@ -95,6 +95,7 @@ describe("floating ListenButton", () => {
     expect(
       screen.getByRole("button", { name: "Listen session-1" }),
     ).not.toBeNull();
+    expect(screen.queryByText("starts in 1s")).toBeNull();
     expect(screen.queryByRole("button", { name: /Join/ })).toBeNull();
   });
 });

--- a/apps/desktop/src/session/components/floating/listen.tsx
+++ b/apps/desktop/src/session/components/floating/listen.tsx
@@ -37,7 +37,7 @@ export function ListenButton({
     tab,
     updateSessionTabState,
   ]);
-  const countdown = useEventCountdown(tab.id, {
+  useEventCountdown(tab.id, {
     onExpire: handleCountdownExpire,
   });
 
@@ -49,14 +49,5 @@ export function ListenButton({
     return null;
   }
 
-  return (
-    <div className="flex flex-col items-center gap-2">
-      {countdown.label && (
-        <div className="text-muted-foreground text-xs whitespace-nowrap">
-          <span>{countdown.label}</span>
-        </div>
-      )}
-      <ListenActionButton sessionId={tab.id} />
-    </div>
-  );
+  return <ListenActionButton sessionId={tab.id} />;
 }

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -137,6 +137,7 @@ describe("OuterHeader", () => {
 
   afterEach(() => {
     cleanup();
+    vi.useRealTimers();
   });
 
   it("does not show a separate stop listening button for active sessions while the sidebar is collapsed", () => {
@@ -391,6 +392,69 @@ describe("OuterHeader", () => {
       null,
     );
     expect(mocks.startListening).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows the meeting countdown to the left of the header action", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-05T09:55:30.000Z"));
+    mocks.nowMs = Date.now();
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const countdown = screen.getByText("starts in 4m 30s");
+    const joinButton = screen.getByRole("button", { name: "Join & record" });
+
+    expect(countdown.getAttribute("data-header-meeting-countdown")).toBe(
+      "true",
+    );
+    expect(countdown.className).toContain("font-mono");
+    expect(
+      countdown.compareDocumentPosition(joinButton) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBe(Node.DOCUMENT_POSITION_FOLLOWING);
+    expect(joinButton.textContent).not.toContain("starts in");
+  });
+
+  it("hides the meeting countdown while listening is active", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-06-05T09:55:30.000Z"));
+    mocks.nowMs = Date.now();
+    mocks.sessionModes = { "session-1": "active" };
+    mocks.sessionEvents = {
+      "session-1": {
+        title: "Design Review",
+        started_at: "2026-06-05T10:00:00.000Z",
+        ended_at: "2026-06-05T10:30:00.000Z",
+        meeting_link: "https://meet.google.com/abc-defg-hij",
+      },
+    };
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "raw" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    expect(screen.getByRole("button", { name: "Stop" })).not.toBeNull();
+    expect(
+      document.querySelector("[data-header-meeting-countdown]"),
+    ).toBeNull();
   });
 
   it("shows record before a meeting without a video link", () => {

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -16,6 +16,7 @@ import { OverflowButton } from "./overflow";
 
 import { useNow } from "~/calendar/hooks";
 import { useShell } from "~/contexts/shell";
+import { useEventCountdown } from "~/session/hooks/useEventCountdown";
 import {
   getRemoteMeeting,
   type RemoteMeeting,
@@ -138,6 +139,7 @@ function HeaderMeetingActionPill({
   const ended = !!endedAt && endedAt.getTime() <= now.getTime();
   const hasTranscript = useHasTranscript(sessionId);
   const { t } = useLingui();
+  const countdown = useEventCountdown(sessionId);
   const start = useCallback(() => {
     if (!isMainWebviewWindow()) {
       void requestMainListenerControl("start", sessionId);
@@ -204,44 +206,59 @@ function HeaderMeetingActionPill({
     };
   })();
   const disabled = sessionMode === "finalizing";
+  const showCountdown =
+    Boolean(countdown.label) &&
+    sessionMode !== "active" &&
+    sessionMode !== "running_batch" &&
+    sessionMode !== "finalizing";
 
   return (
-    <div className="border-border bg-card text-foreground mr-1 flex h-7 max-w-56 shrink-0 items-center overflow-hidden rounded-full border">
-      <button
-        type="button"
-        data-tauri-drag-region="false"
-        aria-label={action.label}
-        title={action.title}
-        disabled={disabled}
-        onClick={action.onClick}
-        className={cn([
-          "flex h-full min-w-0 items-center gap-1.5 py-0 pr-1.5 pl-2.5",
-          "text-sm font-medium",
-          "hover:bg-accent transition-colors",
-          disabled && "cursor-default opacity-60 hover:bg-transparent",
-        ])}
-      >
-        {action.icon}
-        <span className="truncate">{action.label}</span>
-      </button>
-      <MetadataButton
-        sessionId={sessionId}
-        renderTrigger={({ open, label: metadataLabel }) => (
-          <button
-            type="button"
-            data-tauri-drag-region="false"
-            aria-label={metadataLabel}
-            title={metadataLabel}
-            className={cn([
-              "text-muted-foreground flex h-full w-5 shrink-0 items-center justify-center",
-              "hover:bg-accent hover:text-foreground transition-colors",
-              open && "bg-accent text-foreground",
-            ])}
-          >
-            <ChevronDownIcon size={14} />
-          </button>
-        )}
-      />
+    <div className="mr-1 flex min-w-0 shrink-0 items-center gap-2">
+      {showCountdown ? (
+        <div
+          data-header-meeting-countdown
+          className="text-muted-foreground max-w-40 truncate font-mono text-xs whitespace-nowrap"
+        >
+          {countdown.label}
+        </div>
+      ) : null}
+      <div className="border-border bg-card text-foreground flex h-7 max-w-56 shrink-0 items-center overflow-hidden rounded-full border">
+        <button
+          type="button"
+          data-tauri-drag-region="false"
+          aria-label={action.label}
+          title={action.title}
+          disabled={disabled}
+          onClick={action.onClick}
+          className={cn([
+            "flex h-full min-w-0 items-center gap-1.5 py-0 pr-1.5 pl-2.5",
+            "text-sm font-medium",
+            "hover:bg-accent transition-colors",
+            disabled && "cursor-default opacity-60 hover:bg-transparent",
+          ])}
+        >
+          {action.icon}
+          <span className="truncate">{action.label}</span>
+        </button>
+        <MetadataButton
+          sessionId={sessionId}
+          renderTrigger={({ open, label: metadataLabel }) => (
+            <button
+              type="button"
+              data-tauri-drag-region="false"
+              aria-label={metadataLabel}
+              title={metadataLabel}
+              className={cn([
+                "text-muted-foreground flex h-full w-5 shrink-0 items-center justify-center",
+                "hover:bg-accent hover:text-foreground transition-colors",
+                open && "bg-accent text-foreground",
+              ])}
+            >
+              <ChevronDownIcon size={14} />
+            </button>
+          )}
+        />
+      </div>
     </div>
   );
 }

--- a/apps/desktop/src/session/hooks/useEventCountdown.test.tsx
+++ b/apps/desktop/src/session/hooks/useEventCountdown.test.tsx
@@ -32,7 +32,7 @@ describe("useEventCountdown", () => {
       useEventCountdown("session-1", { onExpire }),
     );
 
-    expect(result.current.label).toBe("meeting starts in 2s");
+    expect(result.current.label).toBe("starts in 2s");
 
     act(() => {
       vi.advanceTimersByTime(2000);

--- a/apps/desktop/src/session/hooks/useEventCountdown.ts
+++ b/apps/desktop/src/session/hooks/useEventCountdown.ts
@@ -49,11 +49,7 @@ export function useEventCountdown(
       const totalSeconds = Math.floor(diff / 1000);
       const mins = Math.floor(totalSeconds / 60);
       const secs = totalSeconds % 60;
-      setLabel(
-        mins > 0
-          ? `meeting starts in ${mins}m ${secs}s`
-          : `meeting starts in ${secs}s`,
-      );
+      setLabel(mins > 0 ? `starts in ${mins}m ${secs}s` : `starts in ${secs}s`);
     };
 
     update();


### PR DESCRIPTION
Show the scheduled meeting countdown to the left of the join or record header control and keep the floating listen slot action-only.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5960 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5959
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI relocation and copy change only; auto-start on countdown expiry behavior in the floating listen path is unchanged.
> 
> **Overview**
> Moves the scheduled-meeting countdown from the **floating listen** control into the **session outer header**, shown to the left of the join/record pill (mono text, `data-header-meeting-countdown`).
> 
> The floating `ListenButton` still wires `useEventCountdown` for **auto-start on expire** but no longer renders the countdown label—only the listen action. Countdown copy is shortened from `meeting starts in …` to **`starts in …`** in `useEventCountdown`.
> 
> The header hides the countdown while listening is **active**, **running_batch**, or **finalizing**; tests cover placement, styling, and that active sessions do not show it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 64ee65b4eb9df1ab60a41cb9c35a5b09d7e4765b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->