### PR TITLE
Repair empty session titles

### DIFF
--- a/crates/db-app/migrations/20260713164500_repair_empty_session_titles.sql
+++ b/crates/db-app/migrations/20260713164500_repair_empty_session_titles.sql
@@ -1,0 +1,82 @@
+WITH normalized_documents AS (
+  SELECT
+    document.session_id,
+    document.sort_order,
+    document.created_at,
+    document.id,
+    document.body_format,
+    document.body,
+    ltrim(document.body, char(9) || char(10) || char(13) || ' ') AS normalized_body
+  FROM session_documents AS document
+  JOIN sessions AS session
+    ON session.id = document.session_id
+   AND session.deleted_at IS NULL
+  WHERE trim(session.title) = ''
+    AND document.kind IN ('summary', 'template_output')
+    AND document.deleted_at IS NULL
+),
+document_titles AS (
+  SELECT
+    session_id,
+    sort_order,
+    created_at,
+    id,
+    CASE
+      WHEN body_format = 'markdown'
+        AND substr(normalized_body, 1, 2) = '# '
+      THEN substr(
+        normalized_body,
+        3,
+        instr(normalized_body || char(10), char(10)) - 3
+      )
+      WHEN body_format = 'prosemirror_json'
+        AND json_valid(body)
+        AND json_extract(body, '$.content[0].type') = 'heading'
+        AND json_extract(body, '$.content[0].attrs.level') = 1
+      THEN (
+        SELECT group_concat(json_extract(node.value, '$.text'), '')
+        FROM json_each(body, '$.content[0].content') AS node
+        WHERE json_extract(node.value, '$.type') = 'text'
+      )
+      ELSE ''
+    END AS candidate_title
+  FROM normalized_documents
+),
+valid_titles AS (
+  SELECT
+    session_id,
+    trim(candidate_title) AS title,
+    sort_order,
+    created_at,
+    id
+  FROM document_titles
+  WHERE trim(candidate_title) <> ''
+    AND lower(trim(candidate_title)) NOT IN ('summary', 'untitled', 'untitled note')
+),
+ranked_titles AS (
+  SELECT
+    session_id,
+    title,
+    row_number() OVER (
+      PARTITION BY session_id
+      ORDER BY sort_order, created_at, id
+    ) AS title_rank
+  FROM valid_titles
+)
+UPDATE sessions
+SET
+  title = (
+    SELECT ranked_titles.title
+    FROM ranked_titles
+    WHERE ranked_titles.session_id = sessions.id
+      AND ranked_titles.title_rank = 1
+  ),
+  updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+WHERE trim(title) = ''
+  AND deleted_at IS NULL
+  AND EXISTS (
+    SELECT 1
+    FROM ranked_titles
+    WHERE ranked_titles.session_id = sessions.id
+      AND ranked_titles.title_rank = 1
+  );

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -59,6 +59,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260712170000_template_icons.sql"),
     },
+    hypr_db_migrate::MigrationStep {
+        id: "20260713164500_repair_empty_session_titles",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260713164500_repair_empty_session_titles.sql"),
+    },
 ];
 
 pub fn schema() -> hypr_db_migrate::DbSchema {
@@ -257,6 +262,57 @@ mod tests {
                 "transcripts",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn migration_repairs_empty_titles_from_summary_headings() {
+        let db = Db::connect_memory_plain().await.unwrap();
+        hypr_db_migrate::migrate(
+            &db,
+            hypr_db_migrate::DbSchema {
+                steps: &APP_MIGRATION_STEPS[..APP_MIGRATION_STEPS.len() - 1],
+                validate_cloudsync_table: cloudsync_alter_guard_required,
+            },
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO sessions (id, title)
+             VALUES ('json', ''), ('markdown', '   '), ('generic', ''), ('existing', 'Keep Me')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, body_format, body, sort_order)
+             VALUES
+             ('json-summary', 'json', 'summary', 'prosemirror_json',
+              '{\"type\":\"doc\",\"content\":[{\"type\":\"heading\",\"attrs\":{\"level\":1},\"content\":[{\"type\":\"text\",\"text\":\"Transcript Test \"},{\"type\":\"text\",\"text\":\"Utterances\"}]}]}', 0),
+             ('markdown-summary', 'markdown', 'summary', 'markdown',
+              char(10) || '# Markdown Title' || char(10) || char(10) || 'Details', 0),
+             ('generic-summary', 'generic', 'summary', 'markdown', '# Summary' || char(10) || 'Details', 0),
+             ('existing-summary', 'existing', 'summary', 'markdown', '# Replacement' || char(10) || 'Details', 0)",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        hypr_db_migrate::migrate(&db, schema()).await.unwrap();
+
+        let titles =
+            sqlx::query_as::<_, (String, String)>("SELECT id, title FROM sessions ORDER BY id")
+                .fetch_all(db.pool())
+                .await
+                .unwrap()
+                .into_iter()
+                .collect::<std::collections::HashMap<_, _>>();
+
+        assert_eq!(titles["json"], "Transcript Test Utterances");
+        assert_eq!(titles["markdown"], "Markdown Title");
+        assert_eq!(titles["generic"], "");
+        assert_eq!(titles["existing"], "Keep Me");
     }
 
     #[tokio::test]

--- a/plugins/db/src/import/legacy_vault.rs
+++ b/plugins/db/src/import/legacy_vault.rs
@@ -430,11 +430,17 @@ fn parse_session_meta(
     let series_id = event
         .and_then(|event| value_string(event.get("recurrence_series_id")))
         .unwrap_or_default();
+    let stored_title = value_string(meta.get("title")).unwrap_or_default();
+    let title = if stored_title.trim().is_empty() {
+        recover_title_from_summary(path).unwrap_or(stored_title)
+    } else {
+        stored_title
+    };
 
     batch.rows.push(LegacyImportRow::Session(LegacySession {
         id: session_id.clone(),
         owner_user_id: value_string(meta.get("user_id")).unwrap_or_default(),
-        title: value_string(meta.get("title")).unwrap_or_default(),
+        title,
         created_at: value_string(meta.get("created_at")).unwrap_or_default(),
         started_at,
         ended_at,
@@ -525,6 +531,29 @@ fn parse_session_meta(
     }
 
     Ok(batch)
+}
+
+fn recover_title_from_summary(meta_path: &Path) -> Option<String> {
+    let content = std::fs::read_to_string(meta_path.with_file_name("_summary.md")).ok()?;
+    let document = ParsedDocument::from_str(&content).ok()?;
+    let title = document
+        .content
+        .trim_start()
+        .lines()
+        .next()?
+        .strip_prefix("# ")?
+        .trim();
+
+    if title.is_empty()
+        || matches!(
+            title.to_ascii_lowercase().as_str(),
+            "summary" | "untitled" | "untitled note"
+        )
+    {
+        return None;
+    }
+
+    Some(title.to_string())
 }
 
 fn parse_session_document(
@@ -1126,6 +1155,34 @@ mod tests {
         assert_eq!(status, "completed");
         assert_eq!(body, "Current summary");
         assert_eq!(hidden_item_count, 0);
+    }
+
+    #[tokio::test]
+    async fn empty_session_title_is_recovered_from_summary_heading() {
+        let db = test_db().await;
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join("sessions/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("_meta.json"),
+            r#"{"id":"session-1","created_at":"2026-07-12T01:00:00Z","title":""}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            session_dir.join("_summary.md"),
+            "---\nid: summary-1\nsession_id: session-1\ntitle: Summary\n---\n\n# Transcript Test Utterances\n\nDetails",
+        )
+        .unwrap();
+
+        import_legacy_vault(db.pool(), dir.path(), false)
+            .await
+            .unwrap();
+
+        let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(title, "Transcript Test Utterances");
     }
 
     #[tokio::test]


### PR DESCRIPTION
Backfill empty titles from summary headings and recover them during legacy import.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> One-time data migration mutates `sessions.title` and `updated_at` for empty titles; logic is bounded but wrong heading extraction could mislabel sessions.
> 
> **Overview**
> **Backfills blank session titles** for existing databases and **recovers titles during legacy vault import** when `_meta.json` has an empty title.
> 
> A new plain migration updates `sessions` where `trim(title)` is empty: it reads the first eligible `summary` or `template_output` document (by `sort_order`, then `created_at`, then `id`), extracts an H1 from markdown (`# …`) or from ProseMirror JSON (level-1 heading text nodes), and skips generic headings like `summary`, `untitled`, and `untitled note`. Non-empty titles and sessions without a valid candidate are left unchanged.
> 
> Legacy import now calls `recover_title_from_summary`, which reads `_summary.md` in the session folder and uses the first `# ` line with the same exclusion rules. Migration and import behavior are covered by new tests in `db-app` and `legacy_vault`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fc1a74938747d9612601eac9ec331d8e86a0350. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->