### PR TITLE
Add MeetGeek alternatives article

### DIFF
--- a/apps/web/content/articles/meetgeek-alternatives.mdx
+++ b/apps/web/content/articles/meetgeek-alternatives.mdx
@@ -5,7 +5,7 @@ meta_description: "Compare the best MeetGeek alternatives for bot-free capture, 
 author: "Anarlog Team"
 featured: false
 category: "Comparisons"
-date: "2026-07-12"
+date: "2026-07-13"
 ready_for_review: true
 ---
 

--- a/apps/web/content/articles/meetgeek-alternatives.mdx
+++ b/apps/web/content/articles/meetgeek-alternatives.mdx
@@ -1,0 +1,153 @@
+---
+meta_title: "6 Best MeetGeek Alternatives in 2026"
+display_title: "MeetGeek Alternatives for Teams That Need More Control"
+meta_description: "Compare the best MeetGeek alternatives for bot-free capture, local-first meeting notes, CRM workflows, browser transcription, and open-source meeting AI."
+author: "Anarlog Team"
+featured: false
+category: "Comparisons"
+date: "2026-07-12"
+ready_for_review: true
+---
+
+MeetGeek is a strong AI meeting assistant when the job is team-wide meeting intelligence: automatic recordings, searchable transcripts, analytics, workflows, and CRM handoff.
+
+That is also why some teams look for alternatives. If your real requirement is local files, no meeting bot, browser-only transcription, open-source code, a lower-cost plan, or a sales workflow built around a different CRM stack, MeetGeek may be more platform than you need.
+
+This guide compares six MeetGeek alternatives by workflow, not by generic feature count.
+
+![MeetGeek alternatives decision map](/api/assets/blog/articles/meetgeek-alternatives/meetgeek-alternatives-decision-map.png)
+
+## Quick comparison
+
+| Tool | Best for | Capture model | Starting point |
+| --- | --- | --- | --- |
+| Anarlog | Local-first meeting notes and AI ownership | Desktop system-audio capture, no meeting bot | Free local/BYOK workflow |
+| Jamie | Polished bot-free meeting notes for individuals and teams | Desktop and mobile capture, no meeting bot | Free plan with 10 meetings/month |
+| Tactiq | Browser-based live transcription | Chrome extension for Meet, Zoom, and Teams | Free plan; Pro listed at $8/user/month annually |
+| Fathom | Sales follow-up, call summaries, CRM workflows | Bot capture and bot-free capture in beta | Free individual plan |
+| Fireflies.ai | Shared cloud transcript archive and team analytics | Meeting bot plus apps and integrations | Free plan; Pro listed at $10/seat/month annually |
+| Meetily | Open-source/self-hosted local transcription | Local app and self-hostable workflow | Free Community Edition |
+
+Prices and plan limits change often. Treat this table as a buying shortlist and verify the linked vendor pages before procurement.
+
+## Why teams replace MeetGeek
+
+[MeetGeek](https://meetgeek.ai/) positions itself as an all-in-one meeting assistant for sales, HR, leadership, customer success, and marketing. Its [pricing page](https://meetgeek.ai/pricing) lists a free Basic plan with 3 hours of transcription per month, and Pro at $9.99/user/month with 20 hours of transcription per month when billed annually. MeetGeek also lists recording for Zoom, Google Meet, Teams, and more, transcription in 100+ languages, auto language detection, unlimited AI summaries, meeting analytics, global search, mobile apps, a Chrome extension, and no-bot recording via browser and desktop app.
+
+That is a broad product surface. It works well when a company wants meetings to become a shared workspace: searchable archives, analytics, folders, workflows, and integrations.
+
+It is a weaker fit when the buyer is optimizing for one of these constraints:
+
+- **Ownership:** meeting notes should live as files, not only inside a vendor database.
+- **No bot by default:** the capture method should not add another participant to the meeting.
+- **Approved AI stack:** the team wants to choose which speech-to-text and LLM provider sees meeting data.
+- **Open source:** security review needs source code, not just a trust page.
+- **Single-user workflow:** the buyer needs clean notes, not team analytics.
+- **Browser-only setup:** the team wants a Chrome extension instead of a desktop meeting recorder.
+
+If the main issue is visible bots, read [AI Meeting Notes Without a Bot](/blog/ai-meeting-notes-without-bot/) first. If the issue is broader meeting documentation, the [meeting minutes software comparison](/blog/meeting-minutes-software/) covers board minutes, agenda tools, and formal approval workflows.
+
+## 1. Anarlog: best for local-first meeting notes
+
+[Anarlog](https://anarlog.so/) is the MeetGeek alternative for people who want AI meeting notes without moving every conversation into a cloud meeting platform.
+
+It captures system audio from your desktop, transcribes meetings in real time, and saves notes as plain markdown files on your device. The core product is open source, so a technical buyer can inspect how meeting memory is handled instead of taking the vendor's word for it.
+
+The important difference is architectural. MeetGeek is designed around a shared cloud workspace. Anarlog is designed around ownership: your files, your AI provider, your workflow.
+
+Use Anarlog when:
+
+- meeting notes should stay readable in Obsidian, VS Code, Notion, a local folder, or any markdown-compatible workflow;
+- the team does not want a meeting bot joining calls by default;
+- you want to bring your own API keys or run local models through tools like Ollama or LM Studio;
+- security review values open-source code and local storage;
+- you care more about private meeting memory than sales coaching dashboards.
+
+Anarlog is not the right replacement if you need manager dashboards, deal coaching, auto-updated CRM fields, or a cloud call library for a large revenue organization. Those are real MeetGeek strengths. Anarlog is intentionally narrower: it gives high-agency users control over capture, storage, and AI.
+
+## 2. Jamie: best polished bot-free alternative
+
+[Jamie](https://www.meetjamie.ai/en) leads with the message "without a bot." It turns online or in-person meetings into structured notes, transcripts, and action items, and its site says it supports 100+ languages. Its [pricing page](https://www.meetjamie.ai/pricing) lists a free plan with 10 meetings per month, a 30-minute meeting duration limit, and exports/integrations such as Notion, Google Docs, and OneNote.
+
+Jamie is a good MeetGeek alternative when the buyer wants the bot-free experience but does not want to assemble a local-first workflow. It is packaged as a conventional app: cleaner onboarding, team features on paid plans, speaker recognition, and a more guided product experience.
+
+Choose Jamie over MeetGeek when a visible meeting assistant is the main problem and you still want a commercial SaaS workflow around the notes.
+
+Choose Anarlog instead when the deeper requirement is file ownership, open-source auditability, or choosing the AI stack yourself.
+
+## 3. Tactiq: best browser extension alternative
+
+[Tactiq](https://tactiq.io/) is built around live in-meeting transcription from the browser. It supports Google Meet, Zoom, and Microsoft Teams, and its homepage says it supports over 60 languages. Its [pricing page](https://tactiq.io/buy) lists a free plan, Pro at $8/user/month billed annually, Team at $16.67/user/month billed annually, Business at $29.17/user/month billed annually, and custom Enterprise pricing.
+
+Tactiq is the cleanest MeetGeek alternative when the workflow is browser-first and speed matters more than ownership. You install the Chrome extension, join the meeting, and get a live transcript and AI summaries without deploying a heavier meeting-intelligence platform.
+
+The tradeoff is scope. Browser-extension capture is convenient, but it is not the same as a local-first desktop app that can handle broader audio contexts or keep the file system as the source of truth.
+
+Use Tactiq when:
+
+- meetings happen in browser tabs;
+- a lightweight extension is easier to approve than a full meeting platform;
+- the team wants quick transcription and summaries;
+- budget is a primary constraint.
+
+Use Anarlog when the meeting notes should become durable local files and the browser is not the only place conversations happen.
+
+## 4. Fathom: best for sales follow-up
+
+[Fathom](https://www.fathom.ai/pricing) is a better MeetGeek alternative for teams that care most about sales follow-up and CRM execution. Its pricing page lists a free individual plan with unlimited recordings and transcriptions, plus a choice of bot-free capture in beta or bot capture. Team plans start at $19/user/month monthly or $15/user/month annually, with a two-user minimum.
+
+Fathom and MeetGeek overlap heavily: both can sit close to revenue workflows, create call summaries, and push meeting context into the rest of the sales stack. The decision comes down to which product's workflow feels cleaner for your team and which CRM/reporting features matter.
+
+Choose Fathom when sales reps need fast summaries, highlights, CRM updates, and collaboration around customer conversations.
+
+Choose Anarlog when the meeting is not primarily a sales object. Founder calls, product reviews, legal conversations, hiring loops, and internal strategy meetings often benefit more from private notes you control than from a shared revenue archive.
+
+## 5. Fireflies.ai: best cloud meeting archive
+
+[Fireflies.ai](https://fireflies.ai/pricing) is the MeetGeek alternative for teams that want a broad cloud transcript archive with integrations, analytics, and enterprise controls. Fireflies lists a free plan with unlimited transcription and AI summaries but 400 minutes of storage per team. Pro is listed at $10/seat/month billed annually, Business at $19/seat/month billed annually, and Enterprise at $39/seat/month billed annually.
+
+Fireflies is strong when the organization wants meeting data centralized. It supports Zoom, Google Meet, Teams, uploads, desktop and mobile apps, API access, integrations, conversation intelligence, team analytics, SSO/SCIM on Enterprise, audit logs, HIPAA compliance, private storage, and custom data retention.
+
+That is useful for a company trying to make every meeting searchable across a department. It is less useful for users who do not want a cloud meeting database in the first place.
+
+If you are evaluating Fireflies because MeetGeek feels too heavy, also read the [Fireflies alternatives](/blog/fireflies-ai-alternatives/) and [local AI meeting notes](/blog/local-ai-meeting-notes/) guides. The capture model and storage model matter more than the summary template.
+
+## 6. Meetily: best open-source self-hosted alternative
+
+[Meetily](https://meetily.ai/) is another open-source path. Its site describes the Community Edition as free and open source, with Pro at $10/user/month billed annually and custom Enterprise pricing for self-hosted deployment, admin dashboards, dedicated support, and compliance frameworks.
+
+Meetily is worth evaluating if the buyer wants a local or self-hosted meeting assistant and is comfortable with a more technical deployment path. It competes more directly with Anarlog than with Fireflies or Fathom: the question is whether you want a local-first meeting notetaker that stores notes as plain markdown files on your machine, or a self-hostable assistant whose operational model fits your team better.
+
+For technical teams, the useful comparison is not "which one has more AI features." It is:
+
+- Can security review the code?
+- Where do audio, transcripts, and summaries live by default?
+- Can the team use approved AI providers?
+- What happens if the vendor disappears?
+- How painful is it to leave?
+
+Those questions expose lock-in faster than a feature checklist.
+
+## MeetGeek vs alternatives: how to choose
+
+Use MeetGeek when you want a polished meeting-intelligence platform with summaries, workflows, analytics, search, and team adoption in one place.
+
+Use Anarlog when you want meeting notes you own. That means no meeting bot by default, plain markdown files, open-source code, and control over the AI provider.
+
+Use Jamie when you want a polished commercial bot-free app and do not need the local-file/open-source model.
+
+Use Tactiq when the team lives in browser meetings and wants fast transcripts at a low price.
+
+Use Fathom when the real job is sales follow-up and CRM execution.
+
+Use Fireflies when the organization wants a centralized meeting archive with analytics and enterprise controls.
+
+Use Meetily when self-hosting or open-source local transcription is the primary requirement.
+
+## The bottom line
+
+MeetGeek is not the wrong choice. It is just a specific choice: meeting intelligence as a cloud workspace.
+
+If that is what your team needs, keep it on the shortlist. If the actual requirement is private meeting memory, markdown files, no bot in the room, and control over which AI stack processes your conversations, start with Anarlog.
+
+[Download Anarlog](https://anarlog.so/download/apple-silicon) and try it on one real meeting before committing your meeting history to another platform.

--- a/apps/web/content/articles/meetgeek-alternatives.mdx
+++ b/apps/web/content/articles/meetgeek-alternatives.mdx
@@ -104,9 +104,9 @@ Choose Anarlog when the meeting is not primarily a sales object. Founder calls, 
 
 ## 5. Fireflies.ai: best cloud meeting archive
 
-[Fireflies.ai](https://fireflies.ai/pricing) is the MeetGeek alternative for teams that want a broad cloud transcript archive with integrations, analytics, and enterprise controls. Fireflies lists a free plan with unlimited transcription and AI summaries but 400 minutes of storage per team. Pro is listed at $10/seat/month billed annually, Business at $19/seat/month billed annually, and Enterprise at $39/seat/month billed annually.
+[Fireflies.ai](https://fireflies.ai/pricing) is the MeetGeek alternative for teams that want a broad cloud transcript archive with integrations, analytics, and enterprise controls. Fireflies lists a free plan, with Pro at $10/seat/month billed annually, Business at $19/seat/month billed annually, and Enterprise at $39/seat/month billed annually. Free-plan storage and AI-summary allowances have changed, so verify the live pricing page if those limits affect your decision.
 
-Fireflies is strong when the organization wants meeting data centralized. It supports Zoom, Google Meet, Teams, uploads, desktop and mobile apps, API access, integrations, conversation intelligence, team analytics, SSO/SCIM on Enterprise, audit logs, HIPAA compliance, private storage, and custom data retention.
+Fireflies is strong when the organization wants meeting data centralized. It supports Zoom, Google Meet, Teams, uploads, desktop and mobile apps, API access, integrations, conversation intelligence, and team analytics. Its Enterprise plan lists SSO, HIPAA compliance, private storage, and custom data retention.
 
 That is useful for a company trying to make every meeting searchable across a department. It is less useful for users who do not want a cloud meeting database in the first place.
 


### PR DESCRIPTION
## Summary
- Adds a review-ready Anarlog comparison article: `6 Best MeetGeek Alternatives in 2026`
- Targets July slot 3 in the monthly cadence: conversion/comparison
- Includes an uploaded article-specific workflow visual at `/api/assets/blog/articles/meetgeek-alternatives/meetgeek-alternatives-decision-map.png`

## Semrush evidence used
- `meetgeek alternatives`: 20 US searches/month, competition 0.02, KD 0
- `meetgeek pricing`: 40 US searches/month, CPC $2.11, competition 0.53, KD 17, intent code `2`
- `meetgeek vs fireflies`: 20 US searches/month, competition 0.38, KD 0
- `meetgeek vs otter`: 20 US searches/month, CPC $6.23, competition 0.33, KD 0
- Organic research for `meetgeek.ai` showed branded visibility around `meetgeek`, `meetgeek ai note taker`, and `meetgeek notetaker`, plus broader meeting-minutes content.

Landing-page candidate to consider later: `MeetGeek pricing` has stronger commercial intent than the alternatives query, but this run stayed on the scheduled blog slot.

## Research notes
Primary/current source pages checked for vendor claims:
- MeetGeek pricing and product pages
- Jamie homepage and pricing page
- Tactiq homepage and pricing page
- Fathom pricing page
- Fireflies pricing page
- Meetily homepage
- Anarlog homepage/GitHub positioning

## Verification
- `pnpm exec dprint fmt`
- `pnpm -F @hypr/web typecheck`
- Uploaded image URL returned `HTTP/2 200` with `content-type: image/png`

## Media note
The image was uploaded directly to the existing Supabase `blog` bucket using the documented Infisical production environment. Media catalog registration was skipped because this was a direct storage upload, not the admin helper flow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Content-only addition (marketing MDX and asset reference); no application logic, auth, or data handling changes.
> 
> **Overview**
> Adds a new **Comparisons** blog post at `meetgeek-alternatives.mdx` (July 2026 slot, `ready_for_review: true`) targeting “MeetGeek alternatives” SEO.
> 
> The piece walks through **six workflow-based alternatives** (Anarlog, Jamie, Tactiq, Fathom, Fireflies.ai, Meetily) with a quick comparison table, vendor pricing links, internal links to related guides, and a **decision-map hero image** served from `/api/assets/blog/articles/meetgeek-alternatives/meetgeek-alternatives-decision-map.png`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ee7acce18a4765be5e72253187bdcb6a8dbcf28a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->