### PR TITLE
Increase shared popover corner radius

### DIFF
--- a/packages/ui/src/components/ui/command.tsx
+++ b/packages/ui/src/components/ui/command.tsx
@@ -13,7 +13,7 @@ const Command = React.forwardRef<
   <CommandPrimitive
     ref={ref}
     className={cn([
-      "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-2xl",
+      "bg-popover text-popover-foreground flex h-full w-full flex-col overflow-hidden rounded-[18px]",
       className,
     ])}
     {...props}

--- a/packages/ui/src/components/ui/dropdown-menu.tsx
+++ b/packages/ui/src/components/ui/dropdown-menu.tsx
@@ -51,7 +51,7 @@ const DropdownMenuSubContent = React.forwardRef<
       "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden",
       variant === "app"
         ? appFloatingContentClassName
-        : "bg-popover rounded-2xl border p-1 shadow-lg",
+        : "bg-popover rounded-[18px] border p-1 shadow-lg",
       className,
     ])}
     {...props}
@@ -74,7 +74,7 @@ const DropdownMenuContent = React.forwardRef<
         "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 min-w-32 overflow-hidden",
         variant === "app"
           ? appFloatingContentClassName
-          : "bg-popover rounded-2xl border p-1 shadow-md",
+          : "bg-popover rounded-[18px] border p-1 shadow-md",
         className,
       ])}
       {...props}

--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -12,7 +12,7 @@ export function AppFloatingPanel({
   return (
     <div
       className={cn([
-        "bg-app-floating-panel text-popover-foreground border-app-floating-border rounded-2xl border",
+        "bg-app-floating-panel text-popover-foreground border-app-floating-border rounded-[18px] border",
         className,
       ])}
       {...props}

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -37,8 +37,8 @@ const PopoverContent = React.forwardRef<
         className={cn([
           "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
           variant === "app"
-            ? cn([appFloatingContentClassName, "border-[3px]"])
-            : "bg-popover rounded-2xl border p-4 shadow-md",
+            ? [appFloatingContentClassName, "border-[3px]"]
+            : "bg-popover rounded-[18px] border p-4 shadow-md",
           className,
         ])}
         {...props}

--- a/packages/ui/src/components/ui/select.tsx
+++ b/packages/ui/src/components/ui/select.tsx
@@ -71,7 +71,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn([
-        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-2xl border shadow-md",
+        "bg-popover text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 relative z-50 max-h-(--radix-select-content-available-height) min-w-32 origin-(--radix-select-content-transform-origin) overflow-x-hidden overflow-y-auto rounded-[18px] border shadow-md",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className,


### PR DESCRIPTION
Bump shared app floating surfaces and default popover-style overlays by two pixels.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class changes only; no logic, data, or API impact.
> 
> **Overview**
> **Increases corner radius by 2px** on shared popover-style and app floating surfaces, replacing `rounded-2xl` (16px) with `rounded-[18px]` for visual consistency.
> 
> Applies to **Command**, **Select** dropdown panels, **default** **Popover** and **DropdownMenu** content/subcontent, and **AppFloatingPanel** in `floating-content.tsx`. **Popover**’s `app` variant stops wrapping those classes in an extra `cn()` and passes a plain array into the existing `cn()` merge instead (behavior unchanged).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9922c8d7bbbc2190db048dbc1056b784f37d7d7e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->