### PR TITLE
Update desktop 1.1.11 changelog

### DIFF
--- a/packages/changelog/content/1.1.11.md
+++ b/packages/changelog/content/1.1.11.md
@@ -1,0 +1,21 @@
+---
+date: "2026-07-09"
+summary: "Anarlog makes meeting controls easier to reach, with clearer countdowns and tighter sidebar timing."
+---
+
+## Meetings
+
+- Meeting actions now live in the header as a compact control for recording, joining, stopping, resuming, and opening meeting details
+- Upcoming meeting countdowns now appear beside the header action and use shorter labels
+- The start listening action now shows a pulsing red indicator before recording begins
+- The chat button stays available while listening, so you can keep asking questions during a meeting
+
+## Sidebar
+
+- Upcoming meeting rows now use a left-edge urgency gauge instead of a text pill, leaving more room for event titles
+- Sidebar timeline chips and upcoming meeting rows sit closer to the sidebar chrome
+
+## Polish
+
+- Popovers and menus have slightly roomier corners and sturdier borders
+- Note header and personalization controls have small visual cleanups for a steadier feel


### PR DESCRIPTION
Add the desktop 1.1.11 changelog entry for the next stable release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog addition with no runtime or security impact.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.11.md`** for the next stable desktop release (dated 2026-07-09), with a short summary and user-facing notes grouped under **Meetings**, **Sidebar**, and **Polish**.
> 
> The entry documents header-based meeting controls, countdown and listening UI tweaks, sidebar urgency gauge and spacing changes, and minor popover/menu and note-header polish—no application code is modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 402bfc3d5c688b50c3884e41a454abcd35e538be. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->