### PR TITLE
Hydrate sessions before empty-tab cleanup

### DIFF
--- a/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
@@ -10,6 +10,11 @@ import {
   createSessionTab,
 } from "~/store/zustand/tabs/test-utils";
 
+const flushAsyncCleanup = () =>
+  new Promise((resolve) => {
+    setTimeout(resolve, 0);
+  });
+
 describe("desktop tab lifecycle", () => {
   describe("initializeDesktopTabs", () => {
     it("restores pinned tabs and recent notes without opening a startup tab", async () => {
@@ -73,9 +78,10 @@ describe("desktop tab lifecycle", () => {
   });
 
   describe("createSessionTabCloseHandler", () => {
-    it("cleans up empty sessions on close", () => {
+    it("cleans up empty sessions on close", async () => {
       const invalidateSessionResource = vi.fn();
       const deleteSessionFn = vi.fn();
+      const hydrateSessionContentFn = vi.fn().mockResolvedValue(true);
       const handler = createSessionTabCloseHandler({
         store: {} as Parameters<
           typeof createSessionTabCloseHandler
@@ -87,10 +93,17 @@ describe("desktop tab lifecycle", () => {
         getSessionMode: vi.fn().mockReturnValue(null),
         isSessionEmptyFn: vi.fn().mockReturnValue(true),
         deleteSessionFn,
+        hydrateSessionContentFn,
       });
 
       handler(createSessionTab({ id: "session-1" }));
 
+      await flushAsyncCleanup();
+
+      expect(hydrateSessionContentFn).toHaveBeenCalledWith(
+        expect.anything(),
+        "session-1",
+      );
       expect(invalidateSessionResource).toHaveBeenCalledWith("session-1");
       expect(deleteSessionFn).toHaveBeenCalledWith(
         expect.anything(),
@@ -98,6 +111,66 @@ describe("desktop tab lifecycle", () => {
         "session-1",
         { deferFilesystemDelete: true },
       );
+    });
+
+    it("keeps restored sessions when hydration finds content", async () => {
+      const invalidateSessionResource = vi.fn();
+      const deleteSessionFn = vi.fn();
+      const hydrateSessionContentFn = vi.fn().mockResolvedValue(true);
+      const isSessionEmptyFn = vi
+        .fn()
+        .mockReturnValueOnce(true)
+        .mockReturnValueOnce(false);
+      const handler = createSessionTabCloseHandler({
+        store: {} as Parameters<
+          typeof createSessionTabCloseHandler
+        >[0]["store"],
+        indexes: {} as Parameters<
+          typeof createSessionTabCloseHandler
+        >[0]["indexes"],
+        invalidateSessionResource,
+        getSessionMode: vi.fn().mockReturnValue(null),
+        isSessionEmptyFn,
+        deleteSessionFn,
+        hydrateSessionContentFn,
+      });
+
+      handler(createSessionTab({ id: "session-1" }));
+
+      await flushAsyncCleanup();
+
+      expect(hydrateSessionContentFn).toHaveBeenCalledWith(
+        expect.anything(),
+        "session-1",
+      );
+      expect(deleteSessionFn).not.toHaveBeenCalled();
+      expect(invalidateSessionResource).not.toHaveBeenCalled();
+    });
+
+    it("skips cleanup when hydration fails", async () => {
+      const invalidateSessionResource = vi.fn();
+      const deleteSessionFn = vi.fn();
+      const hydrateSessionContentFn = vi.fn().mockResolvedValue(false);
+      const handler = createSessionTabCloseHandler({
+        store: {} as Parameters<
+          typeof createSessionTabCloseHandler
+        >[0]["store"],
+        indexes: {} as Parameters<
+          typeof createSessionTabCloseHandler
+        >[0]["indexes"],
+        invalidateSessionResource,
+        getSessionMode: vi.fn().mockReturnValue(null),
+        isSessionEmptyFn: vi.fn().mockReturnValue(true),
+        deleteSessionFn,
+        hydrateSessionContentFn,
+      });
+
+      handler(createSessionTab({ id: "session-1" }));
+
+      await flushAsyncCleanup();
+
+      expect(deleteSessionFn).not.toHaveBeenCalled();
+      expect(invalidateSessionResource).not.toHaveBeenCalled();
     });
 
     it("skips cleanup for non-inactive sessions and non-session tabs", () => {

--- a/apps/desktop/src/shared/desktop-tab-lifecycle.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.ts
@@ -1,6 +1,7 @@
 import { isTauri } from "@tauri-apps/api/core";
 import { useEffect, useRef } from "react";
 
+import { hydrateSessionContent } from "~/store/tinybase/persister/session/hydrate";
 import { deleteSessionCascade } from "~/store/tinybase/store/deleteSession";
 import { isSessionEmpty } from "~/store/tinybase/store/sessions";
 import { listenerStore } from "~/store/zustand/listener/instance";
@@ -32,6 +33,7 @@ type SessionTabCloseHandlerOptions = {
   getSessionMode?: (sessionId: string) => string | null | undefined;
   isSessionEmptyFn?: typeof isSessionEmpty;
   deleteSessionFn?: typeof deleteSessionCascade;
+  hydrateSessionContentFn?: typeof hydrateSessionContent;
 };
 
 export async function initializeDesktopTabs({
@@ -65,6 +67,7 @@ export function createSessionTabCloseHandler({
     listenerStore.getState().getSessionMode(sessionId),
   isSessionEmptyFn = isSessionEmpty,
   deleteSessionFn = deleteSessionCascade,
+  hydrateSessionContentFn = hydrateSessionContent,
 }: SessionTabCloseHandlerOptions) {
   return (tab: Tab) => {
     if (tab.type !== "sessions") {
@@ -85,9 +88,18 @@ export function createSessionTabCloseHandler({
       return;
     }
 
-    invalidateSessionResource(sessionId);
-    void deleteSessionFn(store, indexes, sessionId, {
-      deferFilesystemDelete: true,
+    void (async () => {
+      const hydrated = await hydrateSessionContentFn(store, sessionId);
+      if (!hydrated || !isSessionEmptyFn(store, sessionId)) {
+        return;
+      }
+
+      invalidateSessionResource(sessionId);
+      deleteSessionFn(store, indexes, sessionId, {
+        deferFilesystemDelete: true,
+      });
+    })().catch((error) => {
+      console.error("session close cleanup", error);
     });
   };
 }


### PR DESCRIPTION
Summary:
- hydrate persisted session content before removing closed empty tabs
- add regression coverage for restored sessions

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes session deletion timing and adds async I/O on tab close; wrong empty checks could still delete data or leave orphans, but behavior is more conservative than before.
> 
> **Overview**
> Fixes a bug where **closing a session tab** could **delete persisted sessions** that looked empty in memory before disk content was loaded.
> 
> **`createSessionTabCloseHandler`** now runs **async cleanup**: it calls **`hydrateSessionContent`** before **`deleteSessionCascade`**. Deletion and cache invalidation happen only when hydration succeeds **and** the session is still empty afterward. If hydration fails or loads content, cleanup is skipped. Errors are logged via **`session close cleanup`**.
> 
> The handler accepts an injectable **`hydrateSessionContentFn`** (defaults to production **`hydrateSessionContent`**) for tests. Unit tests were updated to **`await`** async work with **`flushAsyncCleanup`**, and new cases cover **restored sessions kept after hydration** and **no delete when hydration returns false**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 87f89169b7eb41152edf7f4ccabede9f8894905d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->