### PR TITLE
Add Notta alternative article

### DIFF
--- a/apps/web/content/articles/notta-ai-alternative.mdx
+++ b/apps/web/content/articles/notta-ai-alternative.mdx
@@ -24,7 +24,7 @@ If your real requirement is open-source code, plain markdown as the canonical no
 | Storage model | Hosted workspace by default; local folder in Desktop Privacy Mode | Plain markdown files on your device |
 | AI-provider control | Notta-managed cloud or local transcription modes | Managed service, bring your own keys, or local models |
 | Open source | No | Yes, MIT-licensed |
-| Pricing model | Free, Pro, Business, and Enterprise tiers; Privacy Mode is available with paid plans | Free with BYOK/local AI; paid managed service when you want Anarlog to run the stack |
+| Pricing model | Free, Pro, Business, and Enterprise tiers; Desktop is available to all users, and Notta documents unlimited Privacy Mode transcription on Pro | Free with BYOK/local AI; paid managed service when you want Anarlog to run the stack |
 | Strongest reason to choose it | You want one polished product for hosted collaboration and optional local transcription | You want meeting memory you can inspect, move, fork, and keep |
 
 ## Why people look for a Notta alternative
@@ -38,7 +38,7 @@ The search for a Notta alternative usually comes from one of five constraints.
 1. You want plain markdown to be the canonical note, not only a file managed by a proprietary app.
 2. You want open-source code your team can inspect and fork.
 3. You want to choose the speech-to-text and LLM provider yourself.
-4. You want a free local or BYOK path instead of tying local transcription to a paid product tier.
+4. You want a free local or BYOK path without making a vendor subscription part of the transcription workflow.
 5. You want meeting files to start inside your existing filesystem workflow.
 
 If those are not your constraints, Notta may be the better fit.
@@ -120,7 +120,7 @@ Anarlog makes sense when the meeting note is primarily an owned working document
 
 ### 5. Cost shape
 
-Notta's free plan is constrained by monthly transcription and per-conversation limits. Paid plans unlock longer recordings, higher quotas, collaboration, admin controls, and unlimited local transcription through Privacy Mode on Pro.
+Notta's free plan is constrained by monthly transcription and per-conversation limits. Paid plans unlock longer cloud recordings, higher quotas, collaboration, and admin controls. Notta's Privacy Mode page specifically says Pro users get unlimited local transcription that does not consume cloud transcription minutes; confirm access and limits for your account because Privacy Mode is not listed in Notta's general plan comparison.
 
 Anarlog's free path is strongest when you are comfortable bringing your own AI keys or running local models. That cost shape is different: you pay the AI provider directly, use local compute, or add Anarlog's managed service when you want the hosted stack handled for you.
 
@@ -135,7 +135,7 @@ Choose Notta if you want:
 - translation and bilingual transcription features;
 - integrations with calendars, cloud drives, CRM tools, and collaboration apps;
 - admin controls like SAML SSO and audit logs on enterprise plans;
-- a paid local Privacy Mode for sensitive meetings;
+- a local Privacy Mode for sensitive meetings, with unlimited local transcription documented for Pro;
 - and a product that handles the whole transcription workspace for you.
 
 That is a reasonable choice. Not every team wants to manage files, providers, or local models.

--- a/apps/web/content/articles/notta-ai-alternative.mdx
+++ b/apps/web/content/articles/notta-ai-alternative.mdx
@@ -5,41 +5,41 @@ meta_description: "Compare Notta with Anarlog for meeting notes, transcription, 
 author: "Anarlog Team"
 featured: false
 category: "Comparisons"
-date: "2026-07-12"
+date: "2026-07-14"
 ready_for_review: true
 ---
 
-Notta is a capable cloud meeting transcription product. It is especially useful when a team wants web, mobile, browser extension, calendar, CRM, and collaboration features in one hosted workspace.
+Notta is a broad meeting transcription platform. Its standard workflow spans web, mobile, browser extension, calendar, CRM, and collaboration features in a hosted workspace. Notta Desktop now adds bot-free capture on Mac and Windows, plus a Privacy Mode that transcribes locally and keeps meeting files on the device.
 
 But that is not the only way to build meeting notes.
 
-If your real requirement is local files, open-source code, no vendor note database, and control over which AI stack touches your meetings, [Anarlog](/) is the Notta alternative worth evaluating. It is not a drop-in clone of Notta. It is a different model: capture meetings from your machine, save notes as plain markdown, and keep the workflow close to your own file system.
+If your real requirement is open-source code, plain markdown as the canonical note, and control over which AI stack touches your meetings, [Anarlog](/) is the Notta alternative worth evaluating. It is not a drop-in clone of Notta. It is a different model: capture meetings from your machine, save notes as portable files, and keep the workflow close to your own tools.
 
 ## Quick comparison
 
 | Question | Notta | Anarlog |
 | --- | --- | --- |
-| Best fit | Hosted transcription, team workspaces, translation, collaboration, CRM integrations | Local-first AI meeting notes, markdown files, open source, BYOK/local AI |
-| Capture model | Web, mobile, Chrome extension, integrations, and Notta Desktop beta | Desktop system-audio capture with no meeting bot |
-| Storage model | Hosted Notta workspace with sync and collaboration | Plain markdown files on your device |
-| AI-provider control | Notta-managed product experience | Managed service, bring your own keys, or local models |
+| Best fit | Hosted team workflows with translation and integrations, plus an optional local Privacy Mode | Local-first AI meeting notes, markdown files, open source, BYOK/local AI |
+| Capture model | Meeting bot, web and mobile recording, Chrome extension, and bot-free Notta Desktop beta | Desktop system-audio capture with no meeting bot |
+| Storage model | Hosted workspace by default; local folder in Desktop Privacy Mode | Plain markdown files on your device |
+| AI-provider control | Notta-managed cloud or local transcription modes | Managed service, bring your own keys, or local models |
 | Open source | No | Yes, MIT-licensed |
-| Pricing model | Free, Pro, Business, Enterprise tiers | Free with BYOK/local AI; paid managed service when you want Anarlog to run the stack |
-| Strongest reason to choose it | You want a polished cloud transcription workspace | You want meeting memory you can inspect, move, fork, and keep |
+| Pricing model | Free, Pro, Business, and Enterprise tiers; Privacy Mode is available with paid plans | Free with BYOK/local AI; paid managed service when you want Anarlog to run the stack |
+| Strongest reason to choose it | You want one polished product for hosted collaboration and optional local transcription | You want meeting memory you can inspect, move, fork, and keep |
 
 ## Why people look for a Notta alternative
 
-Notta's product surface is broad. Its [pricing page](https://www.notta.ai/en/pricing) lists web meeting transcription, file transcription, speaker identification, transcript editing, translations, collaboration features, folders, sharing, Zoom, Google Calendar, Microsoft Teams, Webex, Dropbox, OneDrive, Google Drive, SharePoint, Slack, CRM integrations, usage reports, and admin controls across its paid tiers.
+Notta's product surface is broad. Its [pricing page](https://www.notta.ai/en/pricing) lists web meeting transcription, file transcription, speaker identification, transcript editing, translations, collaboration features, folders, sharing, Zoom, Google Calendar, Microsoft Teams, Webex, Dropbox, OneDrive, Google Drive, SharePoint, Slack, CRM integrations, usage reports, and admin controls across its paid tiers. Its [Privacy Mode](https://www.notta.ai/en/features/privacy-mode) adds offline local transcription and local storage inside Notta Desktop.
 
 That breadth is useful. It can also be too much if you only want one durable thing: a trustworthy record of your meetings that stays in your workflow.
 
 The search for a Notta alternative usually comes from one of five constraints.
 
-1. You do not want meeting notes locked inside a hosted workspace.
-2. You want files on disk instead of export as an afterthought.
+1. You want plain markdown to be the canonical note, not only a file managed by a proprietary app.
+2. You want open-source code your team can inspect and fork.
 3. You want to choose the speech-to-text and LLM provider yourself.
-4. You want open-source code your team can inspect.
-5. You want a bot-free, local-first meeting workflow instead of another cloud system to administer.
+4. You want a free local or BYOK path instead of tying local transcription to a paid product tier.
+5. You want meeting files to start inside your existing filesystem workflow.
 
 If those are not your constraints, Notta may be the better fit.
 
@@ -47,17 +47,21 @@ If those are not your constraints, Notta may be the better fit.
 
 Notta is strongest when the buyer wants a hosted transcription suite, not just a private note-taking tool.
 
-The free plan currently includes 120 transcription minutes per month, a 3-minute maximum per conversation, 50 file uploads per month, and 10 AI summaries per month. The Pro plan lists 1,800 transcription minutes per month and a 5-hour recording limit. The Business plan lists unlimited transcription, collaboration and admin features, and a 5-hour recording limit. Enterprise adds controls such as SAML SSO, audit logs, and full data access control. Those plan details can change, so use [Notta's pricing page](https://www.notta.ai/en/pricing) as the source of truth before buying.
+The free plan currently includes 120 transcription minutes per month, a 3-minute maximum per conversation, 50 file uploads per month, and 10 AI summaries per month. The Pro plan is listed at $8.17 per month when billed annually, with 1,800 transcription minutes per month and a 5-hour recording limit. The Business plan lists unlimited transcription, collaboration and admin features, and a 5-hour recording limit. Enterprise adds controls such as SAML SSO, audit logs, and full data access control. Those plan details can change, so use [Notta's pricing page](https://www.notta.ai/en/pricing) as the source of truth before buying.
 
-Notta also has clear platform breadth. Its Google Meet page describes a Chrome-extension workflow for live transcription, plus support for Zoom, Google Meet, Microsoft Teams, and Webex. The main product page positions Notta around transcription, summaries, collaboration, and generated deliverables.
+Notta also has clear platform breadth. Its Chrome extension handles Google Meet and browser-tab audio, while Notta Bot supports Zoom, Google Meet, Microsoft Teams, and Webex. [Notta Desktop](https://www.notta.ai/en/features/bot-free) captures system audio without adding a meeting participant and is currently labeled beta for both Mac and Windows.
+
+Privacy Mode is the most important recent change. Notta says it stores recordings, transcripts, folders, and related data in a local folder, works offline after setup, and does not consume cloud transcription minutes on Pro. That makes Notta a credible option for buyers who need local transcription but still want Notta's broader hosted product when a meeting is less sensitive.
 
 If you need translations, shared folders, transcript sharing, admin analytics, and CRM or cloud-drive integrations, Notta is built around that hosted team model.
 
 ## Where Notta may be the wrong model
 
-The same hosted model becomes a tradeoff when ownership matters more than collaboration.
+Notta's standard hosted model becomes a tradeoff when ownership matters more than collaboration. Privacy Mode reduces that tradeoff, but it does not make Notta open source or give the user a choice of transcription and summarization providers.
 
-Notta's pricing FAQ says customer data is hosted on AWS and backed up regularly. Its security page highlights compliance and administrative protections. That is normal for a SaaS transcription product. It is not the same as keeping the default meeting record on your laptop as plain files.
+For standard cloud workflows, Notta's [security page](https://www.notta.ai/en/security) says its software is hosted on AWS and user data is regularly backed up. Privacy Mode changes the path for selected desktop meetings: transcription runs locally, the files stay in a local folder, and the mode can work offline after setup.
+
+The remaining distinction is architectural. Privacy Mode is a proprietary mode inside a larger Notta account and workspace. Anarlog is an MIT-licensed application whose default note format is plain markdown and whose AI stack can be managed, BYOK, or local.
 
 There is also a workflow question. Notta is designed as a workspace. Meetings become searchable objects inside Notta, with product features layered around them. That is a good pattern when Notta is the team's meeting system of record.
 
@@ -74,11 +78,11 @@ In those workflows, export is not enough. You want the note to start as somethin
 
 ## Where Anarlog is different
 
-Anarlog starts from the opposite assumption: your meeting notes should be files first.
+Anarlog starts from a narrower assumption: your meeting notes should be portable files first.
 
 Anarlog captures microphone and system audio from your desktop, transcribes meetings in real time, and saves notes as plain markdown files on your device. There is no meeting bot joining the call, no proprietary note database as the canonical record, and no requirement to build your workflow around a vendor workspace.
 
-The practical difference is simple. With Anarlog, the meeting note is something you can open in another editor, move into Obsidian, search from the terminal, sync however you already sync files, or keep in a folder that survives a subscription change.
+The practical difference is simple. With Anarlog, the meeting note starts as markdown you can open in another editor, move into Obsidian, search from the terminal, sync however you already sync files, or keep in a folder that survives a subscription change. The [local AI meeting notes guide](/blog/local-ai-meeting-notes/) explains how this file-first model differs from simply adding a local transcription mode to a larger cloud product.
 
 That matters for engineers, technical founders, consultants, lawyers, operators, and privacy-conscious teams who want meeting memory without turning every conversation into another SaaS object.
 
@@ -88,9 +92,9 @@ That matters for engineers, technical founders, consultants, lawyers, operators,
 
 Ask where the canonical note lives.
 
-If it lives in a vendor workspace and you can export it later, you have portability. If it starts as a markdown file on your machine, you have ownership.
+If it lives in a vendor workspace and you can export it later, you have portability. If it starts as a markdown file on your machine, you have ownership at the format level.
 
-Notta is closer to the first model. Anarlog is built for the second.
+Notta Privacy Mode does keep recordings and transcripts in a local folder. Its public page does not promise plain markdown as the canonical format, so confirm the file and export formats before designing a workflow around it. Anarlog is built around markdown by default.
 
 ### 2. AI-provider control
 
@@ -102,7 +106,7 @@ Anarlog supports a managed path when convenience matters, bring-your-own-key wor
 
 ### 3. Bot-free capture
 
-Notta now lists Notta Desktop as a beta bot-free meeting recorder for Mac and Windows. That is a useful signal: bot-free capture is becoming a mainstream requirement, not a niche preference.
+Notta lists Notta Desktop as a beta bot-free meeting recorder for Mac and Windows. That is a useful signal: bot-free capture is becoming a mainstream requirement, not a niche preference.
 
 But "bot-free" is only one layer. The better question is what happens after capture. Does the audio become a local file? Does the transcript become a portable note? Can you choose the summarization provider? Can your team inspect the code path?
 
@@ -110,13 +114,13 @@ Anarlog's answer is to keep the workflow local-first and open source.
 
 ### 4. Collaboration versus control
 
-Notta makes sense when meeting documentation is a team workspace problem. Sales teams, customer success teams, recruiting teams, and operations teams may want shared transcripts, CRM sync, folders, permissions, and admin controls.
+Notta makes sense when meeting documentation is a team workspace problem. Sales teams, customer success teams, recruiting teams, and operations teams may want shared transcripts, CRM sync, folders, permissions, and admin controls. Privacy Mode gives those users a local path for selected sensitive meetings without leaving the Notta product.
 
 Anarlog makes sense when the meeting note is primarily an owned working document. You can still share the output, but the default is not a shared cloud archive.
 
 ### 5. Cost shape
 
-Notta's free plan is constrained by monthly transcription and per-conversation limits. Paid plans unlock longer recordings, higher quotas, collaboration, and admin controls.
+Notta's free plan is constrained by monthly transcription and per-conversation limits. Paid plans unlock longer recordings, higher quotas, collaboration, admin controls, and unlimited local transcription through Privacy Mode on Pro.
 
 Anarlog's free path is strongest when you are comfortable bringing your own AI keys or running local models. That cost shape is different: you pay the AI provider directly, use local compute, or add Anarlog's managed service when you want the hosted stack handled for you.
 
@@ -131,6 +135,7 @@ Choose Notta if you want:
 - translation and bilingual transcription features;
 - integrations with calendars, cloud drives, CRM tools, and collaboration apps;
 - admin controls like SAML SSO and audit logs on enterprise plans;
+- a paid local Privacy Mode for sensitive meetings;
 - and a product that handles the whole transcription workspace for you.
 
 That is a reasonable choice. Not every team wants to manage files, providers, or local models.
@@ -151,10 +156,10 @@ This is the real Anarlog fit. It is for people who do not want meeting memory to
 
 ## The bottom line
 
-Notta is a strong cloud transcription workspace. Anarlog is a local-first AI meeting notetaker.
+Notta is no longer only a cloud transcription workspace. Its Desktop app offers bot-free capture, and Privacy Mode adds local transcription and local storage for sensitive meetings.
 
-If you need team collaboration, translations, web/mobile coverage, and a large hosted feature surface, start with Notta.
+If you need team collaboration, translations, web/mobile coverage, and the ability to switch selected meetings into a proprietary local mode, start with Notta.
 
-If you want an open-source Notta alternative built around files, bot-free capture, local workflows, and AI-provider control, start with Anarlog.
+If you want an open-source Notta alternative built around plain markdown, bot-free capture, local workflows, and AI-provider control, start with Anarlog.
 
-For more context, read our guides to [AI meeting notes without a bot](/blog/ai-meeting-notes-without-bot/), [open-source meeting transcription software](/blog/open-source-meeting-transcription-software/), and [local AI meeting notetakers](/blog/local-ai-meeting-notes/).
+[Download Anarlog](https://anarlog.so/download/apple-silicon) and compare both tools on one real meeting. The useful question is not which product says "local." It is which ownership model still works when you change providers, editors, or vendors.

--- a/apps/web/content/articles/notta-ai-alternative.mdx
+++ b/apps/web/content/articles/notta-ai-alternative.mdx
@@ -1,0 +1,160 @@
+---
+meta_title: "Notta Alternative: When to Choose a Local-First AI Notetaker"
+display_title: "Notta alternative: when to choose a local-first AI notetaker"
+meta_description: "Compare Notta with Anarlog for meeting notes, transcription, local files, open source workflows, pricing, and AI-provider control."
+author: "Anarlog Team"
+featured: false
+category: "Comparisons"
+date: "2026-07-12"
+ready_for_review: true
+---
+
+Notta is a capable cloud meeting transcription product. It is especially useful when a team wants web, mobile, browser extension, calendar, CRM, and collaboration features in one hosted workspace.
+
+But that is not the only way to build meeting notes.
+
+If your real requirement is local files, open-source code, no vendor note database, and control over which AI stack touches your meetings, [Anarlog](/) is the Notta alternative worth evaluating. It is not a drop-in clone of Notta. It is a different model: capture meetings from your machine, save notes as plain markdown, and keep the workflow close to your own file system.
+
+## Quick comparison
+
+| Question | Notta | Anarlog |
+| --- | --- | --- |
+| Best fit | Hosted transcription, team workspaces, translation, collaboration, CRM integrations | Local-first AI meeting notes, markdown files, open source, BYOK/local AI |
+| Capture model | Web, mobile, Chrome extension, integrations, and Notta Desktop beta | Desktop system-audio capture with no meeting bot |
+| Storage model | Hosted Notta workspace with sync and collaboration | Plain markdown files on your device |
+| AI-provider control | Notta-managed product experience | Managed service, bring your own keys, or local models |
+| Open source | No | Yes, MIT-licensed |
+| Pricing model | Free, Pro, Business, Enterprise tiers | Free with BYOK/local AI; paid managed service when you want Anarlog to run the stack |
+| Strongest reason to choose it | You want a polished cloud transcription workspace | You want meeting memory you can inspect, move, fork, and keep |
+
+## Why people look for a Notta alternative
+
+Notta's product surface is broad. Its [pricing page](https://www.notta.ai/en/pricing) lists web meeting transcription, file transcription, speaker identification, transcript editing, translations, collaboration features, folders, sharing, Zoom, Google Calendar, Microsoft Teams, Webex, Dropbox, OneDrive, Google Drive, SharePoint, Slack, CRM integrations, usage reports, and admin controls across its paid tiers.
+
+That breadth is useful. It can also be too much if you only want one durable thing: a trustworthy record of your meetings that stays in your workflow.
+
+The search for a Notta alternative usually comes from one of five constraints.
+
+1. You do not want meeting notes locked inside a hosted workspace.
+2. You want files on disk instead of export as an afterthought.
+3. You want to choose the speech-to-text and LLM provider yourself.
+4. You want open-source code your team can inspect.
+5. You want a bot-free, local-first meeting workflow instead of another cloud system to administer.
+
+If those are not your constraints, Notta may be the better fit.
+
+## Where Notta is strong
+
+Notta is strongest when the buyer wants a hosted transcription suite, not just a private note-taking tool.
+
+The free plan currently includes 120 transcription minutes per month, a 3-minute maximum per conversation, 50 file uploads per month, and 10 AI summaries per month. The Pro plan lists 1,800 transcription minutes per month and a 5-hour recording limit. The Business plan lists unlimited transcription, collaboration and admin features, and a 5-hour recording limit. Enterprise adds controls such as SAML SSO, audit logs, and full data access control. Those plan details can change, so use [Notta's pricing page](https://www.notta.ai/en/pricing) as the source of truth before buying.
+
+Notta also has clear platform breadth. Its Google Meet page describes a Chrome-extension workflow for live transcription, plus support for Zoom, Google Meet, Microsoft Teams, and Webex. The main product page positions Notta around transcription, summaries, collaboration, and generated deliverables.
+
+If you need translations, shared folders, transcript sharing, admin analytics, and CRM or cloud-drive integrations, Notta is built around that hosted team model.
+
+## Where Notta may be the wrong model
+
+The same hosted model becomes a tradeoff when ownership matters more than collaboration.
+
+Notta's pricing FAQ says customer data is hosted on AWS and backed up regularly. Its security page highlights compliance and administrative protections. That is normal for a SaaS transcription product. It is not the same as keeping the default meeting record on your laptop as plain files.
+
+There is also a workflow question. Notta is designed as a workspace. Meetings become searchable objects inside Notta, with product features layered around them. That is a good pattern when Notta is the team's meeting system of record.
+
+It is less ideal when your real system of record is:
+
+- an Obsidian vault;
+- a local project folder;
+- VS Code and grep;
+- a private Git repo;
+- a filesystem-backed personal knowledge base;
+- or a security-approved AI stack your organization already controls.
+
+In those workflows, export is not enough. You want the note to start as something you own.
+
+## Where Anarlog is different
+
+Anarlog starts from the opposite assumption: your meeting notes should be files first.
+
+Anarlog captures microphone and system audio from your desktop, transcribes meetings in real time, and saves notes as plain markdown files on your device. There is no meeting bot joining the call, no proprietary note database as the canonical record, and no requirement to build your workflow around a vendor workspace.
+
+The practical difference is simple. With Anarlog, the meeting note is something you can open in another editor, move into Obsidian, search from the terminal, sync however you already sync files, or keep in a folder that survives a subscription change.
+
+That matters for engineers, technical founders, consultants, lawyers, operators, and privacy-conscious teams who want meeting memory without turning every conversation into another SaaS object.
+
+## The decision criteria that matter
+
+### 1. File ownership
+
+Ask where the canonical note lives.
+
+If it lives in a vendor workspace and you can export it later, you have portability. If it starts as a markdown file on your machine, you have ownership.
+
+Notta is closer to the first model. Anarlog is built for the second.
+
+### 2. AI-provider control
+
+Meeting transcripts are high-context documents. They can include roadmap plans, customer problems, hiring feedback, legal details, financial data, or security incidents.
+
+If your organization already approves a specific AI provider, a local model, or an OpenAI-compatible internal endpoint, provider choice is not a power-user feature. It is a governance requirement.
+
+Anarlog supports a managed path when convenience matters, bring-your-own-key workflows when provider choice matters, and local-model workflows when data minimization matters most.
+
+### 3. Bot-free capture
+
+Notta now lists Notta Desktop as a beta bot-free meeting recorder for Mac and Windows. That is a useful signal: bot-free capture is becoming a mainstream requirement, not a niche preference.
+
+But "bot-free" is only one layer. The better question is what happens after capture. Does the audio become a local file? Does the transcript become a portable note? Can you choose the summarization provider? Can your team inspect the code path?
+
+Anarlog's answer is to keep the workflow local-first and open source.
+
+### 4. Collaboration versus control
+
+Notta makes sense when meeting documentation is a team workspace problem. Sales teams, customer success teams, recruiting teams, and operations teams may want shared transcripts, CRM sync, folders, permissions, and admin controls.
+
+Anarlog makes sense when the meeting note is primarily an owned working document. You can still share the output, but the default is not a shared cloud archive.
+
+### 5. Cost shape
+
+Notta's free plan is constrained by monthly transcription and per-conversation limits. Paid plans unlock longer recordings, higher quotas, collaboration, and admin controls.
+
+Anarlog's free path is strongest when you are comfortable bringing your own AI keys or running local models. That cost shape is different: you pay the AI provider directly, use local compute, or add Anarlog's managed service when you want the hosted stack handled for you.
+
+Neither model is universally cheaper. The right question is whether you want to pay for a hosted transcription workspace or for control over a local-first workflow.
+
+## When to choose Notta
+
+Choose Notta if you want:
+
+- web, mobile, and browser-extension workflows;
+- a hosted team workspace;
+- translation and bilingual transcription features;
+- integrations with calendars, cloud drives, CRM tools, and collaboration apps;
+- admin controls like SAML SSO and audit logs on enterprise plans;
+- and a product that handles the whole transcription workspace for you.
+
+That is a reasonable choice. Not every team wants to manage files, providers, or local models.
+
+## When to choose Anarlog
+
+Choose Anarlog if you want:
+
+- meeting notes as markdown files on disk;
+- an open-source, MIT-licensed meeting notetaker;
+- system-audio capture without inviting a bot;
+- local-first storage instead of a proprietary meeting database;
+- BYOK or local AI options;
+- a tool that works naturally with Obsidian, VS Code, folders, scripts, and your existing file workflow;
+- and less lock-in around the most sensitive document your meeting creates: the transcript.
+
+This is the real Anarlog fit. It is for people who do not want meeting memory to depend on a hosted workspace they cannot inspect or fork.
+
+## The bottom line
+
+Notta is a strong cloud transcription workspace. Anarlog is a local-first AI meeting notetaker.
+
+If you need team collaboration, translations, web/mobile coverage, and a large hosted feature surface, start with Notta.
+
+If you want an open-source Notta alternative built around files, bot-free capture, local workflows, and AI-provider control, start with Anarlog.
+
+For more context, read our guides to [AI meeting notes without a bot](/blog/ai-meeting-notes-without-bot/), [open-source meeting transcription software](/blog/open-source-meeting-transcription-software/), and [local AI meeting notetakers](/blog/local-ai-meeting-notes/).


### PR DESCRIPTION
## Summary
- Updates the queued Notta comparison for Notta Desktop and Privacy Mode
- Schedules it for July 14, one day after the latest July 13 publication, `meeting-decision-log` (#5985; media corrected in #5986)
- Advances the existing next-slot draft instead of creating a duplicate article
- Primary keyword: `notta alternative`

## Semrush evidence
Revalidated July 15, 2026:
- `notta alternative`: US volume 10, CPC $4.75, competitive density 0.99, KD 0; intent was not returned
- Anarlog has no dedicated Notta URL, so this does not cannibalize an existing Notta-specific article
- `phrase_organic` returned no rows
- `anarlog.so` Organic Research filtered for `notta` returned no rows, so the article makes no ranking claim
- Semrush Organic Competitors reports 14 shared keywords between `anarlog.so` and `notta.ai`
- `notta.ai` currently ranks alternatives pages for adjacent competitor terms, supporting the comparison intent
- The Semrush `anarlog.so` project is still absent; project Position Tracking and Site Audit baselines remain unavailable

## Current-source review
Rechecked July 15 against:
- Notta pricing
- Notta Desktop bot-free feature page
- Notta Desktop Privacy Mode
- Notta Bot
- Notta security page

The comparison acknowledges bot-free Mac/Windows capture, local transcription, offline operation after setup, and local file storage. It differentiates Anarlog on open-source auditability, plain-markdown ownership, AI-provider choice, and cost shape rather than claiming Notta is cloud-only.

Notta says Desktop is available to all users at no additional cost and specifically documents that Privacy Mode on Pro does not consume cloud transcription minutes.

## Media
No body image is required for this table-driven comparison. No generated UI or unverified screenshot is referenced.

## Verification
- `pnpm exec dprint fmt apps/web/content/articles/notta-ai-alternative.mdx`
- `pnpm exec dprint check --config dprint.json apps/web/content/articles/notta-ai-alternative.mdx`
- `pnpm --dir apps/web typecheck`
- Branch rebased onto current `main` through #6045
- Official Notta pricing, Desktop, Privacy Mode, Bot, and security pages rechecked July 15
- Deploy preview, CI, formatting, lint, and Bugbot checks passed on rebased head `4a50f8a20a`

## Review focus
- Verify the ownership-model distinction remains clear without understating Notta's local Privacy Mode
- Recheck time-sensitive pricing immediately before merge

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/content-only addition with no runtime, auth, or data-path changes; main review risk is factual accuracy of competitor pricing and feature claims before merge.
> 
> **Overview**
> Adds a new **Comparisons** article at `notta-ai-alternative.mdx`, scheduled for **2026-07-14**, targeting the **“notta alternative”** keyword.
> 
> The piece positions Anarlog against Notta with a comparison table and decision sections (file ownership, AI-provider control, bot-free capture, collaboration vs. control, pricing). It acknowledges **Notta Desktop** bot-free capture and **Privacy Mode** (local transcription/storage, Pro unlimited local minutes) while contrasting Anarlog on **MIT open source**, **markdown-first** notes, and **BYOK/local AI**.
> 
> No app or API code changes—content and front matter only; no body images per the PR description.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a50f8a20ab9de5c6392f4fd0322decce4f33e20. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->