### PR TITLE
Keep interrupted meetings active through event grace

### DIFF
--- a/apps/desktop/src/stt/contexts.test.tsx
+++ b/apps/desktop/src/stt/contexts.test.tsx
@@ -6,6 +6,7 @@ import { parseAutoStopEndedNotificationKey } from "./auto-stop-notification";
 import {
   AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS,
   AUTO_STOP_CONFIRM_DELAY_MS,
+  AUTO_STOP_EVENT_END_GRACE_MS,
   ListenerProvider,
 } from "./contexts";
 
@@ -218,6 +219,10 @@ describe("ListenerProvider detect events", () => {
     loadSessionEventMock.mockImplementation(readConfiguredSessionEvent);
     listenMock.mockResolvedValue(() => {});
     listMicUsingApplicationsMock.mockResolvedValue({ status: "ok", data: [] });
+    Object.defineProperty(window.navigator, "onLine", {
+      configurable: true,
+      value: true,
+    });
     vi.useRealTimers();
   });
 
@@ -331,6 +336,264 @@ describe("ListenerProvider detect events", () => {
 
     expect(listMicUsingApplicationsMock).toHaveBeenCalledTimes(1);
     expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("holds a network-interrupted meeting until its event end grace expires", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const now = new Date("2026-05-19T10:05:00.000Z");
+    const endedAtMs = new Date("2026-05-19T10:30:00.000Z").getTime();
+    const deadlineMs = endedAtMs + AUTO_STOP_EVENT_END_GRACE_MS;
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+    const handler = listenMock.mock.calls[0]?.[0];
+
+    window.dispatchEvent(new Event("offline"));
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+    window.dispatchEvent(new Event("online"));
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(deadlineMs - Date.now() - 1);
+    expect(stopSpy).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(1);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("cancels a network interruption hold when the meeting resumes during event grace", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const now = new Date("2026-05-19T10:05:00.000Z");
+    const endedAtMs = new Date("2026-05-19T10:30:00.000Z").getTime();
+    const deadlineMs = endedAtMs + AUTO_STOP_EVENT_END_GRACE_MS;
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+    const handler = listenMock.mock.calls[0]?.[0];
+
+    window.dispatchEvent(new Event("offline"));
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+    await vi.advanceTimersByTimeAsync(
+      endedAtMs + AUTO_STOP_EVENT_END_GRACE_MS / 2 - Date.now(),
+    );
+
+    window.dispatchEvent(new Event("online"));
+    handler({
+      payload: {
+        type: "micDetected",
+        key: "mic-resumed",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+        duration_secs: 15,
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(deadlineMs - Date.now());
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("upgrades a pending auto-stop when the network drops during confirmation", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const now = new Date("2026-05-19T10:05:00.000Z");
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+    const handler = listenMock.mock.calls[0]?.[0];
+
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS - 1);
+    window.dispatchEvent(new Event("offline"));
+    await vi.advanceTimersByTimeAsync(1);
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("keeps standard auto-stop behavior for offline ad-hoc meetings", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+    const handler = listenMock.mock.calls[0]?.[0];
+
+    vi.useFakeTimers();
+    window.dispatchEvent(new Event("offline"));
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
+  });
+
+  test("does not let an interrupted meeting timer stop a replacement session", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+    const now = new Date("2026-05-19T10:05:00.000Z");
+    const deadlineMs =
+      new Date("2026-05-19T10:30:00.000Z").getTime() +
+      AUTO_STOP_EVENT_END_GRACE_MS;
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T10:00:00.000Z",
+        ended_at: "2026-05-19T10:30:00.000Z",
+      }),
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(now);
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+    const handler = listenMock.mock.calls[0]?.[0];
+
+    window.dispatchEvent(new Event("offline"));
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+
+    setStoreActive(store, "session-2");
+    await vi.advanceTimersByTimeAsync(deadlineMs - Date.now());
+
+    expect(stopSpy).not.toHaveBeenCalled();
+  });
+
+  test("does not hold for a future linked event outside the early-start buffer", async () => {
+    const store = createListenerStore();
+    const stopSpy = vi.fn();
+
+    store.setState({ stop: stopSpy });
+    store.getState().setTriggerAppIds(["us.zoom.xos"]);
+    setStoreActive(store);
+    (useStoreMock as any).mockReturnValue(
+      mockSessionEventStore({
+        started_at: "2026-05-19T11:00:00.000Z",
+        ended_at: "2026-05-19T11:30:00.000Z",
+      }),
+    );
+
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-05-19T10:00:00.000Z"));
+
+    render(
+      <ListenerProvider store={store}>
+        <div>child</div>
+      </ListenerProvider>,
+    );
+
+    await vi.waitFor(() => expect(listenMock).toHaveBeenCalledTimes(1));
+    const handler = listenMock.mock.calls[0]?.[0];
+
+    window.dispatchEvent(new Event("offline"));
+    handler({
+      payload: {
+        type: "micStopped",
+        apps: [{ id: "us.zoom.xos", name: "Zoom" }],
+      },
+    });
+
+    await vi.advanceTimersByTimeAsync(AUTO_STOP_CONFIRM_DELAY_MS);
+    expect(stopSpy).toHaveBeenCalledTimes(1);
   });
 
   test("does not stop on MicStopped when auto-stop is disabled", async () => {

--- a/apps/desktop/src/stt/contexts.tsx
+++ b/apps/desktop/src/stt/contexts.tsx
@@ -1,5 +1,5 @@
 import { resolveResource } from "@tauri-apps/api/path";
-import React, { createContext, useContext, useEffect, useRef } from "react";
+import React, { createContext, useContext, useRef } from "react";
 import { useStore } from "zustand";
 import { useShallow } from "zustand/shallow";
 
@@ -23,6 +23,7 @@ import {
 } from "~/calendar/queries";
 import { loadSessionEvent } from "~/session/queries";
 import { useConfigValue } from "~/shared/config";
+import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import {
   createListenerStore,
   type ListenerStore,
@@ -32,6 +33,9 @@ const ListenerContext = createContext<ListenerStore | null>(null);
 export const AUTO_STOP_CONFIRM_DELAY_MS = 5_000;
 export const AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS = 3 * 60_000;
 export const AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS = 5 * 60_000;
+export const AUTO_STOP_EVENT_END_GRACE_MS = 10 * 60_000;
+
+const MAX_TIMEOUT_DELAY_MS = 2_147_483_647;
 
 const BROWSER_AUTO_STOP_APP_IDS = new Set([
   "at.studio.AsideBrowser",
@@ -72,6 +76,12 @@ const UNRELIABLE_AUTO_STOP_APP_IDS = new Set(["com.kakao.KakaoTalkMac"]);
 
 type MicApp = { id: string; name: string };
 type NearbyEvent = NearbyCalendarEvent;
+type PendingAutoStop = {
+  timeout?: ReturnType<typeof setTimeout>;
+  requireMicSnapshot: boolean;
+  sessionId: string | null;
+  networkInterrupted: boolean;
+};
 type MeetingPlatform = {
   displayName: string;
   iconResource: NotificationIconResource;
@@ -717,6 +727,36 @@ async function shouldPromptBeforeAutoStopping({
   return nowMs < endMs - AUTO_STOP_CALENDAR_EARLY_END_THRESHOLD_MS;
 }
 
+async function getNetworkInterruptionDeadlineMs({
+  sessionId,
+  nowMs,
+}: {
+  sessionId: string | null;
+  nowMs: number;
+}): Promise<number | null> {
+  if (!sessionId) {
+    return null;
+  }
+
+  const event = await loadSessionEvent(sessionId);
+  if (!event || event.is_all_day) {
+    return null;
+  }
+
+  const endMs = parseEventTimeMs(event.ended_at);
+  if (!endMs) {
+    return null;
+  }
+
+  const startMs = parseEventTimeMs(event.started_at);
+  if (startMs && nowMs < startMs - AUTO_STOP_CALENDAR_EARLY_START_BUFFER_MS) {
+    return null;
+  }
+
+  const deadlineMs = endMs + AUTO_STOP_EVENT_END_GRACE_MS;
+  return deadlineMs > nowMs ? deadlineMs : null;
+}
+
 function getPrimaryStoppedApp(
   stoppedTriggerAppIds: string[],
   stoppedApps: { id: string; name: string }[],
@@ -841,18 +881,19 @@ const useHandleDetectEvents = (store: ListenerStore) => {
 
   const autoStopMeetingsRef = useRef(autoStopMeetings);
   autoStopMeetingsRef.current = autoStopMeetings;
-  const pendingAutoStopRef = useRef<{
-    timeout: ReturnType<typeof setTimeout>;
-    requireMicSnapshot: boolean;
-  } | null>(null);
+  const isOnlineRef = useRef(true);
+  const pendingAutoStopRef = useRef<PendingAutoStop | null>(null);
   const pendingMicDetectedPromptRef = useRef(false);
 
-  useEffect(() => {
-    let unlisten: (() => void) | undefined;
+  useMountEffect(() => {
+    let unlistenDetect: (() => void) | undefined;
     let cancelled = false;
+    isOnlineRef.current = navigator.onLine;
     const clearPendingAutoStop = () => {
       if (pendingAutoStopRef.current) {
-        clearTimeout(pendingAutoStopRef.current.timeout);
+        if (pendingAutoStopRef.current.timeout) {
+          clearTimeout(pendingAutoStopRef.current.timeout);
+        }
         pendingAutoStopRef.current = null;
       }
     };
@@ -877,13 +918,47 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         .setTriggerAppIds([...new Set([...currentTrigger, ...appIds])]);
     };
 
-    const confirmAutoStop = async (
+    function scheduleAutoStop(
+      delayMs: number,
       candidateAppIds: string[],
       stoppedApps: { id: string; name: string }[],
-      requireMicSnapshot = false,
-    ) => {
+      requireMicSnapshot: boolean,
+      sessionId: string | null,
+      networkInterrupted: boolean,
+    ) {
+      clearPendingAutoStop();
+
+      const pending: PendingAutoStop = {
+        requireMicSnapshot,
+        sessionId,
+        networkInterrupted,
+      };
+      pending.timeout = setTimeout(
+        () => {
+          void confirmAutoStop(candidateAppIds, stoppedApps, pending).finally(
+            () => {
+              if (pendingAutoStopRef.current === pending) {
+                pendingAutoStopRef.current = null;
+              }
+            },
+          );
+        },
+        Math.min(Math.max(delayMs, 0), MAX_TIMEOUT_DELAY_MS),
+      );
+      pendingAutoStopRef.current = pending;
+    }
+
+    async function confirmAutoStop(
+      candidateAppIds: string[],
+      stoppedApps: { id: string; name: string }[],
+      pending: PendingAutoStop,
+    ) {
       const live = store.getState().live;
-      if (live.status !== "active") {
+      if (
+        pendingAutoStopRef.current !== pending ||
+        live.status !== "active" ||
+        live.sessionId !== pending.sessionId
+      ) {
         return;
       }
 
@@ -908,21 +983,47 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         if (activeCheckAppIds.some((id) => activeAppIds.has(id))) {
           return;
         }
-      } else if (requireMicSnapshot || hasUnreliableActiveCheckApp) {
+      } else if (pending.requireMicSnapshot || hasUnreliableActiveCheckApp) {
         return;
       }
 
-      const sessionId = store.getState().live.sessionId;
-      if (
-        await shouldPromptBeforeAutoStopping({
-          appIds: candidateAppIds,
-          sessionId,
+      if (pendingAutoStopRef.current !== pending) {
+        return;
+      }
+
+      if (pending.networkInterrupted || !isOnlineRef.current) {
+        const deadlineMs = await getNetworkInterruptionDeadlineMs({
+          sessionId: pending.sessionId,
           nowMs: Date.now(),
-        })
-      ) {
-        if (sessionId) {
+        });
+        if (pendingAutoStopRef.current !== pending) {
+          return;
+        }
+        if (deadlineMs) {
+          scheduleAutoStop(
+            deadlineMs - Date.now(),
+            candidateAppIds,
+            stoppedApps,
+            pending.requireMicSnapshot,
+            pending.sessionId,
+            true,
+          );
+          return;
+        }
+      }
+
+      const shouldPrompt = await shouldPromptBeforeAutoStopping({
+        appIds: candidateAppIds,
+        sessionId: pending.sessionId,
+        nowMs: Date.now(),
+      });
+      if (pendingAutoStopRef.current !== pending) {
+        return;
+      }
+      if (shouldPrompt) {
+        if (pending.sessionId) {
           await showMeetingEndedPrompt({
-            sessionId,
+            sessionId: pending.sessionId,
             stoppedTriggerAppIds: candidateAppIds,
             stoppedApps,
           });
@@ -930,8 +1031,29 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         return;
       }
 
+      const currentLive = store.getState().live;
+      if (
+        pendingAutoStopRef.current !== pending ||
+        currentLive.status !== "active" ||
+        currentLive.sessionId !== pending.sessionId
+      ) {
+        return;
+      }
+
       stop();
+    }
+
+    const handleOffline = () => {
+      isOnlineRef.current = false;
+      if (pendingAutoStopRef.current) {
+        pendingAutoStopRef.current.networkInterrupted = true;
+      }
     };
+    const handleOnline = () => {
+      isOnlineRef.current = true;
+    };
+    window.addEventListener("offline", handleOffline);
+    window.addEventListener("online", handleOnline);
 
     detectEvents.detectEvent
       .listen(({ payload }) => {
@@ -1044,19 +1166,14 @@ const useHandleDetectEvents = (store: ListenerStore) => {
               return;
             }
 
-            clearPendingAutoStop();
-
-            pendingAutoStopRef.current = {
-              timeout: setTimeout(() => {
-                pendingAutoStopRef.current = null;
-                void confirmAutoStop(
-                  candidateAppIds,
-                  payload.apps,
-                  requireMicSnapshot,
-                );
-              }, AUTO_STOP_CONFIRM_DELAY_MS),
+            scheduleAutoStop(
+              AUTO_STOP_CONFIRM_DELAY_MS,
+              candidateAppIds,
+              payload.apps,
               requireMicSnapshot,
-            };
+              store.getState().live.sessionId,
+              !isOnlineRef.current,
+            );
           }
         } else if (payload.type === "sleepStateChanged") {
           if (payload.value) {
@@ -1071,7 +1188,7 @@ const useHandleDetectEvents = (store: ListenerStore) => {
         if (cancelled) {
           fn();
         } else {
-          unlisten = fn;
+          unlistenDetect = fn;
         }
       })
       .catch((err) => {
@@ -1081,7 +1198,9 @@ const useHandleDetectEvents = (store: ListenerStore) => {
     return () => {
       cancelled = true;
       clearPendingAutoStop();
-      unlisten?.();
+      window.removeEventListener("offline", handleOffline);
+      window.removeEventListener("online", handleOnline);
+      unlistenDetect?.();
     };
-  }, [stop, setMuted, store]);
+  });
 };


### PR DESCRIPTION
Hold network-interrupted sessions until the linked event ends plus grace, cancel on mic resume, and cover event/ad-hoc timing races.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when listening stops for real users (timers, offline detection, session binding); behavior is nuanced but heavily covered by new tests.
> 
> **Overview**
> When the network drops during meeting auto-stop, **calendar-linked sessions** can stay active until the linked event’s end time plus a new **10-minute grace** (`AUTO_STOP_EVENT_END_GRACE_MS`), instead of stopping on the usual mic-stopped confirmation path.
> 
> Auto-stop pending state now tracks **`sessionId`** and **`networkInterrupted`**, listens for **`online`/`offline`**, and routes confirmation through **`scheduleAutoStop`** / **`getNetworkInterruptionDeadlineMs`**. Going offline during an in-flight confirmation **upgrades** the pending stop to the interruption hold; **mic resume** still clears the hold. **Ad-hoc** sessions and linked events **outside the early-start window** keep prior auto-stop behavior, and timers **won’t stop a different session** after the user switches sessions.
> 
> Detect-event setup moves from **`useEffect`** to **`useMountEffect`**, with broad **Vitest** coverage for these races.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 406bb7c1e275d30b6189d1ffd6be23e21532b8aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->