### PR TITLE
Keep popovers within window bounds

### DIFF
--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -24,6 +24,7 @@ const PopoverContent = React.forwardRef<
       className,
       align = "center",
       sideOffset = 4,
+      collisionPadding = 8,
       variant = "default",
       ...props
     },
@@ -34,6 +35,7 @@ const PopoverContent = React.forwardRef<
         ref={ref}
         align={align}
         sideOffset={sideOffset}
+        collisionPadding={collisionPadding}
         className={cn([
           "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
           variant === "app"


### PR DESCRIPTION
Summary:
- add a shared collision inset for popovers
- keep flipped content and shadows visible at window edges

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small UI positioning default on a shared popover wrapper with no auth, data, or API impact; overridable via existing Radix props.
> 
> **Overview**
> **Popover positioning** now passes Radix **`collisionPadding`** with a default of **8px** on `PopoverContent`, so collision detection keeps popovers (and their borders/shadows) inset from the viewport instead of clipping at window edges.
> 
> Callers can still override **`collisionPadding`** via props; only the shared default behavior changes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f3b7c3c2585c4de1c3a6b69c14eca5f60130fce8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->