### PR TITLE
Reduce editor compositor work

### DIFF
--- a/apps/desktop/src/session/components/note-input/audio-drop-target.tsx
+++ b/apps/desktop/src/session/components/note-input/audio-drop-target.tsx
@@ -25,7 +25,7 @@ export function AudioDropTarget({
           role="status"
           className={cn([
             "pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-lg border border-dashed",
-            "border-border/70 bg-background/90 text-muted-foreground dark:bg-background/85 shadow-inner backdrop-blur-[1px]",
+            "border-border/70 bg-background text-muted-foreground shadow-inner",
             "[background-image:radial-gradient(circle_at_center,_rgba(113,113,122,0.34)_1px,_transparent_1px)]",
             "[background-size:18px_18px]",
           ])}

--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -255,6 +255,9 @@ describe("NoteInput tab selection", () => {
     renderNoteInput();
 
     expect(
+      screen.getByTestId("raw-editor").parentElement?.className,
+    ).not.toContain("scroll-fade-y");
+    expect(
       hoisted.rawEditorProps[hoisted.rawEditorProps.length - 1],
     ).toMatchObject({
       rawMd: "stored memo",

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -321,7 +321,7 @@ const NoteInputContent = forwardRef<
               "pt-2",
               renderedCurrentTab.type === "transcript"
                 ? "overflow-hidden pb-0"
-                : "scroll-fade-y overflow-auto pb-6",
+                : "overflow-auto pb-6",
             ])}
           >
             {renderedCurrentTab.type === "enhanced" && (

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -248,6 +248,7 @@ describe("RawEditor", () => {
     expect(
       screen.getByText("Drop to upload and transcribe audio"),
     ).not.toBeNull();
+    expect(screen.getByRole("status").className).not.toContain("backdrop-blur");
     expect(
       screen.getByText("WAV, MP3, OGG, MP4, M4A, FLAC, WEBM, or AAC audio"),
     ).not.toBeNull();


### PR DESCRIPTION
Remove the full editor scroll mask and drag-overlay backdrop filter while preserving editor focus and audio drop behavior.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #5995 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5994
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only CSS changes in the note input; behavior is covered by existing and updated unit tests.
> 
> **Overview**
> Removes **expensive visual effects** from the session note editor area to cut compositor work, without changing scroll or audio-drop behavior.
> 
> The note input scroll container for memo/summary tabs no longer uses the **`scroll-fade-y`** edge mask—only **`overflow-auto`** remains (transcript tab styling is unchanged). The audio drag overlay drops **`backdrop-blur`** and semi-transparent **`bg-background/90`** styling in favor of a solid **`bg-background`**.
> 
> Tests lock this in: memo editor parent must not include **`scroll-fade-y`**, and the drop overlay **`role="status"`** must not include **`backdrop-blur`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa47341fda7a490966cf822f504736c62d73a313. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->