### PR TITLE
Persist the dev database

### DIFF
--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use hypr_db_core::Db;
 
-const DEV_BUNDLE_ID: &str = "com.hyprnote.dev";
 const DB_FILENAME: &str = "app.db";
 
 pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
@@ -19,10 +18,6 @@ pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
 }
 
 fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
-    if identifier == DEV_BUNDLE_ID {
-        return None;
-    }
-
     let data_dir = dirs::data_dir().expect("data_dir must be available");
     let default_dir =
         hypr_storage::global::compute_default_base(identifier).expect("data_dir must be available");
@@ -32,5 +27,17 @@ fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
         Some(identifier_dir)
     } else {
         Some(default_dir)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn dev_uses_an_isolated_persistent_database() {
+        let db_dir = desktop_db_dir("com.hyprnote.dev").unwrap();
+
+        assert!(db_dir.ends_with("com.hyprnote.dev"));
     }
 }


### PR DESCRIPTION
Use the isolated dev application-support path so migrations and plugin startup share one durable SQLite schema.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized desktop DB path change for dev only; production path selection is unchanged aside from removing the dev bypass.
> 
> **Overview**
> **Dev builds no longer open an ephemeral database** — the special case that returned `None` for `com.hyprnote.dev` (so `open_app_db` had no on-disk path) is removed.
> 
> `desktop_db_dir` now always resolves a directory via the same `compute_default_base` / legacy `identifier_dir` logic as other bundle IDs, so the dev app keeps `app.db` under the isolated `com.hyprnote.dev` application-support path across restarts and matches where migrations and plugins expect durable storage.
> 
> A unit test asserts the dev identifier resolves to a path ending in `com.hyprnote.dev`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 951e28827b008c8f8cf6dd063814c6bc06015a53. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->