### PR TITLE
Use consistent borders for app popovers

### DIFF
--- a/packages/ui/src/components/ui/floating-content.tsx
+++ b/packages/ui/src/components/ui/floating-content.tsx
@@ -1,7 +1,7 @@
 import { cn } from "@hypr/utils";
 
 export const appFloatingContentClassName =
-  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-[18px] border p-1 shadow-lg";
+  "bg-app-floating-chrome text-popover-foreground border-app-floating-border overflow-hidden rounded-[22px] border p-1 shadow-lg";
 
 export type FloatingContentVariant = "default" | "app";
 

--- a/packages/ui/src/components/ui/popover.tsx
+++ b/packages/ui/src/components/ui/popover.tsx
@@ -39,7 +39,7 @@ const PopoverContent = React.forwardRef<
         className={cn([
           "text-popover-foreground data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-72 origin-(--radix-popover-content-transform-origin) outline-hidden",
           variant === "app"
-            ? [appFloatingContentClassName, "border-[3px]"]
+            ? appFloatingContentClassName
             : "bg-popover rounded-[18px] border p-4 shadow-md",
           className,
         ])}


### PR DESCRIPTION
Remove the 3px override so app popovers match shared floating surfaces.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling in the UI package with no auth, data, or behavior changes.
> 
> **Overview**
> App-variant popovers now use the shared `appFloatingContentClassName` styling without a thicker border override, so they match other app floating UI (e.g. dropdowns) instead of rendering a **3px** border.
> 
> The shared floating chrome token also bumps corner radius from **18px** to **22px**, which applies anywhere that class is used—not only popovers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 19041595d88dea35ea18ef5c5a346e415965458f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->