### PR TITLE
Match floating action bar to Figma themes

### DIFF
--- a/apps/desktop/src/session/components/floating/index.tsx
+++ b/apps/desktop/src/session/components/floating/index.tsx
@@ -16,7 +16,7 @@ export function FloatingActionButton(_props: {
     <div
       className={cn([
         "absolute left-1/2 z-30 flex max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center",
-        "pointer-events-none bottom-3 h-10 w-40 pb-0",
+        "pointer-events-none bottom-3 h-10 w-[180px] pb-0",
       ])}
     >
       <AnimatePresence mode="wait" initial={false}>

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -50,28 +50,33 @@ describe("ChatCTA", () => {
 
     expect(button.hasAttribute("data-chat-cta-trigger")).toBe(true);
     expect(button.className).toContain("h-10");
-    expect(button.className).toContain("w-40");
+    expect(button.className).toContain("w-[180px]");
     expect(button.className).toContain("cursor-text");
     expect(surface?.className).toContain("absolute");
     expect(surface?.className).toContain("bottom-0");
     expect(surface?.className).toContain("left-1/2");
     expect(surface?.className).toContain("w-[min(640px,calc(100cqw_-_2rem))]");
     expect(surface?.className).toContain(
-      "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
+      "[clip-path:inset(0_max(0px,calc(50%_-_90px))_0_max(0px,calc(50%_-_90px))_round_32px)]",
     );
     expect(surface?.className).toContain(
       "transition-[clip-path,height,padding,background-color,border-color,box-shadow]",
     );
     expect(surface?.className).toContain("origin-bottom");
     expect(surface?.className).toContain("h-2");
+    expect(surface?.className).toContain("dark:h-3");
     expect(surface?.className).toContain("rounded-full");
-    expect(surface?.className).toContain("bg-black");
-    expect(surface?.className).toContain("dark:bg-white");
     expect(surface?.className).toContain(
-      "shadow-[0_10px_26px_rgba(0,0,0,0.22)]",
+      "bg-[linear-gradient(180deg,#faf8f6_0%,#e3e1df_100%)]",
     );
     expect(surface?.className).toContain(
-      "dark:shadow-[0_10px_30px_rgba(0,0,0,0.5)]",
+      "dark:bg-[linear-gradient(180deg,#211d1d_0%,#574f3b_100%)]",
+    );
+    expect(surface?.className).toContain(
+      "shadow-[0_0_0_1px_rgba(0,0,0,0.1),0_4px_12px_rgba(0,0,0,0.16),0_4px_16px_rgba(0,0,0,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)]",
+    );
+    expect(surface?.className).toContain(
+      "dark:shadow-[0_4px_12px_rgba(33,29,29,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)]",
     );
     expect(surface?.className).toContain(
       "group-hover/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)]",
@@ -124,7 +129,7 @@ describe("ChatCTA", () => {
     }).parentElement?.parentElement;
 
     expect(hoverZone?.className).toContain("h-10");
-    expect(hoverZone?.className).toContain("w-40");
+    expect(hoverZone?.className).toContain("w-[180px]");
     expect(hoverZone?.className).toContain("bottom-3");
     expect(hoverZone?.className).toContain("pb-0");
   });

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -31,19 +31,19 @@ export function ChatCTA({
       data-chat-cta-trigger
       aria-label={ariaLabel ?? t`Ask Anarlog anything`}
       onClick={handleClick}
-      className="group/anarlog-chat-cta relative h-10 w-40 max-w-full cursor-text focus-visible:outline-none"
+      className="group/anarlog-chat-cta relative h-10 w-[180px] max-w-full cursor-text focus-visible:outline-none"
     >
       <span
         data-chat-cta-surface
         aria-hidden="true"
         className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent bg-black dark:bg-white",
-          "[clip-path:inset(0_calc(50%_-_3rem)_0_calc(50%_-_3rem)_round_9999px)]",
-          "origin-bottom px-0 text-sm shadow-[0_10px_26px_rgba(0,0,0,0.22)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:shadow-[0_10px_30px_rgba(0,0,0,0.5)]",
+          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent dark:h-3",
+          "[clip-path:inset(0_max(0px,calc(50%_-_90px))_0_max(0px,calc(50%_-_90px))_round_32px)]",
+          "origin-bottom bg-[linear-gradient(180deg,#faf8f6_0%,#e3e1df_100%)] px-0 text-sm shadow-[0_0_0_1px_rgba(0,0,0,0.1),0_4px_12px_rgba(0,0,0,0.16),0_4px_16px_rgba(0,0,0,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:bg-[linear-gradient(180deg,#211d1d_0%,#574f3b_100%)] dark:shadow-[0_4px_12px_rgba(33,29,29,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)]",
           "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
           "group-hover/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] group-focus-visible/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] dark:group-hover/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)] dark:group-focus-visible/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)]",
-          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
-          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)] dark:group-hover/anarlog-chat-cta:h-10",
+          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)] dark:group-focus-visible/anarlog-chat-cta:h-10",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
         ])}
       >
@@ -66,7 +66,7 @@ export function ChatCTA({
 
 export function FloatingChatCTA({ label }: { label?: ReactNode }) {
   return (
-    <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 flex h-10 w-40 max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center pb-0">
+    <div className="pointer-events-none absolute bottom-3 left-1/2 z-20 flex h-10 w-[180px] max-w-[calc(100%-2rem)] -translate-x-1/2 items-end justify-center pb-0">
       <div className="pointer-events-auto max-w-full">
         <ChatCTA label={label} />
       </div>


### PR DESCRIPTION
Summary:
- apply the light and dark floating action bar gradients, dimensions, and shadows
- preserve the existing expanded chat interaction and cover the CTA behavior

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only changes to chat CTA presentation with no logic or data-path changes; risk is limited to visual regression on the floating bar.
> 
> **Overview**
> Updates the **floating “Ask anything” chat CTA** to match Figma: trigger width goes from `w-40` to **`180px`** on `ChatCTA`, `FloatingChatCTA`, and the session floating action wrapper.
> 
> The collapsed **handle** surface swaps solid black/white for **light/dark linear gradients**, a tighter **clip-path** (`90px` half-width, `32px` corner radius), slightly taller dark-mode rest height (`dark:h-3`), and **layered inset/outset shadows**. Hover/focus expansion (full pill, label reveal, open chat) is unchanged; tests were updated to assert the new classes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c2f9f4588c9414c57d8da14f057da856109aa803. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->