### PR TITLE
Add desktop 1.1.13 changelog

### DIFF
--- a/packages/changelog/content/1.1.13.md
+++ b/packages/changelog/content/1.1.13.md
@@ -1,0 +1,33 @@
+---
+date: "2026-07-12"
+summary: "Anarlog moves your notes to more reliable storage, adds template icons, and improves trial and Dock workflows."
+---
+
+<banner title="More reliable local storage" variant="info">
+Anarlog now stores app data in SQLite. Existing notes, transcripts, summaries, contacts, calendars, and settings are migrated automatically and verified before the app opens. Your previous files remain available until you choose to clean them up in Settings.
+</banner>
+
+## Reliability
+
+- Notes, transcripts, summaries, chats, contacts, calendars, tasks, and settings now use a single local SQLite database
+- Anarlog verifies migrated data before switching over and keeps legacy files as a recovery copy
+- Settings now shows migration status and offers an explicit cleanup action after migration completes
+- Pending edits are saved before Anarlog quits
+
+## Templates
+
+- Templates can now have custom icons or emojis, shown throughout the template picker
+- The summary template picker is more compact and easier to scan
+
+## Dock
+
+- Right-click the Dock icon to create a note, open Anarlog, open Settings, check for updates, restart, or quit completely
+
+## Pro Trials
+
+- Trial checkout and recovery are more reliable
+- Cardless trials receive timely payment reminders, while trials with a saved payment method continue without unnecessary prompts
+
+## Polish
+
+- App popovers now use consistent borders


### PR DESCRIPTION
Document the automatic verified SQLite migration, user-controlled legacy cleanup, template icons, Dock quick actions, and trial improvements shipping in 1.1.13.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or application code changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.13.md`** for the desktop **1.1.13** release, following the same frontmatter + section layout as recent entries like **1.1.12**.
> 
> The entry documents **SQLite migration** (automatic verified migration, legacy file retention, Settings status/cleanup, quit-time save), **template icons** and a tighter summary template picker, **Dock** context-menu shortcuts, **Pro trial** checkout/recovery and payment reminders, and minor **popover** border polish.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 808f53dd412c4f01a1686b639dc1d89a8ca20317. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->