### PR TITLE
Replace upcoming row countdown pill with gauge

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -201,17 +201,20 @@ vi.mock("./item", () => ({
     item,
     itemNodeRef,
     upcomingLabel,
+    upcomingProgress,
   }: {
     isUpcoming?: boolean;
     item: { id: string };
     itemNodeRef?: (node: HTMLDivElement | null) => void;
     upcomingLabel?: string;
+    upcomingProgress?: number;
   }) => (
     <div
       ref={itemNodeRef}
       data-testid={`timeline-item-${item.id}`}
       data-upcoming={isUpcoming ? "true" : undefined}
       data-upcoming-label={upcomingLabel}
+      data-upcoming-progress={upcomingProgress}
     />
   ),
 }));
@@ -758,6 +761,9 @@ describe("TimelineView", () => {
     expect(
       screen.getByTestId("timeline-item-standup").dataset.upcomingLabel,
     ).toBe("In 51s");
+    expect(
+      screen.getByTestId("timeline-item-standup").dataset.upcomingProgress,
+    ).toBe("0.17");
     expect(
       container.querySelector("[data-sidebar-timeline-top-spacer]")?.className,
     ).toContain("h-12");

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -531,6 +531,7 @@ export const TimelineView = memo(function TimelineView({
                   getFlatItemKeys={getFlatItemKeys}
                   upcomingItemKey={upcomingMeetingStatus?.itemKey}
                   upcomingItemLabel={upcomingMeetingStatus?.label}
+                  upcomingItemProgress={upcomingMeetingStatus?.progress}
                   upcomingItemNodeRef={setUpcomingMeetingNodeRef}
                 />
               ) : (
@@ -559,6 +560,11 @@ export const TimelineView = memo(function TimelineView({
                       upcomingLabel={
                         itemKey === upcomingMeetingStatus?.itemKey
                           ? upcomingMeetingStatus.label
+                          : undefined
+                      }
+                      upcomingProgress={
+                        itemKey === upcomingMeetingStatus?.itemKey
+                          ? upcomingMeetingStatus.progress
                           : undefined
                       }
                     />
@@ -867,6 +873,7 @@ function TodayBucket({
   getFlatItemKeys,
   upcomingItemKey,
   upcomingItemLabel,
+  upcomingItemProgress,
   upcomingItemNodeRef,
 }: {
   items: TimelineItem[];
@@ -880,6 +887,7 @@ function TodayBucket({
   getFlatItemKeys: () => string[];
   upcomingItemKey?: string;
   upcomingItemLabel?: string;
+  upcomingItemProgress?: number;
   upcomingItemNodeRef: RefCallback<HTMLDivElement>;
 }) {
   const currentTimeMs = useCurrentTimeMs();
@@ -960,6 +968,9 @@ function TodayBucket({
           upcomingLabel={
             itemKey === upcomingItemKey ? upcomingItemLabel : undefined
           }
+          upcomingProgress={
+            itemKey === upcomingItemKey ? upcomingItemProgress : undefined
+          }
         />
       );
 
@@ -1024,6 +1035,7 @@ function TodayBucket({
     getFlatItemKeys,
     upcomingItemKey,
     upcomingItemLabel,
+    upcomingItemProgress,
     upcomingItemNodeRef,
   ]);
 

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -270,29 +270,30 @@ describe("TimelineItemComponent", () => {
         multiSelected={false}
         flatItemKeys={["event-event-standup"]}
         isUpcoming
-        upcomingLabel="In 4 minutes"
+        upcomingProgress={0.8}
       />,
     );
 
     const rowButton = screen.getByText("Team standup").closest("button");
-    const countdown = screen.getByText("In 4 minutes");
+    const gauge = document.querySelector(
+      "[data-sidebar-timeline-upcoming-gauge]",
+    );
+    const gaugeFill = document.querySelector<HTMLElement>(
+      "[data-sidebar-timeline-upcoming-gauge-fill]",
+    );
 
     expect(rowButton?.className).toContain("bg-destructive/8");
+    expect(rowButton?.className).toContain("pl-4");
     expect(rowButton?.className).not.toContain("motion-safe:animate-pulse");
     expect(rowButton?.className).not.toContain("shadow-[0_0_22px");
     expect(rowButton?.className).not.toContain("ring-1");
     expect(rowButton?.className).not.toContain("opacity-65");
-    expect(
-      countdown.getAttribute("data-sidebar-timeline-upcoming-countdown"),
-    ).toBe("true");
-    expect(countdown.className).toContain("bg-destructive");
-    expect(countdown.className).toContain("rounded-full");
-    expect(countdown.className).toContain("text-[11px]");
-    expect(countdown.className).not.toContain("w-24");
-    expect(countdown.className).toContain("justify-center");
+    expect(screen.queryByText("In 4 minutes")).toBeNull();
+    expect(gauge).not.toBeNull();
+    expect(gaugeFill?.style.height).toBe("80%");
   });
 
-  it("does not render a countdown chip on non-upcoming rows", () => {
+  it("renders a full gauge for an active upcoming meeting row", () => {
     render(
       <TimelineItemComponent
         item={{
@@ -311,11 +312,44 @@ describe("TimelineItemComponent", () => {
         timezone="UTC"
         multiSelected={false}
         flatItemKeys={["event-event-standup"]}
-        upcomingLabel="In 4 minutes"
+        isUpcoming
+        upcomingProgress={1}
       />,
     );
 
-    expect(screen.queryByText("In 4 minutes")).toBeNull();
+    expect(
+      document.querySelector<HTMLElement>(
+        "[data-sidebar-timeline-upcoming-gauge-fill]",
+      )?.style.height,
+    ).toBe("100%");
+  });
+
+  it("does not render an upcoming gauge on non-upcoming rows", () => {
+    render(
+      <TimelineItemComponent
+        item={{
+          type: "event",
+          id: "event-standup",
+          data: {
+            title: "Team standup",
+            started_at: "2024-01-15T10:30:00.000Z",
+            ended_at: "2024-01-15T11:00:00.000Z",
+            tracking_id_event: "tracking-standup",
+            has_recurrence_rules: false,
+          },
+        }}
+        precision="time"
+        selected={false}
+        timezone="UTC"
+        multiSelected={false}
+        flatItemKeys={["event-event-standup"]}
+        upcomingProgress={0.8}
+      />,
+    );
+
+    expect(
+      document.querySelector("[data-sidebar-timeline-upcoming-gauge]"),
+    ).toBeNull();
   });
 
   it("exposes an arbitrary timeline row for visibility checks", () => {

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -61,7 +61,7 @@ type ItemBaseProps = {
   itemNodeRef?: RefCallback<HTMLDivElement>;
   timelineSessionId?: string;
   isUpcoming?: boolean;
-  upcomingLabel?: string;
+  upcomingProgress?: number;
 };
 
 export const TimelineItemComponent = memo(
@@ -76,7 +76,7 @@ export const TimelineItemComponent = memo(
     selectedNodeRef,
     itemNodeRef,
     isUpcoming,
-    upcomingLabel,
+    upcomingProgress,
   }: {
     item: TimelineItem;
     precision: TimelinePrecision;
@@ -89,6 +89,7 @@ export const TimelineItemComponent = memo(
     itemNodeRef?: RefCallback<HTMLDivElement>;
     isUpcoming?: boolean;
     upcomingLabel?: string;
+    upcomingProgress?: number;
   }) => {
     const readFlatItemKeys =
       getFlatItemKeys ?? (() => flatItemKeys ?? EMPTY_TIMELINE_ITEM_KEYS);
@@ -105,7 +106,7 @@ export const TimelineItemComponent = memo(
           selectedNodeRef={selectedNodeRef}
           itemNodeRef={itemNodeRef}
           isUpcoming={isUpcoming}
-          upcomingLabel={upcomingLabel}
+          upcomingProgress={upcomingProgress}
         />
       );
     }
@@ -120,7 +121,7 @@ export const TimelineItemComponent = memo(
         selectedNodeRef={selectedNodeRef}
         itemNodeRef={itemNodeRef}
         isUpcoming={isUpcoming}
-        upcomingLabel={upcomingLabel}
+        upcomingProgress={upcomingProgress}
       />
     );
   },
@@ -148,13 +149,20 @@ const ItemBase = memo(function ItemBase({
   itemNodeRef,
   timelineSessionId,
   isUpcoming,
-  upcomingLabel,
+  upcomingProgress,
 }: ItemBaseProps) {
   const { t } = useLingui();
   const hasSelection = useTimelineSelection((s) => s.selectedIds.length > 0);
   const showLiveStop = isLive && onStop;
-  const showUpcomingCountdown =
-    Boolean(upcomingLabel) && Boolean(isUpcoming) && !isLive && !showSpinner;
+  const showUpcomingGauge =
+    typeof upcomingProgress === "number" &&
+    Boolean(isUpcoming) &&
+    !isLive &&
+    !showSpinner;
+  const upcomingGaugePercent =
+    typeof upcomingProgress === "number"
+      ? Math.round(Math.max(0, Math.min(upcomingProgress, 1)) * 100)
+      : 0;
   const showTrailingStatus = showLiveStop || showSpinner;
   const setItemRef = useCallback(
     (node: HTMLDivElement | null) => {
@@ -179,6 +187,7 @@ const ItemBase = memo(function ItemBase({
         contextMenu={hasSelection ? undefined : contextMenu}
         className={cn([
           "w-full rounded-lg px-3 py-2 text-left",
+          showUpcomingGauge && "pl-4",
           showTrailingStatus && "pr-10",
           ignored ? "cursor-default" : "cursor-pointer",
           multiSelected && "bg-accent",
@@ -221,19 +230,21 @@ const ItemBase = memo(function ItemBase({
               </div>
             )}
           </div>
-          {showUpcomingCountdown ? (
-            <span
-              data-sidebar-timeline-upcoming-countdown
-              className={cn([
-                "bg-destructive text-destructive-foreground pointer-events-none shrink-0",
-                "inline-flex h-6 items-center justify-center rounded-full px-2 text-[11px] leading-none font-medium whitespace-nowrap",
-              ])}
-            >
-              {upcomingLabel}
-            </span>
-          ) : null}
         </div>
       </InteractiveButton>
+      {showUpcomingGauge ? (
+        <div
+          aria-hidden
+          data-sidebar-timeline-upcoming-gauge
+          className="bg-destructive/20 pointer-events-none absolute top-2 bottom-2 left-1.5 w-0.5 overflow-hidden rounded-full"
+        >
+          <div
+            data-sidebar-timeline-upcoming-gauge-fill
+            className="bg-destructive absolute bottom-0 left-0 w-full rounded-full transition-[height] duration-300 ease-linear"
+            style={{ height: `${upcomingGaugePercent}%` }}
+          />
+        </div>
+      ) : null}
       {showSpinner ? (
         <div
           aria-hidden
@@ -305,7 +316,7 @@ function itemBasePropsAreEqual(prev: ItemBaseProps, next: ItemBaseProps) {
     prev.itemNodeRef === next.itemNodeRef &&
     prev.timelineSessionId === next.timelineSessionId &&
     prev.isUpcoming === next.isUpcoming &&
-    prev.upcomingLabel === next.upcomingLabel
+    prev.upcomingProgress === next.upcomingProgress
   );
 }
 
@@ -320,7 +331,7 @@ const EventItem = memo(
     selectedNodeRef,
     itemNodeRef,
     isUpcoming,
-    upcomingLabel,
+    upcomingProgress,
   }: {
     item: EventTimelineItem;
     precision: TimelinePrecision;
@@ -331,7 +342,7 @@ const EventItem = memo(
     selectedNodeRef?: RefCallback<HTMLDivElement>;
     itemNodeRef?: RefCallback<HTMLDivElement>;
     isUpcoming?: boolean;
-    upcomingLabel?: string;
+    upcomingProgress?: number;
   }) => {
     const { t } = useLingui();
     const store = main.UI.useStore(main.STORE_ID);
@@ -462,7 +473,7 @@ const EventItem = memo(
         selectedNodeRef={selected ? selectedNodeRef : undefined}
         itemNodeRef={itemNodeRef}
         isUpcoming={isUpcoming}
-        upcomingLabel={upcomingLabel}
+        upcomingProgress={upcomingProgress}
       />
     );
   },
@@ -479,7 +490,7 @@ const SessionItem = memo(
     selectedNodeRef,
     itemNodeRef,
     isUpcoming,
-    upcomingLabel,
+    upcomingProgress,
   }: {
     item: SessionTimelineItem;
     precision: TimelinePrecision;
@@ -490,7 +501,7 @@ const SessionItem = memo(
     selectedNodeRef?: RefCallback<HTMLDivElement>;
     itemNodeRef?: RefCallback<HTMLDivElement>;
     isUpcoming?: boolean;
-    upcomingLabel?: string;
+    upcomingProgress?: number;
   }) => {
     const { t } = useLingui();
     const openCurrent = useTabs((state) => state.openCurrent);
@@ -623,7 +634,7 @@ const SessionItem = memo(
         itemNodeRef={itemNodeRef}
         timelineSessionId={sessionId}
         isUpcoming={isUpcoming}
-        upcomingLabel={upcomingLabel}
+        upcomingProgress={upcomingProgress}
         draggable
       />
     );

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
@@ -127,6 +127,7 @@ describe("useSidebarUpcomingMeetingStatus", () => {
     expect(visible.result.current).toMatchObject({
       itemKey: "event-standup",
       label: "In 3m 0s",
+      progress: 0.6,
       title: "Deleted standup",
     });
   });
@@ -147,6 +148,7 @@ describe("useSidebarUpcomingMeetingStatus", () => {
     expect(active.result.current).toMatchObject({
       itemKey: "event-standup",
       label: "Now",
+      progress: 1,
       title: "Team standup",
     });
 

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
@@ -20,6 +20,7 @@ export type SidebarUpcomingMeetingStatus = {
   itemKey: string;
   label: string;
   title: string;
+  progress?: number;
 };
 
 export function useSidebarUpcomingMeetingStatus({
@@ -132,6 +133,7 @@ export function getUpcomingMeetingStatus(
     return {
       itemKey: active.itemKey,
       label: activeLabel,
+      progress: 1,
       title: active.title,
     };
   }
@@ -143,8 +145,13 @@ export function getUpcomingMeetingStatus(
   return {
     itemKey: nearest.itemKey,
     label: formatLabel(nearest.diffMs),
+    progress: getUpcomingMeetingProgress(nearest.diffMs),
     title: nearest.title,
   };
+}
+
+function getUpcomingMeetingProgress(diffMs: number): number {
+  return Math.max(0, Math.min(diffMs / UPCOMING_MEETING_VISIBLE_WINDOW_MS, 1));
 }
 
 export function useUpcomingMeetingLabelFormatter(): (diffMs: number) => string {


### PR DESCRIPTION
Show upcoming meeting urgency as a shrinking left-edge row gauge so event titles keep their horizontal space.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Sidebar timeline presentation and prop plumbing only; countdown chip at the top is unchanged and behavior is covered by unit tests.
> 
> **Overview**
> **Upcoming meeting rows** no longer show a trailing countdown pill (`In 4m`, etc.). They now show a **left-edge vertical gauge** whose fill height reflects how close the meeting is, so titles keep more horizontal space.
> 
> `SidebarUpcomingMeetingStatus` gains an optional **`progress`** (0–1): **1** while a meeting is in progress until its scheduled end, and for not-yet-started meetings **`diffMs / 5 minutes`** within the existing visibility window. `TimelineView` passes that value into `TimelineItemComponent` as `upcomingProgress`.
> 
> The **floating top chip** still uses the text label; only the **in-list row** UI changed. Tests were updated for gauge rendering and progress propagation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a8860382a0b67abbb7f0da6c7284b5d4b0aca52. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->