### PR TITLE
Update desktop 1.1.12 changelog

### DIFF
--- a/packages/changelog/content/1.1.12.md
+++ b/packages/changelog/content/1.1.12.md
@@ -1,0 +1,20 @@
+---
+date: "2026-07-10"
+summary: "Anarlog protects restored notes, keeps pasted links predictable, and improves floating chat and popovers."
+---
+
+## Reliability
+
+- Closing a restored note no longer risks deleting it before its saved content finishes loading
+
+## Editor
+
+- Pasted work links now remain regular links instead of turning into app-specific chips
+
+## Chat
+
+- The floating chat handle now matches the app's light and dark themes and expands reliably in narrow windows
+
+## Polish
+
+- Popovers keep a small gap from window edges so their content and shadows stay visible


### PR DESCRIPTION
Summary:
- add the user-facing changelog for the next stable desktop release
- cover restored-note safety, pasted link behavior, floating chat theming, and popover boundaries

Validation:
- pnpm exec dprint fmt
- pnpm -F @hypr/changelog typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog entry with no runtime or build logic changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.12.md`** for desktop **1.1.12** (dated 2026-07-10), documenting user-visible fixes and polish for that release.
> 
> **Reliability:** closing a restored note is described as no longer risking deletion before saved content finishes loading.
> 
> **Editor:** pasted work links stay regular links instead of becoming app-specific chips.
> 
> **Chat:** the floating chat handle is called out for light/dark theming and reliable expansion in narrow windows.
> 
> **Polish:** popovers are noted as keeping a gap from window edges so content and shadows stay visible.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b6b4cdd0b0178210bc557857b78d46606eb63ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->