### PR TITLE
Avoid masking the sidebar timeline

### DIFF
--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -417,6 +417,9 @@ describe("TimelineView", () => {
 
     expect(header?.className).toContain("top-12");
     expect(header?.className).toContain("z-20");
+    expect(header?.className).toContain("bg-background");
+    expect(header?.className).not.toContain("backdrop-blur");
+    expect(container.querySelector("[class*='backdrop-blur']")).toBeNull();
     expect(queryTopOccluder(container)?.className).toContain("z-10");
   });
 
@@ -599,9 +602,8 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 120;
     fireEvent.scroll(scroller!);
 
-    expect(scroller!.style.maskImage).toBe(
-      "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)",
-    );
+    expect(scroller!.style.maskImage).toBe("");
+    expect(queryBottomFade(container)).toBeTruthy();
   });
 
   it("does not show a top scroll fade when future notes are hidden above a sticky header", () => {
@@ -639,9 +641,8 @@ describe("TimelineView", () => {
     expect(screen.getByText("Today")).toBeTruthy();
     expect(queryTopFade(container)).toBeNull();
     expect(queryTopOccluder(container)?.className).toContain("h-12");
-    expect(scroller!.style.maskImage).toBe(
-      "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)",
-    );
+    expect(scroller!.style.maskImage).toBe("");
+    expect(queryBottomFade(container)).toBeTruthy();
   });
 
   it("drops the bottom scroll fade at the bottom edge", () => {
@@ -676,7 +677,40 @@ describe("TimelineView", () => {
     scroller!.scrollTop = 1000;
     fireEvent.scroll(scroller!);
 
-    expect(scroller!.style.maskImage).toBe("none");
+    expect(scroller!.style.maskImage).toBe("");
+    expect(queryBottomFade(container)).toBeNull();
+  });
+
+  it("keeps the bottom now chip above the scroll fade", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
+    mocks.isAnchorVisible = false;
+    mocks.isScrolledPastAnchor = false;
+    mocks.timelineSessionsTable = {
+      later: {
+        title: "Design sync",
+        created_at: "2024-01-16T11:00:00.000Z",
+      },
+    };
+
+    const { container } = render(<TimelineView />);
+    const scroller = container.querySelector(
+      "[data-sidebar-timeline-scroll]",
+    ) as HTMLDivElement;
+    Object.defineProperty(scroller, "clientHeight", {
+      configurable: true,
+      value: 200,
+    });
+    Object.defineProperty(scroller, "scrollHeight", {
+      configurable: true,
+      value: 1200,
+    });
+    scroller.scrollTop = 120;
+    fireEvent.scroll(scroller);
+    const nowChip = screen.getByRole("button", { name: "Go back to now" });
+
+    expect(queryBottomFade(container)?.className).toContain("z-30");
+    expect(nowChip.className).toContain("z-40");
   });
 
   it("shows an imminent meeting chip over the sidebar timeline", () => {
@@ -904,7 +938,9 @@ describe("TimelineView", () => {
 
     expect(scroller).toBeInstanceOf(HTMLDivElement);
 
-    expect(screen.getByRole("button", { name: "Go back to now" })).toBeTruthy();
+    const nowButton = screen.getByRole("button", { name: "Go back to now" });
+    expect(nowButton.className).toContain("bg-card");
+    expect(nowButton.className).not.toContain("backdrop-blur");
     expect(
       container.querySelector("[data-sidebar-timeline-top-chip-stack]")
         ?.className,
@@ -1149,6 +1185,10 @@ function queryTopFade(container: HTMLElement) {
 
 function queryTopOccluder(container: HTMLElement) {
   return container.querySelector("[data-sidebar-timeline-top-occluder]");
+}
+
+function queryBottomFade(container: HTMLElement) {
+  return container.querySelector("[data-sidebar-timeline-bottom-fade]");
 }
 
 function isBefore(first: Element, second: Element) {

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -270,12 +270,6 @@ export const TimelineView = memo(function TimelineView({
     upcomingMeetingStatus?.itemKey,
   ]);
 
-  const scrollFadeMask = useMemo(() => {
-    return getTimelineScrollFadeMask({
-      showBottomFade: !isScrolledToBottom,
-    });
-  }, [isScrolledToBottom]);
-
   const todayBucketLength = useMemo(() => {
     const b = buckets.find((bucket) => bucket.label === "Today");
     return b?.items.length ?? 0;
@@ -434,10 +428,6 @@ export const TimelineView = memo(function TimelineView({
           "scrollbar-hide flex h-full flex-col overflow-y-auto",
           "rounded-xl",
         ])}
-        style={{
-          WebkitMaskImage: scrollFadeMask,
-          maskImage: scrollFadeMask,
-        }}
       >
         {(topChromeInset || hasMoreFutureItems) && (
           <div
@@ -476,7 +466,7 @@ export const TimelineView = memo(function TimelineView({
                 className={cn([
                   "sticky z-20",
                   bucketHeaderTopClassName,
-                  "bg-background/95 pt-0 pr-1 pb-1 pl-3 backdrop-blur",
+                  "bg-background pt-0 pr-1 pb-1 pl-3",
                 ])}
               >
                 <div className="text-foreground text-base font-bold">
@@ -551,6 +541,14 @@ export const TimelineView = memo(function TimelineView({
           ))}
       </div>
 
+      {!isScrolledToBottom && (
+        <div
+          aria-hidden
+          data-sidebar-timeline-bottom-fade
+          className="from-background/0 to-background pointer-events-none absolute inset-x-0 bottom-0 z-30 h-7 bg-linear-to-b"
+        />
+      )}
+
       {topChromeInset && (
         <div
           aria-hidden
@@ -595,7 +593,7 @@ export const TimelineView = memo(function TimelineView({
           direction="down"
           className={cn([
             "absolute bottom-2 left-1/2 -translate-x-1/2 transform",
-            "z-20",
+            "z-40",
           ])}
         />
       )}
@@ -644,7 +642,7 @@ function TimelineTopChip({
   onClick?: () => void;
 }) {
   const className = cn([
-    "border-border bg-card/95 text-muted-foreground flex h-6 items-center gap-1 rounded-full border px-2.5 text-xs font-medium shadow-xs backdrop-blur",
+    "border-border bg-card text-muted-foreground flex h-6 items-center gap-1 rounded-full border px-2.5 text-xs font-medium shadow-xs",
     onClick && "hover:bg-accent hover:text-foreground transition-colors",
     "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
     props.className,
@@ -782,7 +780,7 @@ function TimelineNowChip({
       type="button"
       aria-label={t`Go back to now`}
       className={cn([
-        "border-border bg-card/95 text-foreground flex h-6 items-center gap-1 rounded-full border px-2.5 text-xs font-semibold shadow-md backdrop-blur",
+        "border-border bg-card text-foreground flex h-6 items-center gap-1 rounded-full border px-2.5 text-xs font-semibold shadow-md",
         "hover:border-border hover:bg-accent hover:text-foreground transition-colors",
         "focus-visible:ring-ring focus-visible:ring-2 focus-visible:outline-hidden",
         className,
@@ -1116,16 +1114,4 @@ function useTimelineData({
       ),
     };
   }, [windowData, currentTimeMs, timezone]);
-}
-
-function getTimelineScrollFadeMask({
-  showBottomFade,
-}: {
-  showBottomFade: boolean;
-}): string {
-  if (showBottomFade) {
-    return "linear-gradient(to bottom, #000 0, #000 calc(100% - 28px), transparent 100%)";
-  }
-
-  return "none";
 }


### PR DESCRIPTION
Replace the full scroll-layer mask with a lightweight bottom fade overlay to reduce compositor work during note selection.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only timeline chrome and scroll affordances; no auth, data, or API changes. Minor risk of subtle visual regressions at scroll edges or sticky headers.
> 
> **Overview**
> The sidebar timeline no longer applies a **CSS mask** on the scroll container for the bottom edge fade. That logic (`getTimelineScrollFadeMask` and inline `maskImage` styles) is removed; when the list is not at the bottom, a separate **absolute bottom gradient** (`data-sidebar-timeline-bottom-fade`, `z-30`) is shown instead, and it is hidden at the scroll bottom.
> 
> **Visual simplification:** sticky bucket headers and floating chips (calendar, upcoming meeting, **Now**) drop `backdrop-blur` and semi-transparent backgrounds in favor of solid `bg-background` / `bg-card`. The bottom **Now** chip is raised to **`z-40`** so it stays above the new fade.
> 
> Tests now assert empty scroller masks, bottom-fade presence/absence, no `backdrop-blur` in chrome, and the fade/chip stacking order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 35c84844376230ae7a5dbc1f5cb6a0091451f9cf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->