### PR TITLE
Show session titles in memo and summary editors

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -7,7 +7,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { EnhancedEditor } from "./editor";
+import { EnhancedEditor as SessionEnhancedEditor } from "./editor";
 
 const hoisted = vi.hoisted(() => ({
   content: JSON.stringify({ type: "doc", content: [] }),
@@ -81,9 +81,19 @@ vi.mock("~/stt/useUploadFile", () => ({
 
 vi.mock("~/session/queries", () => ({
   useEnhancedNote: () => ({ content: hoisted.content }),
-  useSession: () => ({ title: hoisted.sessionTitle }),
   useUpdateEnhancedNoteContent: () => hoisted.persistContent,
 }));
+
+function EnhancedEditor(
+  props: Omit<
+    React.ComponentProps<typeof SessionEnhancedEditor>,
+    "sessionTitle"
+  >,
+) {
+  return (
+    <SessionEnhancedEditor {...props} sessionTitle={hoisted.sessionTitle} />
+  );
+}
 
 describe("EnhancedEditor", () => {
   afterEach(() => {

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -17,7 +17,7 @@ import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { hasStoredNoteContent } from "~/session/components/shared";
-import { useSession, useUpdateEnhancedNoteContent } from "~/session/queries";
+import { useUpdateEnhancedNoteContent } from "~/session/queries";
 import {
   ensureFirstLineTitle,
   extractFirstLineTitle,
@@ -29,6 +29,7 @@ export const EnhancedEditor = forwardRef<
   NoteEditorRef,
   {
     sessionId: string;
+    sessionTitle: string;
     enhancedNoteId: string;
     content: string;
     contentOverride?: JSONContent;
@@ -40,6 +41,7 @@ export const EnhancedEditor = forwardRef<
   (
     {
       sessionId,
+      sessionTitle,
       enhancedNoteId,
       content,
       contentOverride,
@@ -51,7 +53,6 @@ export const EnhancedEditor = forwardRef<
   ) => {
     const { audioDropTargetProps, fileHandlerConfig, isAudioDragActive } =
       useNoteFileHandlerConfig(sessionId);
-    const sessionTitle = useSession(sessionId)?.title;
     const updateContent = useUpdateEnhancedNoteContent(
       enhancedNoteId,
       sessionId,

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { Enhanced } from "./index";
+import { Enhanced as SessionEnhanced } from "./index";
 
 import type { LLMConnectionStatus } from "~/ai/hooks";
 
@@ -61,7 +61,6 @@ vi.mock("~/ai/hooks", () => ({
 vi.mock("~/session/queries", () => ({
   useEnhancedNote: () =>
     hoisted.noteExists ? { content: hoisted.content } : null,
-  useSession: () => ({ title: hoisted.sessionTitle }),
 }));
 
 vi.mock("./config-error", () => ({
@@ -105,6 +104,22 @@ vi.mock("./editor", () => ({
 vi.mock("./enhance-error", () => ({
   EnhanceError: () => <div>Enhance error</div>,
 }));
+
+function Enhanced({
+  sessionId,
+  enhancedNoteId,
+}: {
+  sessionId: string;
+  enhancedNoteId: string;
+}) {
+  return (
+    <SessionEnhanced
+      sessionId={sessionId}
+      sessionTitle={hoisted.sessionTitle}
+      enhancedNoteId={enhancedNoteId}
+    />
+  );
+}
 
 describe("Enhanced", () => {
   afterEach(() => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -18,6 +18,7 @@ export const Enhanced = forwardRef<
   NoteEditorRef,
   {
     sessionId: string;
+    sessionTitle: string;
     enhancedNoteId: string;
     onNavigateToTitle?: (pixelWidth?: number) => void;
     onViewReady?: (view: EditorView) => void;
@@ -27,6 +28,7 @@ export const Enhanced = forwardRef<
   (
     {
       sessionId,
+      sessionTitle,
       enhancedNoteId,
       onNavigateToTitle,
       onViewReady,
@@ -54,7 +56,11 @@ export const Enhanced = forwardRef<
 
     if (status === "generating") {
       return (
-        <StreamingView sessionId={sessionId} enhancedNoteId={enhancedNoteId} />
+        <StreamingView
+          sessionId={sessionId}
+          sessionTitle={sessionTitle}
+          enhancedNoteId={enhancedNoteId}
+        />
       );
     }
 
@@ -72,6 +78,7 @@ export const Enhanced = forwardRef<
       <EnhancedEditor
         ref={ref}
         sessionId={sessionId}
+        sessionTitle={sessionTitle}
         enhancedNoteId={enhancedNoteId}
         content={enhancedNote.content}
         onNavigateToTitle={onNavigateToTitle}

--- a/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/streaming.tsx
@@ -6,7 +6,6 @@ import { cn } from "@hypr/utils";
 import { streamdownComponents } from "../../streamdown";
 
 import { useAITaskTask } from "~/ai/hooks";
-import { useSession } from "~/session/queries";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { getPersistableGeneratedTitle } from "~/store/zustand/ai-task/task-configs/title-success";
 
@@ -34,16 +33,18 @@ function SummaryTitleSpace({ title }: { title: string }) {
 
 export function StreamingView({
   sessionId,
+  sessionTitle,
   enhancedNoteId,
 }: {
   sessionId: string;
+  sessionTitle: string;
   enhancedNoteId: string;
 }) {
   const taskId = createTaskId(enhancedNoteId, "enhance");
   const { streamedText, isGenerating } = useAITaskTask(taskId, "enhance");
   const titleTaskId = createTaskId(sessionId, "title");
   const { streamedText: streamedTitle } = useAITaskTask(titleTaskId, "title");
-  const title = useSession(sessionId)?.title.trim() ?? "";
+  const title = sessionTitle.trim();
   const generatedTitle = getPersistableGeneratedTitle(streamedTitle);
   const visibleTitle = title || generatedTitle;
 

--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -8,13 +8,18 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const hoisted = vi.hoisted(() => ({
   editorTabs: [{ type: "raw" }, { type: "transcript" }] as EditorView[],
   hotkeys: [] as Array<{ keys: string; callback: () => void }>,
+  enhancedEditorProps: [] as Record<string, unknown>[],
   onBeforeTabChange: vi.fn(),
+  rawEditorProps: [] as Record<string, unknown>[],
   sessionMode: "inactive",
   updateSessionTabState: vi.fn(),
 }));
 
 vi.mock("./enhanced", () => ({
-  Enhanced: () => <div data-testid="enhanced-editor" />,
+  Enhanced: (props: Record<string, unknown>) => {
+    hoisted.enhancedEditorProps.push(props);
+    return <div data-testid="enhanced-editor" />;
+  },
 }));
 
 vi.mock("./header", () => ({
@@ -47,7 +52,10 @@ vi.mock("./header", () => ({
 }));
 
 vi.mock("./raw", () => ({
-  RawEditor: () => <div data-testid="raw-editor" />,
+  RawEditor: (props: Record<string, unknown>) => {
+    hoisted.rawEditorProps.push(props);
+    return <div data-testid="raw-editor" />;
+  },
 }));
 
 vi.mock("./search/bar", () => ({
@@ -125,6 +133,8 @@ function renderNoteInput({
           state: { autoStart: null, view: currentTab },
           type: "sessions",
         }}
+        rawMd="stored memo"
+        sessionTitle="Stored title"
         editorTabs={hoisted.editorTabs}
         currentTab={currentTab}
         handleTabChange={handleTabChange}
@@ -141,7 +151,9 @@ describe("NoteInput tab selection", () => {
   beforeEach(() => {
     hoisted.editorTabs = [{ type: "raw" }, { type: "transcript" }];
     hoisted.hotkeys = [];
+    hoisted.enhancedEditorProps = [];
     hoisted.onBeforeTabChange.mockClear();
+    hoisted.rawEditorProps = [];
     hoisted.sessionMode = "inactive";
     hoisted.updateSessionTabState.mockClear();
   });
@@ -204,6 +216,8 @@ describe("NoteInput tab selection", () => {
           state: { autoStart: null, view: currentTab },
           type: "sessions",
         }}
+        rawMd="stored memo"
+        sessionTitle="Stored title"
         editorTabs={hoisted.editorTabs}
         currentTab={currentTab}
         handleTabChange={handleTabChange}
@@ -235,5 +249,33 @@ describe("NoteInput tab selection", () => {
     renderNoteInput();
 
     expect(screen.getByTestId("is-transcribing").textContent).toBe("true");
+  });
+
+  it("passes hydrated session content to the memo editor", () => {
+    renderNoteInput();
+
+    expect(
+      hoisted.rawEditorProps[hoisted.rawEditorProps.length - 1],
+    ).toMatchObject({
+      rawMd: "stored memo",
+      sessionTitle: "Stored title",
+    });
+  });
+
+  it("passes the hydrated session title to the summary editor", () => {
+    hoisted.editorTabs = [
+      { type: "enhanced", id: "summary-1" },
+      { type: "raw" },
+    ];
+
+    renderNoteInput({
+      currentTab: { type: "enhanced", id: "summary-1" },
+    });
+
+    expect(
+      hoisted.enhancedEditorProps[hoisted.enhancedEditorProps.length - 1],
+    ).toMatchObject({
+      sessionTitle: "Stored title",
+    });
   });
 });

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -39,6 +39,8 @@ export interface NoteInputHandle {
 
 type NoteInputProps = {
   tab: Extract<Tab, { type: "sessions" }>;
+  rawMd: string;
+  sessionTitle: string;
   onNavigateToTitle?: (pixelWidth?: number) => void;
   onScroll?: UIEventHandler<HTMLDivElement>;
   editorTabs?: TabEditorView[];
@@ -131,6 +133,8 @@ const NoteInputContent = forwardRef<
   (
     {
       tab,
+      rawMd,
+      sessionTitle,
       onNavigateToTitle,
       onScroll,
       editorTabs,
@@ -324,6 +328,7 @@ const NoteInputContent = forwardRef<
               <Enhanced
                 ref={internalEditorRef}
                 sessionId={sessionId}
+                sessionTitle={sessionTitle}
                 enhancedNoteId={renderedCurrentTab.id}
                 onNavigateToTitle={onNavigateToTitle}
                 onViewReady={handleViewReady}
@@ -334,6 +339,8 @@ const NoteInputContent = forwardRef<
               <RawEditor
                 ref={internalEditorRef}
                 sessionId={sessionId}
+                rawMd={rawMd}
+                sessionTitle={sessionTitle}
                 onNavigateToTitle={onNavigateToTitle}
                 onViewReady={handleViewReady}
                 onViewDisposed={handleViewDisposed}

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -8,7 +8,7 @@ import {
 } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { RawEditor } from "./raw";
+import { RawEditor as SessionRawEditor } from "./raw";
 
 const hoisted = vi.hoisted(() => ({
   rawMd: JSON.stringify({ type: "doc", content: [] }),
@@ -77,12 +77,25 @@ vi.mock("~/session/components/shared", () => ({
 }));
 
 vi.mock("~/session/queries", () => ({
-  useSession: () => ({
-    raw_md: hoisted.rawMd,
-    title: hoisted.sessionTitle,
-  }),
   useUpdateSession: () => hoisted.persistChange,
 }));
+
+function RawEditor({
+  sessionId,
+  className,
+}: {
+  sessionId: string;
+  className?: string;
+}) {
+  return (
+    <SessionRawEditor
+      sessionId={sessionId}
+      rawMd={hoisted.rawMd}
+      sessionTitle={hoisted.sessionTitle}
+      className={className}
+    />
+  );
+}
 
 vi.mock("~/shared/hooks/useFileUpload", () => ({
   useFileUpload: () => hoisted.fileUpload,

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -19,7 +19,7 @@ import { openEditorLink } from "~/editor-bridge/open-editor-link";
 import { sessionMentionDropConfig } from "~/editor-bridge/session-mention-drop";
 import { SessionNodeView } from "~/editor-bridge/session-view";
 import { hasStoredNoteContent } from "~/session/components/shared";
-import { useSession, useUpdateSession } from "~/session/queries";
+import { useUpdateSession } from "~/session/queries";
 import {
   ensureFirstLineTitle,
   extractFirstLineTitle,
@@ -31,6 +31,8 @@ export const RawEditor = forwardRef<
   NoteEditorRef,
   {
     sessionId: string;
+    rawMd: string;
+    sessionTitle: string;
     className?: string;
     onNavigateToTitle?: (pixelWidth?: number) => void;
     syncTasks?: boolean;
@@ -42,6 +44,8 @@ export const RawEditor = forwardRef<
   (
     {
       sessionId,
+      rawMd,
+      sessionTitle,
       className,
       onNavigateToTitle,
       syncTasks = true,
@@ -51,9 +55,6 @@ export const RawEditor = forwardRef<
     },
     ref,
   ) => {
-    const session = useSession(sessionId);
-    const rawMd = session?.raw_md ?? "";
-    const sessionTitle = session?.title;
     const updateSession = useUpdateSession(sessionId);
     const { audioDropTargetProps, fileHandlerConfig, isAudioDragActive } =
       useNoteFileHandlerConfig(sessionId);

--- a/apps/desktop/src/session/index.tsx
+++ b/apps/desktop/src/session/index.tsx
@@ -153,7 +153,8 @@ function TabContentNoteInner({
     sessionMode,
   });
   const enhancedNoteIds = useEnhancedNotes(sessionId);
-  const contentHydrated = useHydrateSessionContent(sessionId);
+  const session = useSession(sessionId);
+  const contentHydrated = session !== null;
   useEnsureDefaultSummaryFromState({
     batchError: Boolean(batchError),
     enabled: contentHydrated,
@@ -240,10 +241,12 @@ function TabContentNoteInner({
             </div>
           ) : null}
           <div className="min-h-0 flex-1">
-            {contentHydrated ? (
+            {session ? (
               <NoteInput
                 ref={noteInputRef}
                 tab={tab}
+                rawMd={session.raw_md}
+                sessionTitle={session.title}
                 editorTabs={editorTabs}
                 currentTab={currentView}
                 handleTabChange={handleTabChange}
@@ -258,10 +261,6 @@ function TabContentNoteInner({
       </SessionSurface>
     </>
   );
-}
-
-function useHydrateSessionContent(sessionId: string): boolean {
-  return useSession(sessionId) !== null;
 }
 
 function SessionContentLoading() {


### PR DESCRIPTION
Pass hydrated session content into editor views so titles and memo bodies are present when TipTap mounts.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5995
- <kbd>&nbsp;1&nbsp;</kbd> #5994 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized data-flow change in session note UI; persistence paths are unchanged and editors only mount after the session record exists.
> 
> **Overview**
> Session **memo** and **summary** editors no longer read `raw_md` / title via `useSession` inside `RawEditor`, `EnhancedEditor`, and `StreamingView`. Those values are required props threaded from the session tab once SQLite hydration has a session row.
> 
> `NoteInput` now takes **`rawMd`** and **`sessionTitle`** and forwards them to **Raw** and **Enhanced** (including the enhance **streaming** UI). The session view still gates on `useSession(sessionId) !== null`, then passes `session.raw_md` and `session.title` into `NoteInput` so TipTap’s initial content (including the first-line title via `ensureFirstLineTitle`) is correct on first mount.
> 
> Tests were updated with thin wrappers that inject hoisted session fields and new cases assert `NoteInput` passes hydrated props to child editors.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9d3ed070290331c5f4ff2de2654e91ce2ebe96e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->