### PR TITLE
Add desktop 1.1.15 changelog

### DIFF
--- a/packages/changelog/content/1.1.15.md
+++ b/packages/changelog/content/1.1.15.md
@@ -1,0 +1,8 @@
+---
+date: "2026-07-13"
+summary: "Google Calendar sync now handles events without locations or other optional details."
+---
+
+## Reliability
+
+- Fixed Google Calendar sync failures when existing events did not include a location, meeting link, description, or recurrence details


### PR DESCRIPTION
## Summary
- add the user-facing changelog for the Google Calendar sync reliability patch
- prepare the stable 1.1.15 release gate

## Verification
- `pnpm exec dprint fmt`
- `pnpm -F @hypr/changelog typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changelog content with no application or infrastructure code changes.
> 
> **Overview**
> Adds the **1.1.15** user-facing changelog entry for the stable release gate.
> 
> The note documents a **Reliability** fix: Google Calendar sync no longer fails when events lack optional fields (location, meeting link, description, or recurrence).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0674d096c1232189fcb3a41296a0ab5d0d263fa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->