### PR TITLE
Prevent meeting status render cascades

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -6,7 +6,7 @@ import {
   screen,
   waitFor,
 } from "@testing-library/react";
-import { forwardRef, useImperativeHandle } from "react";
+import { forwardRef, useImperativeHandle, useState } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { commands } from "~/types/tauri.gen";
@@ -47,6 +47,16 @@ const mocks = vi.hoisted(() => ({
     status: null as null | "available" | "downloading" | "ready" | "failed",
     version: null as string | null,
   },
+  upcomingMeetingStatus: null as null | {
+    itemKey: string;
+    label: string;
+    title: string;
+  },
+  setUpcomingMeetingStatus: null as
+    | null
+    | ((
+        status: null | { itemKey: string; label: string; title: string },
+      ) => void),
 }));
 
 vi.mock("@hypr/ui/components/ui/resizable", () => ({
@@ -223,7 +233,11 @@ vi.mock("~/shared/useNewNote", () => ({
 }));
 
 vi.mock("~/sidebar/timeline/upcoming-meeting", () => ({
-  useSidebarUpcomingMeetingStatus: () => null,
+  useSidebarUpcomingMeetingStatus: () => {
+    const [status, setStatus] = useState(mocks.upcomingMeetingStatus);
+    mocks.setUpcomingMeetingStatus = setStatus;
+    return status;
+  },
 }));
 
 import { ClassicMainBody } from "./body";
@@ -274,6 +288,8 @@ describe("ClassicMainBody", () => {
     mocks.windowsCommands.devtoolsPanelShow.mockClear();
     mocks.updateControl.status = null;
     mocks.updateControl.version = null;
+    mocks.upcomingMeetingStatus = null;
+    mocks.setUpcomingMeetingStatus = null;
     vi.mocked(commands.showDevtool).mockClear();
     vi.mocked(commands.showDevtool).mockResolvedValue(true);
   });
@@ -572,6 +588,25 @@ describe("ClassicMainBody", () => {
     expect(bodyRoot?.style.getPropertyValue("--left-sidebar-panel-size")).toBe(
       "18",
     );
+  });
+
+  it("updates the upcoming meeting badge without rerendering tab content", () => {
+    mocks.leftsidebar.expanded = false;
+    render(<ClassicMainBody />);
+    const initialRenderCount = mocks.tabContentRenderCount;
+
+    act(() => {
+      mocks.setUpcomingMeetingStatus?.({
+        itemKey: "event-standup",
+        label: "In 1m",
+        title: "Team standup",
+      });
+    });
+
+    expect(
+      screen.getByTestId("collapsed-sidebar-upcoming-meeting-badge"),
+    ).toBeTruthy();
+    expect(mocks.tabContentRenderCount).toBe(initialRenderCount);
   });
 
   it("keeps the update button in the fixed sidebar control group", () => {

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -165,14 +165,9 @@ export function ClassicMainBody() {
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
-  const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus({
-    showIgnored: showIgnoredTimelineEvents,
-  });
   const [leftSidebarResizing, setLeftSidebarResizing] = useState(false);
-  const hasUpcomingMeetingBadge = upcomingMeetingStatus
-    ? currentTab?.type !== "sessions" ||
-      upcomingMeetingStatus.itemKey !== `session-${currentTab.id}`
-    : false;
+  const currentSessionId =
+    currentTab?.type === "sessions" ? currentTab.id : undefined;
   const createNewNote = useNewNote();
   const openNoteDialog = useOpenNoteDialog();
   const handleOpenNoteDialog = useCallback(() => {
@@ -508,15 +503,16 @@ export function ClassicMainBody() {
       className="flex h-9 shrink-0 items-start pt-[9px] pr-1 pl-[76px]"
       onWheelCapture={handleSidebarTimelineHeaderWheel}
     >
-      <SidebarTimelineChrome
+      <SidebarTimelineChromeWithUpcomingMeeting
+        currentSessionId={currentSessionId}
         sidebarExpanded
         showDevtoolsPanelButton={showDevtoolsPanelButton}
+        showIgnoredTimelineEvents={showIgnoredTimelineEvents}
         devtoolsPanelOpen={devtoolsPanelOpen}
         onNewNote={createNewNote}
         onSearch={handleOpenNoteDialog}
         onOpenDevtools={handleOpenDevtoolsPanel}
         onToggleSidebar={handleToggleLeftSidebar}
-        hasUpcomingMeeting={hasUpcomingMeetingBadge}
         update={update}
       />
     </div>
@@ -543,15 +539,16 @@ export function ClassicMainBody() {
             data-tauri-drag-region
             className="flex h-full min-w-0 items-start pt-[9px] pr-1 pl-[76px]"
           >
-            <SidebarTimelineChrome
+            <SidebarTimelineChromeWithUpcomingMeeting
+              currentSessionId={currentSessionId}
               sidebarExpanded={false}
               showDevtoolsPanelButton={showDevtoolsPanelButton}
+              showIgnoredTimelineEvents={showIgnoredTimelineEvents}
               devtoolsPanelOpen={devtoolsPanelOpen}
               onNewNote={createNewNote}
               onSearch={handleOpenNoteDialog}
               onOpenDevtools={handleOpenDevtoolsPanel}
               onToggleSidebar={handleToggleLeftSidebar}
-              hasUpcomingMeeting={hasUpcomingMeetingBadge}
               update={update}
             />
           </div>
@@ -893,6 +890,52 @@ function isMainAreaWindowDrag(
   return (
     deltaX * deltaX + deltaY * deltaY >=
     MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX * MAIN_AREA_WINDOW_DRAG_THRESHOLD_PX
+  );
+}
+
+function SidebarTimelineChromeWithUpcomingMeeting({
+  currentSessionId,
+  devtoolsPanelOpen,
+  onNewNote,
+  onOpenDevtools,
+  onSearch,
+  onToggleSidebar,
+  sidebarExpanded,
+  showDevtoolsPanelButton,
+  showIgnoredTimelineEvents,
+  update,
+}: {
+  currentSessionId?: string;
+  devtoolsPanelOpen: boolean;
+  onNewNote: () => void;
+  onOpenDevtools: () => void;
+  onSearch: () => void;
+  onToggleSidebar: () => void;
+  sidebarExpanded: boolean;
+  showDevtoolsPanelButton: boolean;
+  showIgnoredTimelineEvents: boolean;
+  update: DesktopUpdateControl;
+}) {
+  const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus({
+    showIgnored: showIgnoredTimelineEvents,
+  });
+  const hasUpcomingMeeting = upcomingMeetingStatus
+    ? !currentSessionId ||
+      upcomingMeetingStatus.itemKey !== `session-${currentSessionId}`
+    : false;
+
+  return (
+    <SidebarTimelineChrome
+      devtoolsPanelOpen={devtoolsPanelOpen}
+      hasUpcomingMeeting={hasUpcomingMeeting}
+      onNewNote={onNewNote}
+      onOpenDevtools={onOpenDevtools}
+      onSearch={onSearch}
+      onToggleSidebar={onToggleSidebar}
+      sidebarExpanded={sidebarExpanded}
+      showDevtoolsPanelButton={showDevtoolsPanelButton}
+      update={update}
+    />
   );
 }
 

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -858,6 +858,7 @@ describe("TimelineView", () => {
 
     vi.setSystemTime(new Date("2024-01-15T12:01:00.000Z"));
     mocks.currentTimeMs = Date.now();
+    fireEvent.focus(window);
     rerender(<TimelineView topChromeInset showOpenCalendarButton />);
 
     expect(
@@ -867,6 +868,7 @@ describe("TimelineView", () => {
 
     vi.setSystemTime(new Date("2024-01-15T12:06:01.000Z"));
     mocks.currentTimeMs = Date.now();
+    fireEvent.focus(window);
     rerender(<TimelineView topChromeInset showIgnoredEvents={false} />);
 
     expect(
@@ -876,6 +878,7 @@ describe("TimelineView", () => {
 
     vi.setSystemTime(new Date("2024-01-15T12:30:01.000Z"));
     mocks.currentTimeMs = Date.now();
+    fireEvent.focus(window);
     rerender(
       <TimelineView
         topChromeInset

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -28,7 +28,7 @@ import {
   useSmartCurrentTime,
 } from "./realtime";
 import {
-  getUpcomingMeetingStatus,
+  useUpcomingMeetingStatus,
   useUpcomingMeetingLabelFormatter,
 } from "./upcoming-meeting";
 import {
@@ -95,17 +95,12 @@ export const TimelineView = memo(function TimelineView({
     () => buckets.some((bucket) => bucket.label === "Today"),
     [buckets],
   );
-  const currentTimeMs = useCurrentTimeMs(1000);
+  const indicatorTimeMs = useCurrentTimeMs();
   const formatUpcomingMeetingLabel = useUpcomingMeetingLabelFormatter();
-  const upcomingMeetingStatus = useMemo(
-    () =>
-      getUpcomingMeetingStatus(
-        buckets,
-        currentTimeMs,
-        formatUpcomingMeetingLabel,
-        t`Now`,
-      ),
-    [buckets, currentTimeMs, formatUpcomingMeetingLabel, t],
+  const upcomingMeetingStatus = useUpcomingMeetingStatus(
+    buckets,
+    formatUpcomingMeetingLabel,
+    t`Now`,
   );
   const [isUpcomingMeetingVisible, setIsUpcomingMeetingVisible] =
     useState(false);
@@ -335,7 +330,7 @@ export const TimelineView = memo(function TimelineView({
       return -1;
     }
     return getFallbackIndicatorIndex(buckets, Date.now());
-  }, [buckets, hasToday, currentTimeMs]);
+  }, [buckets, hasToday, indicatorTimeMs]);
 
   const toggleShowIgnored = useCallback(() => {
     const nextShowIgnored = !showIgnored;

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -271,6 +271,8 @@ describe("TimelineItemComponent", () => {
     );
 
     expect(rowButton?.className).toContain("bg-destructive/8");
+    expect(rowButton?.className).toContain("hover:bg-accent/50");
+    expect(rowButton?.className).not.toContain("hover:bg-destructive/12");
     expect(rowButton?.className).toContain("pl-4");
     expect(rowButton?.className).not.toContain("motion-safe:animate-pulse");
     expect(rowButton?.className).not.toContain("shadow-[0_0_22px");

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -195,7 +195,7 @@ const ItemBase = memo(function ItemBase({
           isUpcoming &&
             !isLive && [
               "bg-destructive/8 text-foreground",
-              "hover:bg-destructive/12 focus-visible:ring-destructive/25",
+              "focus-visible:ring-destructive/25",
             ],
           isLive && [
             "bg-destructive text-destructive-foreground hover:bg-destructive/90",

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.test.tsx
@@ -1,8 +1,7 @@
-import { renderHook } from "@testing-library/react";
+import { act, renderHook } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  currentTimeMs: Date.now(),
   isIgnored: vi.fn(() => false),
   timelineEventsTable: {} as Record<string, Record<string, unknown>>,
   timelineSessionsTable: {} as Record<string, Record<string, unknown>>,
@@ -74,10 +73,6 @@ vi.mock("~/calendar/ignored-events", () => ({
   }),
 }));
 
-vi.mock("./realtime", () => ({
-  useCurrentTimeMs: () => mocks.currentTimeMs,
-}));
-
 import { useSidebarUpcomingMeetingStatus } from "./upcoming-meeting";
 
 describe("useSidebarUpcomingMeetingStatus", () => {
@@ -85,7 +80,6 @@ describe("useSidebarUpcomingMeetingStatus", () => {
     vi.clearAllMocks();
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T12:00:00.000Z"));
-    mocks.currentTimeMs = Date.parse("2024-01-15T12:00:00.000Z");
     mocks.isIgnored.mockReturnValue(false);
     mocks.timelineEventsTable = {};
     mocks.timelineSessionsTable = {};
@@ -145,9 +139,99 @@ describe("useSidebarUpcomingMeetingStatus", () => {
       title: "Team standup",
     });
 
-    mocks.currentTimeMs = Date.parse("2024-01-15T12:30:01.000Z");
-    active.rerender();
+    vi.setSystemTime(new Date("2024-01-15T12:30:01.000Z"));
+    act(() => {
+      vi.advanceTimersByTime(1_000);
+    });
 
     expect(active.result.current).toBeNull();
+  });
+
+  it("does not rerender every second while the active status is unchanged", () => {
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T11:55:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+    let renderCount = 0;
+
+    renderHook(() => {
+      renderCount += 1;
+      return useSidebarUpcomingMeetingStatus();
+    });
+    const initialRenderCount = renderCount;
+
+    act(() => {
+      vi.advanceTimersByTime(5_000);
+    });
+
+    expect(renderCount).toBe(initialRenderCount);
+  });
+
+  it("refreshes the status when the window regains focus", () => {
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T11:55:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const active = renderHook(() => useSidebarUpcomingMeetingStatus());
+    vi.setSystemTime(new Date("2024-01-15T12:30:01.000Z"));
+
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    expect(active.result.current).toBeNull();
+  });
+
+  it("refreshes the status when the document becomes visible", () => {
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-15T11:55:00.000Z",
+        ended_at: "2024-01-15T12:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const active = renderHook(() => useSidebarUpcomingMeetingStatus());
+    vi.setSystemTime(new Date("2024-01-15T12:30:01.000Z"));
+
+    act(() => document.dispatchEvent(new Event("visibilitychange")));
+
+    expect(active.result.current).toBeNull();
+  });
+
+  it("rebuilds timeline buckets after a day boundary", () => {
+    vi.setSystemTime(new Date("2024-01-15T23:59:00.000Z"));
+    mocks.timelineEventsTable = {
+      standup: {
+        title: "Team standup",
+        started_at: "2024-01-17T00:01:00.000Z",
+        ended_at: "2024-01-17T00:30:00.000Z",
+        tracking_id_event: "event-standup",
+        has_recurrence_rules: false,
+      },
+    };
+
+    const upcoming = renderHook(() => useSidebarUpcomingMeetingStatus());
+    expect(upcoming.result.current).toBeNull();
+
+    vi.setSystemTime(new Date("2024-01-16T23:59:00.000Z"));
+    act(() => window.dispatchEvent(new Event("focus")));
+
+    expect(upcoming.result.current).toMatchObject({
+      itemKey: "event-standup",
+      label: "In 2m 0s",
+      title: "Team standup",
+    });
   });
 });

--- a/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
+++ b/apps/desktop/src/sidebar/timeline/upcoming-meeting.ts
@@ -1,7 +1,6 @@
 import { useLingui } from "@lingui/react/macro";
-import { useCallback, useMemo } from "react";
+import { useCallback, useMemo, useSyncExternalStore } from "react";
 
-import { useCurrentTimeMs } from "./realtime";
 import {
   buildTimelineBuckets,
   deriveTimelineWindowData,
@@ -14,7 +13,7 @@ import { useTimelineTables } from "~/calendar/queries";
 import { useConfigValue } from "~/shared/config";
 
 const UPCOMING_MEETING_VISIBLE_WINDOW_MS = 5 * 60 * 1000;
-const UPCOMING_MEETING_STATUS_TICK_MS = 1000;
+const UPCOMING_MEETING_STATUS_TICK_MS = 1_000;
 
 export type SidebarUpcomingMeetingStatus = {
   itemKey: string;
@@ -33,9 +32,9 @@ export function useSidebarUpcomingMeetingStatus({
   const { isIgnored } = useIgnoredEvents();
   const formatLabel = useUpcomingMeetingLabelFormatter();
   const { timelineEventsTable, timelineSessionsTable } = useTimelineTables();
-  const currentTimeMs = useCurrentTimeMs(UPCOMING_MEETING_STATUS_TICK_MS);
+  const currentDay = useCurrentDay(timezone);
 
-  return useMemo(() => {
+  const buckets = useMemo(() => {
     const windowData = deriveTimelineWindowData({
       isEventIgnored: isIgnored,
       showIgnored,
@@ -43,28 +42,140 @@ export function useSidebarUpcomingMeetingStatus({
       timelineSessionsTable,
       timezone,
     });
-    const buckets = buildTimelineBuckets({
+
+    return buildTimelineBuckets({
       timelineEventsTable: windowData.timelineEventsTable,
       timelineSessionsTable: windowData.timelineSessionsTable,
       timezone,
     });
-
-    return getUpcomingMeetingStatus(
-      buckets,
-      currentTimeMs,
-      formatLabel,
-      t`Now`,
-    );
   }, [
-    currentTimeMs,
-    formatLabel,
     isIgnored,
+    currentDay,
     showIgnored,
     timelineEventsTable,
     timelineSessionsTable,
-    t,
     timezone,
   ]);
+
+  return useUpcomingMeetingStatus(buckets, formatLabel, t`Now`);
+}
+
+function useCurrentDay(timezone: string | undefined) {
+  const store = useMemo(() => createCurrentDayStore(timezone), [timezone]);
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+}
+
+function createCurrentDayStore(timezone: string | undefined) {
+  const getCurrentDay = () =>
+    new Intl.DateTimeFormat("en-CA", {
+      day: "2-digit",
+      month: "2-digit",
+      timeZone: timezone,
+      year: "numeric",
+    }).format(new Date());
+  let currentDay = getCurrentDay();
+
+  const subscribe = (listener: () => void) => {
+    const refresh = () => {
+      const nextDay = getCurrentDay();
+      if (nextDay === currentDay) return;
+      currentDay = nextDay;
+      listener();
+    };
+    const interval = setInterval(refresh, 60_000);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") refresh();
+    };
+
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    refresh();
+
+    return () => {
+      clearInterval(interval);
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  };
+
+  return {
+    getSnapshot: () => currentDay,
+    subscribe,
+  };
+}
+
+export function useUpcomingMeetingStatus(
+  buckets: TimelineBucket[],
+  formatLabel: (diffMs: number) => string,
+  activeLabel: string,
+): SidebarUpcomingMeetingStatus | null {
+  const store = useMemo(
+    () => createUpcomingMeetingStatusStore(buckets, formatLabel, activeLabel),
+    [activeLabel, buckets, formatLabel],
+  );
+
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  );
+}
+
+function createUpcomingMeetingStatusStore(
+  buckets: TimelineBucket[],
+  formatLabel: (diffMs: number) => string,
+  activeLabel: string,
+) {
+  const getCurrentStatus = () =>
+    getUpcomingMeetingStatus(
+      buckets,
+      Math.floor(Date.now() / UPCOMING_MEETING_STATUS_TICK_MS) *
+        UPCOMING_MEETING_STATUS_TICK_MS,
+      formatLabel,
+      activeLabel,
+    );
+  let status = getCurrentStatus();
+  const listeners = new Set<() => void>();
+
+  const refresh = () => {
+    const nextStatus = getCurrentStatus();
+    if (upcomingMeetingStatusesAreEqual(status, nextStatus)) {
+      return;
+    }
+
+    status = nextStatus;
+    listeners.forEach((listener) => listener());
+  };
+
+  const subscribe = (listener: () => void) => {
+    listeners.add(listener);
+    const interval = setInterval(refresh, UPCOMING_MEETING_STATUS_TICK_MS);
+    const handleVisibilityChange = () => {
+      if (document.visibilityState === "visible") {
+        refresh();
+      }
+    };
+
+    window.addEventListener("focus", refresh);
+    document.addEventListener("visibilitychange", handleVisibilityChange);
+    refresh();
+
+    return () => {
+      listeners.delete(listener);
+      clearInterval(interval);
+      window.removeEventListener("focus", refresh);
+      document.removeEventListener("visibilitychange", handleVisibilityChange);
+    };
+  };
+
+  return {
+    getSnapshot: () => status,
+    subscribe,
+  };
 }
 
 export function getUpcomingMeetingStatus(
@@ -145,6 +256,21 @@ export function getUpcomingMeetingStatus(
 
 function getUpcomingMeetingProgress(diffMs: number): number {
   return Math.max(0, Math.min(diffMs / UPCOMING_MEETING_VISIBLE_WINDOW_MS, 1));
+}
+
+function upcomingMeetingStatusesAreEqual(
+  left: SidebarUpcomingMeetingStatus | null,
+  right: SidebarUpcomingMeetingStatus | null,
+) {
+  return (
+    left === right ||
+    (left !== null &&
+      right !== null &&
+      left.itemKey === right.itemKey &&
+      left.label === right.label &&
+      left.title === right.title &&
+      left.progress === right.progress)
+  );
 }
 
 export function useUpcomingMeetingLabelFormatter(): (diffMs: number) => string {


### PR DESCRIPTION
Keep active meeting snapshots stable and isolate badge updates from the main editor tree.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance and UI-isolation changes in sidebar chrome and timeline; behavior is heavily tested but clock/day-boundary edge cases deserve a quick manual check.
> 
> **Overview**
> **Upcoming meeting status** no longer drives per-second React updates through `useCurrentTimeMs` in the main shell and timeline. Status is derived via `useSyncExternalStore` stores that tick on a 1s interval but **only notify subscribers when** `itemKey`, `label`, `title`, or `progress` actually change; focus and `visibilitychange` force a refresh, and a separate **current-day** store rebuilds buckets after midnight (with a 60s poll).
> 
> **`ClassicMainBody`** stops calling `useSidebarUpcomingMeetingStatus` directly. A new **`SidebarTimelineChromeWithUpcomingMeeting`** wrapper owns that hook and passes `hasUpcomingMeeting` into the chrome so collapsed-badge updates stay out of the tab/editor tree (covered by a new body test).
> 
> **Timeline** switches from `useMemo` + `getUpcomingMeetingStatus` to shared **`useUpcomingMeetingStatus`**. Upcoming timeline rows use the standard **`hover:bg-accent/50`** instead of a destructive hover tint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ecd85a1ee767b0d2f05a3d4fe418a31ef39aa71e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->