### PR TITLE
Fix trial payment method state

### DIFF
--- a/apps/desktop/src/auth/billing.tsx
+++ b/apps/desktop/src/auth/billing.tsx
@@ -297,6 +297,7 @@ export function BillingProvider({ children }: { children: ReactNode }) {
         open={trialStartedOpen}
         onOpenChange={setTrialStartedOpen}
         trialDaysRemaining={billing.trialDaysRemaining}
+        hasPaymentMethod={claimsQuery.data?.has_payment_method === true}
       />
       <TrialPaymentReminderDialog
         open={trialPaymentReminderOpen}

--- a/apps/desktop/src/billing/trial-started-dialog.test.tsx
+++ b/apps/desktop/src/billing/trial-started-dialog.test.tsx
@@ -1,0 +1,35 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { TrialStartedDialog } from "./trial-started-dialog";
+
+describe("TrialStartedDialog", () => {
+  afterEach(cleanup);
+
+  it("confirms automatic continuation for card-backed trials", () => {
+    render(
+      <TrialStartedDialog
+        open
+        onOpenChange={() => {}}
+        trialDaysRemaining={14}
+        hasPaymentMethod
+      />,
+    );
+
+    expect(screen.getByText(/continue automatically/)).toBeTruthy();
+    expect(screen.queryByText(/Add a payment method/)).toBeNull();
+  });
+
+  it("asks cardless trial users to add a payment method", () => {
+    render(
+      <TrialStartedDialog
+        open
+        onOpenChange={() => {}}
+        trialDaysRemaining={14}
+        hasPaymentMethod={false}
+      />,
+    );
+
+    expect(screen.getByText(/Add a payment method/)).toBeTruthy();
+  });
+});

--- a/apps/desktop/src/billing/trial-started-dialog.tsx
+++ b/apps/desktop/src/billing/trial-started-dialog.tsx
@@ -14,12 +14,14 @@ interface TrialStartedDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   trialDaysRemaining: number | null;
+  hasPaymentMethod: boolean;
 }
 
 export function TrialStartedDialog({
   open,
   onOpenChange,
   trialDaysRemaining,
+  hasPaymentMethod,
 }: TrialStartedDialogProps) {
   const days = trialDaysRemaining ?? 14;
 
@@ -32,8 +34,9 @@ export function TrialStartedDialog({
             Your Pro trial just started
           </DialogTitle>
           <DialogDescription className="text-foreground w-full text-center text-[13px] leading-[1.36]">
-            Your {days}-day Pro trial starts now. Add a payment method before it
-            ends to keep Pro.
+            {hasPaymentMethod
+              ? `Your ${days}-day Pro trial starts now. Pro will continue automatically when it ends.`
+              : `Your ${days}-day Pro trial starts now. Add a payment method before it ends to keep Pro.`}
           </DialogDescription>
         </DialogHeader>
         <DialogFooter className="px-4 pt-4 pb-4 sm:justify-center">

--- a/apps/desktop/src/devtools-panel/host.tsx
+++ b/apps/desktop/src/devtools-panel/host.tsx
@@ -480,6 +480,7 @@ function useDevtoolsPanelActions() {
           open={trialStartedOpen}
           onOpenChange={setTrialStartedOpen}
           trialDaysRemaining={trialDaysRemaining}
+          hasPaymentMethod={false}
         />
         <TrialEndedDialog
           open={trialEndedOpen}

--- a/supabase/migrations/20260712000002_auth_hook_fix_payment_method_claim.sql
+++ b/supabase/migrations/20260712000002_auth_hook_fix_payment_method_claim.sql
@@ -1,0 +1,68 @@
+CREATE OR REPLACE FUNCTION public.custom_access_token_hook(event jsonb)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+AS $$
+DECLARE
+  claims jsonb;
+  entitlements jsonb := '[]'::jsonb;
+  v_user_id uuid := (event->>'user_id')::uuid;
+  v_customer_id text;
+  v_subscription_status text;
+  v_trial_end bigint;
+  v_has_payment_method boolean;
+BEGIN
+  SELECT p.stripe_customer_id INTO v_customer_id
+  FROM public.profiles p
+  WHERE p.id = v_user_id;
+
+  SELECT
+    COALESCE(
+      jsonb_agg(ae.lookup_key ORDER BY ae.lookup_key)
+        FILTER (WHERE ae.lookup_key IS NOT NULL),
+      '[]'::jsonb
+    )
+  INTO entitlements
+  FROM public.profiles p
+  JOIN stripe.active_entitlements ae
+    ON ae.customer = p.stripe_customer_id
+  WHERE p.id = v_user_id;
+
+  IF v_customer_id IS NOT NULL THEN
+    SELECT
+      s.status::text,
+      (s.trial_end #>> '{}')::bigint,
+      s.default_payment_method IS NOT NULL
+        OR c.invoice_settings->>'default_payment_method' IS NOT NULL
+        OR c.default_source IS NOT NULL
+    INTO v_subscription_status, v_trial_end, v_has_payment_method
+    FROM stripe.subscriptions s
+    JOIN stripe.customers c ON c.id = s.customer
+    WHERE s.customer = v_customer_id
+      AND s.status IN ('trialing', 'active')
+    ORDER BY
+      CASE s.status WHEN 'active' THEN 1 WHEN 'trialing' THEN 2 END,
+      s.created DESC
+    LIMIT 1;
+  END IF;
+
+  claims := event->'claims';
+  claims := jsonb_set(claims, '{entitlements}', entitlements);
+
+  IF v_subscription_status IS NOT NULL THEN
+    claims := jsonb_set(claims, '{subscription_status}', to_jsonb(v_subscription_status));
+  END IF;
+
+  IF v_trial_end IS NOT NULL THEN
+    claims := jsonb_set(claims, '{trial_end}', to_jsonb(v_trial_end));
+  END IF;
+
+  IF v_has_payment_method IS NOT NULL THEN
+    claims := jsonb_set(claims, '{has_payment_method}', to_jsonb(v_has_payment_method));
+  END IF;
+
+  event := jsonb_set(event, '{claims}', claims);
+
+  RETURN event;
+END;
+$$;

--- a/supabase/tests/003-auth-custom-access-token-hook.sql
+++ b/supabase/tests/003-auth-custom-access-token-hook.sql
@@ -105,12 +105,12 @@ update public.profiles
 set stripe_customer_id = 'cus_trialing'
 where id = tests.get_supabase_uid('trialing');
 
-insert into stripe.customers (id)
-values ('cus_trialing')
+insert into stripe.customers (id, invoice_settings)
+values ('cus_trialing', '{"default_payment_method":"pm_trialing"}')
 on conflict (id) do nothing;
 
-insert into stripe.subscriptions (id, customer, status, trial_end, default_payment_method, created)
-values ('sub_trialing', 'cus_trialing', 'trialing', '1738627200', 'pm_trialing', 1000)
+insert into stripe.subscriptions (id, customer, status, trial_end, created)
+values ('sub_trialing', 'cus_trialing', 'trialing', '1738627200', 1000)
 on conflict (id) do nothing;
 
 select results_eq(
@@ -155,7 +155,7 @@ select results_eq(
   )::text
   $$,
   array['true'],
-  'custom_access_token_hook detects a trial payment method'
+  'custom_access_token_hook detects a customer-level trial payment method'
 );
 
 select tests.create_supabase_user('active', 'active@example.com');


### PR DESCRIPTION
Detect customer-level payment methods added through the billing portal and tailor trial-started messaging to whether a card is already present.

Includes focused desktop dialog coverage and updates the Supabase auth-hook test to exercise customer-level defaults.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes JWT claim logic used for billing UX and trial reminders; incorrect detection could mislead users or skip payment reminders, but scope is limited to claim derivation and messaging.
> 
> **Overview**
> Fixes **`has_payment_method`** in the Supabase **`custom_access_token_hook`** so cards added via the billing portal count: it now treats subscription **`default_payment_method`**, customer **`invoice_settings.default_payment_method`**, and **`default_source`** as signals (with a **`stripe.customers`** join), instead of only the subscription field.
> 
> The desktop **trial-started** dialog takes a **`hasPaymentMethod`** prop from JWT claims and shows either automatic Pro continuation or the “add a payment method” message. **`BillingProvider`** wires claims into the dialog; devtools preview passes **`hasPaymentMethod={false}`**. Vitest covers both copy paths; the auth-hook SQL test asserts customer-level defaults.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit df644db3d011866b89b5186f79616aa87abee3a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->