### PR TITLE
Reduce sidebar timeline chip top gap

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -327,7 +327,7 @@ describe("ClassicMainBody", () => {
     expect(sidebarContent?.getAttribute("aria-hidden")).toBe("false");
     expect(sidebarChrome).toBeNull();
     expect(sidebarTimelineHeader).toBeTruthy();
-    expect(sidebarTimelineHeader?.className).toContain("h-12");
+    expect(sidebarTimelineHeader?.className).toContain("h-9");
     expect(sidebarTimelineHeader?.className).not.toContain("absolute");
 
     const bodyRoot = screen.getByTestId("panel-group").parentElement;

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -505,7 +505,7 @@ export function ClassicMainBody() {
     <div
       data-tauri-drag-region
       data-sidebar-timeline-header
-      className="flex h-12 shrink-0 items-start pt-[9px] pr-1 pl-[76px]"
+      className="flex h-9 shrink-0 items-start pt-[9px] pr-1 pl-[76px]"
       onWheelCapture={handleSidebarTimelineHeaderWheel}
     >
       <SidebarTimelineChrome

--- a/apps/desktop/src/shared/main/body.test.tsx
+++ b/apps/desktop/src/shared/main/body.test.tsx
@@ -240,7 +240,7 @@ describe("ClassicMainBody", () => {
     expect(chromeFrame).toBe(timelineHeader);
     expect(chromeFrame?.className).toContain("pr-1");
     expect(chromeFrame?.className).not.toContain("pr-3");
-    expect(timelineHeader?.className).toContain("h-12");
+    expect(timelineHeader?.className).toContain("h-9");
     expect(timelineHeader?.className).not.toContain("absolute");
     expect(chrome?.hasAttribute("data-tauri-drag-region")).toBe(true);
     expect(
@@ -452,7 +452,7 @@ describe("ClassicMainBody", () => {
     expect(sidebarToggle.parentElement?.className.split(" ")).not.toContain(
       "gap-0.5",
     );
-    expect(timelineHeader?.className).toContain("h-12");
+    expect(timelineHeader?.className).toContain("h-9");
     expect(timelineHeader?.className).not.toContain("absolute");
     expect(screen.getByTestId("main-tab-content").textContent).toContain(
       "changelog",

--- a/apps/desktop/src/sidebar/index.test.tsx
+++ b/apps/desktop/src/sidebar/index.test.tsx
@@ -14,14 +14,17 @@ vi.mock("~/store/zustand/tabs", () => ({
 vi.mock("~/sidebar/timeline", () => ({
   TimelineView: ({
     showOpenCalendarButton = true,
+    topChipsOverlapHeader = false,
     topChromeInset = false,
   }: {
     showOpenCalendarButton?: boolean;
+    topChipsOverlapHeader?: boolean;
     topChromeInset?: boolean;
   }) => (
     <div
       data-testid="timeline-view"
       data-show-open-calendar-button={String(showOpenCalendarButton)}
+      data-top-chips-overlap-header={String(topChipsOverlapHeader)}
       data-top-chrome-inset={String(topChromeInset)}
     />
   ),
@@ -70,6 +73,11 @@ describe("LeftSidebar", () => {
     expect(
       screen.getByTestId("timeline-view").getAttribute("data-top-chrome-inset"),
     ).toBe("true");
+    expect(
+      screen
+        .getByTestId("timeline-view")
+        .getAttribute("data-top-chips-overlap-header"),
+    ).toBe("false");
     expect(container.firstElementChild?.className).toContain("pt-0");
     expect(container.firstElementChild?.className).not.toContain("pr-1");
   });
@@ -87,6 +95,11 @@ describe("LeftSidebar", () => {
     expect(
       screen.getByTestId("timeline-view").getAttribute("data-top-chrome-inset"),
     ).toBe("false");
+    expect(
+      screen
+        .getByTestId("timeline-view")
+        .getAttribute("data-top-chips-overlap-header"),
+    ).toBe("true");
   });
 
   it.each([

--- a/apps/desktop/src/sidebar/index.tsx
+++ b/apps/desktop/src/sidebar/index.tsx
@@ -53,6 +53,9 @@ export function LeftSidebar({
               showIgnoredEvents={showIgnoredTimelineEvents}
               onShowIgnoredEventsChange={onShowIgnoredTimelineEventsChange}
               topChromeInset={isTimelineSidebarLayout && !timelineHeader}
+              topChipsOverlapHeader={
+                isTimelineSidebarLayout && !!timelineHeader
+              }
             />
           )}
         </div>

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -287,7 +287,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-8");
+    ).toContain("top-4");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-14");
@@ -464,6 +464,32 @@ describe("TimelineView", () => {
     fireEvent.click(calendarButton);
 
     expect(mocks.openNew).toHaveBeenCalledWith({ type: "calendar" });
+  });
+
+  it("keeps overlapping header chips inside the visible timeline", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.smartCurrentTimeMs = Date.now();
+    mocks.timelineSessionsTable = {
+      later: {
+        title: "Quarterly planning",
+        created_at: "2024-01-17T12:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView topChipsOverlapHeader />);
+
+    expect(
+      container.querySelector("[data-sidebar-timeline-root]")?.className,
+    ).not.toContain("-mt-3");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-chip-stack]")
+        ?.className,
+    ).toContain("top-1");
+    expect(
+      container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
+    ).toContain("h-9");
   });
 
   it("selects all visible notes with Cmd+A after a sidebar note selection", () => {
@@ -738,7 +764,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-8");
+    ).toContain("top-4");
     expect(screen.queryByText("Now")).toBeNull();
 
     fireEvent.click(chip!);
@@ -894,7 +920,7 @@ describe("TimelineView", () => {
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
-    ).toContain("top-8");
+    ).toContain("top-4");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-12");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -64,11 +64,13 @@ export const TimelineView = memo(function TimelineView({
   showOpenCalendarButton = true,
   showIgnoredEvents,
   onShowIgnoredEventsChange,
+  topChipsOverlapHeader = false,
   topChromeInset = false,
 }: {
   showOpenCalendarButton?: boolean;
   showIgnoredEvents?: boolean;
   onShowIgnoredEventsChange?: (showIgnored: boolean) => void;
+  topChipsOverlapHeader?: boolean;
   topChromeInset?: boolean;
 } = {}) {
   const { t } = useLingui();
@@ -198,12 +200,19 @@ export const TimelineView = memo(function TimelineView({
     ? reserveOpenCalendarChipSpace
       ? "h-14"
       : "h-12"
-    : "h-8";
+    : topChipsOverlapHeader
+      ? "h-9"
+      : "h-8";
   const bucketHeaderTopClassName = topChromeInset
     ? showOpenCalendarChip
       ? "top-14"
       : "top-12"
     : "top-0";
+  const topChipStackTopClassName = topChromeInset
+    ? "top-4"
+    : topChipsOverlapHeader
+      ? "top-1"
+      : "top-2";
   const selectedSessionScrollFrameRef = useRef<number | null>(null);
   const scrollSelectedSessionIntoView = useCallback<
     RefCallback<HTMLDivElement>
@@ -502,7 +511,7 @@ export const TimelineView = memo(function TimelineView({
                 className={cn([
                   "sticky z-20",
                   bucketHeaderTopClassName,
-                  "bg-background/95 py-1 pr-1 pl-3 backdrop-blur",
+                  "bg-background/95 pt-0 pr-1 pb-1 pl-3 backdrop-blur",
                 ])}
               >
                 <div className="text-foreground text-base font-bold">
@@ -584,7 +593,7 @@ export const TimelineView = memo(function TimelineView({
           data-sidebar-timeline-top-chip-stack
           className={cn([
             "absolute left-1/2 z-20 flex -translate-x-1/2 transform flex-col items-center gap-2",
-            topChromeInset ? "top-8" : "top-2",
+            topChipStackTopClassName,
           ])}
         >
           {showOpenCalendarChip && (


### PR DESCRIPTION
Move shared top timeline chips closer to the sidebar chrome and cover header-overlap mode in tests.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop sidebar layout and Tailwind class tweaks only; no auth, data, or API changes.
> 
> **Overview**
> **Shrinks the expanded sidebar timeline header** from `h-12` to `h-9` and **moves shared top chips closer to the chrome** (`top-8` → `top-4` when `topChromeInset`).
> 
> When the timeline sits under the in-sidebar header (`timelineHeader`), **`LeftSidebar` enables `topChipsOverlapHeader`** on `TimelineView`, which uses a **`h-9` top spacer**, **`top-1` chip stack**, and avoids negative margin so chips stay visible under the header.
> 
> Sticky bucket headers lose extra top padding (`pt-0` instead of `py-1`). Tests cover the new overlap mode and updated class expectations.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4f22e4696e7235194461b3c16e515f9f1aba50df. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->