### PR TITLE
Secure transcription provider settings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -875,6 +875,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "apple-native-keyring-store"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "797f94b6a53d7d10b56dc18290e0d40a2158352f108bb4ff32350825081a9f29"
+dependencies = [
+ "keyring-core",
+ "log",
+ "security-framework 3.7.0",
+]
+
+[[package]]
 name = "apple-note"
 version = "0.1.0"
 dependencies = [
@@ -9961,6 +9972,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "keyring"
+version = "4.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6ee8d4dae108d4177d0a0ce241f98acc1ef28e20837bdef43cff4d160cf70fe"
+dependencies = [
+ "apple-native-keyring-store",
+ "keyring-core",
+ "windows-native-keyring-store",
+ "zbus-secret-service-keyring-store",
+]
+
+[[package]]
+name = "keyring-core"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e621458ca9c51aa110bd0339d4751a056b9576bf1253aee1aa560dda0fc9d"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "khronos-egl"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -15431,6 +15463,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "secret-service"
+version = "5.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a62d7f86047af0077255a29494136b9aaaf697c76ff70b8e49cded4e2623c14"
+dependencies = [
+ "aes",
+ "cbc",
+ "futures-util",
+ "generic-array",
+ "getrandom 0.2.17",
+ "hkdf",
+ "num",
+ "once_cell",
+ "serde",
+ "sha2 0.10.9",
+ "zbus",
+]
+
+[[package]]
 name = "security-framework"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18889,6 +18940,7 @@ name = "tauri-plugin-store2"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "keyring",
  "serde",
  "serde_json",
  "specta",
@@ -22469,6 +22521,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
+name = "windows-native-keyring-store"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "063426e76fdec7438d56bb777f67e318a84a25c707b07e575cb8b78e10c028f8"
+dependencies = [
+ "byteorder",
+ "keyring-core",
+ "regex",
+ "windows-sys 0.61.2",
+ "zeroize",
+]
+
+[[package]]
 name = "windows-numerics"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -23345,6 +23410,17 @@ dependencies = [
  "zbus_macros",
  "zbus_names",
  "zvariant",
+]
+
+[[package]]
+name = "zbus-secret-service-keyring-store"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ccede190ba363386a24e8021c7f3848393976609ec9f5d1f8c6c09ef37075b4"
+dependencies = [
+ "keyring-core",
+ "secret-service",
+ "zbus",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -182,6 +182,7 @@ hypr-whisper-local = { path = "crates/whisper-local", package = "whisper-local" 
 hypr-whisper-local-model = { path = "crates/whisper-local-model", package = "whisper-local-model" }
 hypr-ws-client = { path = "crates/ws-client", package = "ws-client" }
 hypr-ws-utils = { path = "crates/ws-utils", package = "ws-utils" }
+keyring = "4.1.4"
 legacy-db-core = { path = "legacy/db-core", package = "legacy-db-core" }
 legacy-db-parser = { path = "legacy/db-parser", package = "db-parser" }
 legacy-db-user = { path = "legacy/db-user", package = "db-user" }

--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -29,6 +29,7 @@ import { EventListeners } from "./services/event-listeners";
 import { TaskManager } from "./services/task-manager";
 import { useRemoteSessionDeletionUndoListener } from "./session/hooks/useDeleteSession";
 import { refreshLegacySettingsSnapshots } from "./settings/legacy-snapshots";
+import { migratePlaintextAiProviderApiKeys } from "./settings/providers";
 import { initializeApplicationSettings } from "./settings/queries";
 import { initializeAppExitFlush } from "./shared/app-exit";
 import { ErrorComponent, NotFoundComponent } from "./shared/control";
@@ -136,6 +137,9 @@ async function renderApp() {
   });
   await initializeApplicationSettings().catch((error) => {
     console.error("Failed to initialize application settings", error);
+  });
+  await migratePlaintextAiProviderApiKeys().catch((error) => {
+    console.error("Failed to migrate AI provider credentials", error);
   });
   await Promise.all([bootstrapThemeFromSettings(), enableReactScanInDev()]);
   const root = ReactDOM.createRoot(rootElement);

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -34,7 +34,6 @@ import { cn } from "@hypr/utils";
 import { useSttSettings } from "./context";
 import { HealthStatusIndicator, useConnectionHealth } from "./health";
 import { LocalModelBackendBadge, LocalModelLabel } from "./model-icon";
-import { getPreferredProviderModel } from "./selection";
 import {
   displayModelLabel,
   displayModelTitle,
@@ -69,6 +68,10 @@ import {
   isSupportedLanguagesLive,
   isSupportedLocalSttModel,
 } from "~/stt/capabilities";
+import {
+  getDefaultSttModel,
+  getPreferredProviderModel,
+} from "~/stt/model-selection";
 
 export function SelectProviderAndModel() {
   const { t } = useLingui();
@@ -124,11 +127,14 @@ export function SelectProviderAndModel() {
 
     const providerId = provider as ProviderId;
     const nextModels = configuredProviders[providerId]?.models ?? [];
-    const nextModel = getPreferredProviderModel(
-      lastSelectedModelsRef.current[provider],
-      nextModels,
-      { allowSavedModelWithoutChoices: providerId === "custom" },
-    );
+    const nextModel =
+      getPreferredProviderModel(
+        lastSelectedModelsRef.current[provider],
+        nextModels,
+        { allowSavedModelWithoutChoices: providerId === "custom" },
+      ) ||
+      getDefaultSttModel(providerId) ||
+      "";
 
     rememberModel(provider, nextModel);
     handleSelectProvider(provider);

--- a/apps/desktop/src/settings/ai/stt/selection.test.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.test.ts
@@ -1,6 +1,18 @@
 import { describe, expect, test } from "vitest";
 
-import { getPreferredProviderModel } from "./selection";
+import { getDefaultSttModel, getPreferredProviderModel } from "./selection";
+
+describe("getDefaultSttModel", () => {
+  test("repairs external providers with their first supported model", () => {
+    expect(getDefaultSttModel("deepgram")).toBe("nova-3-general");
+    expect(getDefaultSttModel("soniox")).toBe("stt-rt-v5");
+  });
+
+  test("does not invent a model for custom or Anarlog providers", () => {
+    expect(getDefaultSttModel("custom")).toBeUndefined();
+    expect(getDefaultSttModel("hyprnote")).toBeUndefined();
+  });
+});
 
 describe("getPreferredProviderModel", () => {
   test("returns the remembered model when it is still available", () => {

--- a/apps/desktop/src/settings/ai/stt/selection.ts
+++ b/apps/desktop/src/settings/ai/stt/selection.ts
@@ -1,1 +1,4 @@
-export { getPreferredProviderModel } from "~/stt/model-selection";
+export {
+  getDefaultSttModel,
+  getPreferredProviderModel,
+} from "~/stt/model-selection";

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -2,10 +2,24 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   execute: vi.fn(),
+  getSecret: vi.fn(async () => ({
+    status: "ok",
+    data: null as string | null,
+  })),
+  setSecret: vi.fn(async () => ({ status: "ok", data: null })),
+  deleteSecret: vi.fn(async () => ({ status: "ok", data: null })),
   executeTransaction: vi.fn(
     (_statements: Array<{ sql: string; params: unknown[] }>) =>
       Promise.resolve([1]),
   ),
+}));
+
+vi.mock("@hypr/plugin-store2", () => ({
+  commands: {
+    getSecret: mocks.getSecret,
+    setSecret: mocks.setSecret,
+    deleteSecret: mocks.deleteSecret,
+  },
 }));
 
 vi.mock("~/db", () => ({
@@ -19,11 +33,20 @@ vi.mock("~/db/write-queue", () => ({
     operation(),
 }));
 
-import { parseAiProviders, setAiProvider } from "./providers";
+import {
+  loadAiProviderApiKeys,
+  migratePlaintextAiProviderApiKeys,
+  parseAiProviders,
+  setAiProvider,
+} from "./providers";
 
 describe("SQLite AI providers", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mocks.executeTransaction.mockResolvedValue([1]);
+    mocks.getSecret.mockResolvedValue({ status: "ok", data: null });
+    mocks.setSecret.mockResolvedValue({ status: "ok", data: null });
+    mocks.deleteSecret.mockResolvedValue({ status: "ok", data: null });
   });
 
   it("uses direct provider rows over imported legacy configuration", () => {
@@ -80,14 +103,21 @@ describe("SQLite AI providers", () => {
 
     await setAiProvider("stt", "deepgram", { api_key: "new-key" });
 
-    const statement = mocks.executeTransaction.mock.calls[0][0][0];
+    const statement = mocks.executeTransaction.mock.calls[0][0].find(
+      (candidate) => candidate.sql.includes("INSERT INTO app_settings"),
+    )!;
     expect(statement.sql).toContain("INSERT INTO app_settings");
     expect(statement.params[0]).toBe("ai_provider:stt:deepgram");
     expect(JSON.parse(String(statement.params[1]))).toEqual({
       type: "stt",
       base_url: "https://legacy.example",
-      api_key: "new-key",
+      api_key: "",
     });
+    expect(mocks.setSecret).toHaveBeenCalledWith(
+      "ai-provider-api-keys",
+      "stt:deepgram",
+      "new-key",
+    );
   });
 
   it("retries partial writes without dropping a concurrent field", async () => {
@@ -122,7 +152,194 @@ describe("SQLite AI providers", () => {
     expect(JSON.parse(String(statement.params[0]))).toEqual({
       type: "llm",
       base_url: "https://concurrent.example",
-      api_key: "new-key",
+      api_key: "",
     });
+  });
+
+  it("restores secure storage when the SQLite write never commits", async () => {
+    mocks.execute.mockResolvedValue([
+      {
+        id: "ai_provider:llm:openai",
+        value_json: JSON.stringify({
+          type: "llm",
+          base_url: "https://old.example",
+          api_key: "",
+        }),
+      },
+    ]);
+    mocks.executeTransaction.mockResolvedValue([0]);
+
+    await expect(
+      setAiProvider("llm", "openai", { api_key: "new-key" }),
+    ).rejects.toThrow("changed too frequently");
+
+    expect(mocks.setSecret).toHaveBeenCalledWith(
+      "ai-provider-api-keys",
+      "llm:openai",
+      "new-key",
+    );
+    expect(mocks.deleteSecret).toHaveBeenCalledWith(
+      "ai-provider-api-keys",
+      "llm:openai",
+    );
+  });
+
+  it("hydrates plaintext API keys until startup migration runs", async () => {
+    const rows = [
+      {
+        id: "ai_provider:stt:deepgram",
+        value_json: JSON.stringify({
+          type: "stt",
+          base_url: "https://api.deepgram.com/v1",
+          api_key: "deepgram-key",
+        }),
+      },
+    ];
+
+    const providers = await loadAiProviderApiKeys(rows, "stt");
+
+    expect(providers["stt:deepgram"]?.api_key).toBe("deepgram-key");
+    expect(mocks.setSecret).not.toHaveBeenCalled();
+    expect(mocks.executeTransaction).not.toHaveBeenCalled();
+  });
+
+  it("keeps the plaintext key when secure storage rejects migration", async () => {
+    mocks.execute.mockResolvedValueOnce([
+      {
+        id: "ai_provider:stt:deepgram",
+        value_json: JSON.stringify({
+          type: "stt",
+          base_url: "https://api.deepgram.com/v1",
+          api_key: "deepgram-key",
+        }),
+      },
+    ]);
+    mocks.setSecret.mockRejectedValueOnce(new Error("keychain unavailable"));
+
+    await expect(migratePlaintextAiProviderApiKeys()).rejects.toThrow(
+      "keychain unavailable",
+    );
+
+    expect(mocks.executeTransaction).not.toHaveBeenCalled();
+  });
+
+  it("securely deletes migrated values and truncates the SQLite WAL", async () => {
+    mocks.execute.mockResolvedValueOnce([
+      {
+        id: "ai_provider:stt:deepgram",
+        value_json: JSON.stringify({
+          type: "stt",
+          base_url: "https://api.deepgram.com/v1",
+          api_key: "deepgram-key",
+        }),
+      },
+    ]);
+
+    await migratePlaintextAiProviderApiKeys();
+
+    const statements = mocks.executeTransaction.mock.calls[0][0];
+    expect(statements[0].sql).toContain("PRAGMA secure_delete = ON");
+    expect(mocks.execute).toHaveBeenLastCalledWith(
+      "PRAGMA wal_checkpoint(TRUNCATE)",
+    );
+  });
+
+  it("redacts reintroduced legacy keys without replacing an existing secret", async () => {
+    mocks.getSecret.mockResolvedValue({
+      status: "ok",
+      data: "current-secure-key",
+    });
+    mocks.execute.mockResolvedValueOnce([
+      {
+        id: "legacy_settings_document",
+        value_json: JSON.stringify({
+          ai: {
+            stt: {
+              deepgram: {
+                base_url: "https://legacy.example",
+                api_key: "stale-legacy-key",
+              },
+            },
+          },
+        }),
+      },
+      {
+        id: "ai_provider:stt:deepgram",
+        value_json: JSON.stringify({
+          type: "stt",
+          base_url: "https://direct.example",
+          api_key: "",
+        }),
+      },
+    ]);
+
+    await migratePlaintextAiProviderApiKeys();
+
+    expect(mocks.setSecret).not.toHaveBeenCalled();
+    const legacyUpdate = mocks.executeTransaction.mock.calls[0][0].find(
+      (candidate) =>
+        candidate.sql.includes("UPDATE app_settings") &&
+        candidate.params.includes("legacy_settings_document"),
+    )!;
+    expect(String(legacyUpdate.params[0])).not.toContain("stale-legacy-key");
+  });
+
+  it("redacts stale direct keys without replacing an existing secret", async () => {
+    mocks.getSecret.mockResolvedValue({
+      status: "ok",
+      data: "current-secure-key",
+    });
+    mocks.execute.mockResolvedValueOnce([
+      {
+        id: "ai_provider:stt:deepgram",
+        value_json: JSON.stringify({
+          type: "stt",
+          base_url: "https://direct.example",
+          api_key: "stale-direct-key",
+        }),
+      },
+    ]);
+
+    await migratePlaintextAiProviderApiKeys();
+
+    expect(mocks.setSecret).not.toHaveBeenCalled();
+    const directUpdate = mocks.executeTransaction.mock.calls[0][0].find(
+      (candidate) => candidate.params.includes("ai_provider:stt:deepgram"),
+    )!;
+    expect(String(directUpdate.params[0])).not.toContain("stale-direct-key");
+  });
+
+  it("refreshes legacy settings before migrating the next provider type", async () => {
+    const legacySettings = (llmKey: string, sttKey: string) => ({
+      id: "legacy_settings_document",
+      value_json: JSON.stringify({
+        ai: {
+          llm: {
+            openai: {
+              base_url: "https://api.openai.com/v1",
+              api_key: llmKey,
+            },
+          },
+          stt: {
+            deepgram: {
+              base_url: "https://api.deepgram.com/v1",
+              api_key: sttKey,
+            },
+          },
+        },
+      }),
+    });
+    mocks.execute
+      .mockResolvedValueOnce([legacySettings("llm-key", "stt-key")])
+      .mockResolvedValueOnce([legacySettings("", "stt-key")]);
+
+    await migratePlaintextAiProviderApiKeys();
+
+    const sttStatements = mocks.executeTransaction.mock.calls[1][0];
+    const legacyUpdate = sttStatements.find((candidate) =>
+      candidate.params.includes("legacy_settings_document"),
+    )!;
+    expect(String(legacyUpdate.params[0])).not.toContain("llm-key");
+    expect(String(legacyUpdate.params[0])).not.toContain("stt-key");
   });
 });

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -1,4 +1,7 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { useCallback } from "react";
+
+import { commands as store2Commands } from "@hypr/plugin-store2";
 
 import { executeTransaction, liveQueryClient, useLiveQuery } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
@@ -14,19 +17,38 @@ export type AiProviderConfig = {
 type AppSettingRow = { id: string; value_json: string };
 
 const LEGACY_SETTINGS_ID = "legacy_settings_document";
+const PROVIDER_SECRET_SCOPE = "ai-provider-api-keys";
 const EMPTY_PROVIDERS: Record<string, AiProviderConfig> = {};
+const EMPTY_ROWS: AppSettingRow[] = [];
 
 export function useAiProviders(
   type: AiProviderType,
 ): Record<string, AiProviderConfig> {
-  const { data = EMPTY_PROVIDERS } = useLiveQuery<
+  const { data: rows = EMPTY_ROWS, isLoading } = useLiveQuery<
     AppSettingRow,
-    Record<string, AiProviderConfig>
+    AppSettingRow[]
   >({
     sql: `SELECT id, value_json FROM app_settings ORDER BY id`,
-    mapRows: (rows) => parseAiProviders(rows, type),
+    mapRows: (rows) => rows,
   });
-  return data;
+  const providers = parseAiProviders(rows, type);
+  const providerIds = Object.keys(providers).sort();
+  const { data: secureApiKeys = EMPTY_PROVIDERS } = useQuery({
+    queryKey: ["ai-provider-api-keys", type, providerIds],
+    queryFn: () => loadAiProviderApiKeys(rows, type),
+    enabled: !isLoading,
+    staleTime: Infinity,
+  });
+
+  return Object.fromEntries(
+    Object.entries(providers).map(([rowId, provider]) => [
+      rowId,
+      {
+        ...provider,
+        api_key: secureApiKeys[rowId]?.api_key ?? provider.api_key,
+      },
+    ]),
+  );
 }
 
 export function useAiProvider(
@@ -44,68 +66,146 @@ export function setAiProvider(
 ): Promise<void> {
   const storageId = providerStorageId(type, providerId);
   return enqueueDatabaseWrite(storageId, async () => {
-    for (let attempt = 0; attempt < 5; attempt += 1) {
-      const rows = await liveQueryClient.execute<AppSettingRow>(
-        `
+    const previousApiKey = await getProviderApiKey(type, providerId);
+
+    try {
+      for (let attempt = 0; attempt < 5; attempt += 1) {
+        const rows = await liveQueryClient.execute<AppSettingRow>(
+          `
           SELECT id, value_json
           FROM app_settings
           WHERE id IN (?, ?)
         `,
-        [storageId, LEGACY_SETTINGS_ID],
-      );
-      const direct = rows.find((row) => row.id === storageId);
-      const legacy = parseLegacyProvider(
-        rows.find((row) => row.id === LEGACY_SETTINGS_ID)?.value_json,
-        type,
-        providerId,
-      );
-      const current = direct
-        ? (parseProviderValue(direct.value_json, type) ?? legacy)
-        : legacy;
-      const next: AiProviderConfig = {
-        type,
-        base_url: changes.base_url ?? current?.base_url ?? "",
-        api_key: changes.api_key ?? current?.api_key ?? "",
-      };
-      const now = new Date().toISOString();
-      const [updated = 0] = await executeTransaction([
-        direct
-          ? {
-              sql: `
+          [storageId, LEGACY_SETTINGS_ID],
+        );
+        const direct = rows.find((row) => row.id === storageId);
+        const legacy = parseLegacyProvider(
+          rows.find((row) => row.id === LEGACY_SETTINGS_ID)?.value_json,
+          type,
+          providerId,
+        );
+        const current = direct
+          ? (parseProviderValue(direct.value_json, type) ?? legacy)
+          : legacy;
+        const next: AiProviderConfig = {
+          type,
+          base_url: changes.base_url ?? current?.base_url ?? "",
+          api_key: changes.api_key ?? previousApiKey ?? current?.api_key ?? "",
+        };
+        await setProviderApiKey(type, providerId, next.api_key);
+
+        const persisted = { ...next, api_key: "" };
+        const now = new Date().toISOString();
+        const statements = [
+          direct
+            ? {
+                sql: `
                 UPDATE app_settings
                 SET value_json = ?, updated_at = ?
                 WHERE id = ? AND value_json = ?
               `,
-              params: [JSON.stringify(next), now, storageId, direct.value_json],
-            }
-          : {
-              sql: `
+                params: [
+                  JSON.stringify(persisted),
+                  now,
+                  storageId,
+                  direct.value_json,
+                ],
+              }
+            : {
+                sql: `
                 INSERT INTO app_settings (id, value_json, updated_at)
                 VALUES (?, ?, ?)
                 ON CONFLICT(id) DO NOTHING
               `,
-              params: [storageId, JSON.stringify(next), now],
-            },
-      ]);
-      if (updated === 1) return;
-    }
+                params: [storageId, JSON.stringify(persisted), now],
+              },
+        ];
 
-    throw new Error(`Provider ${type}:${providerId} changed too frequently`);
+        const legacyRow = rows.find((row) => row.id === LEGACY_SETTINGS_ID);
+        const redactedLegacy = redactLegacyProviderApiKey(
+          legacyRow?.value_json,
+          type,
+          providerId,
+        );
+        if (legacyRow && redactedLegacy) {
+          statements.push({
+            sql: `
+            UPDATE app_settings
+            SET value_json = ?, updated_at = ?
+            WHERE id = ?
+          `,
+            params: [redactedLegacy, now, LEGACY_SETTINGS_ID],
+          });
+        }
+
+        const [updated = 0] = await executeTransaction(statements);
+        if (updated === 1) return;
+      }
+
+      throw new Error(`Provider ${type}:${providerId} changed too frequently`);
+    } catch (error) {
+      await setProviderApiKey(type, providerId, previousApiKey ?? "");
+      throw error;
+    }
   });
 }
 
 export function useSetAiProvider(type: AiProviderType, providerId: string) {
+  const queryClient = useQueryClient();
+
   return useCallback(
     (changes: Partial<Pick<AiProviderConfig, "base_url" | "api_key">>) => {
-      void setAiProvider(type, providerId, changes).catch((error) => {
-        console.error(
-          `[settings] failed to update provider ${type}:${providerId}`,
-          error,
-        );
-      });
+      void setAiProvider(type, providerId, changes)
+        .then(() =>
+          queryClient.invalidateQueries({
+            queryKey: ["ai-provider-api-keys", type],
+          }),
+        )
+        .catch((error) => {
+          console.error(
+            `[settings] failed to update provider ${type}:${providerId}`,
+            error,
+          );
+        });
     },
-    [providerId, type],
+    [providerId, queryClient, type],
   );
+}
+
+export async function loadAiProviderApiKeys(
+  rows: AppSettingRow[],
+  type: AiProviderType,
+): Promise<Record<string, AiProviderConfig>> {
+  const providers = parseAiProviders(rows, type);
+  const hydrated: Record<string, AiProviderConfig> = {};
+
+  for (const [rowId, provider] of Object.entries(providers)) {
+    const providerId = rowId.slice(`${type}:`.length);
+    const apiKey = provider.api_key.trim();
+
+    hydrated[rowId] = {
+      ...provider,
+      api_key: apiKey || (await getProviderApiKey(type, providerId)) || "",
+    };
+  }
+
+  return hydrated;
+}
+
+export async function migratePlaintextAiProviderApiKeys(): Promise<void> {
+  let rows = await liveQueryClient.execute<AppSettingRow>(
+    `SELECT id, value_json FROM app_settings ORDER BY id`,
+  );
+  const migratedLlm = await migratePlaintextProviderApiKeys(rows, "llm");
+  if (migratedLlm) {
+    rows = await liveQueryClient.execute<AppSettingRow>(
+      `SELECT id, value_json FROM app_settings ORDER BY id`,
+    );
+  }
+  const migratedStt = await migratePlaintextProviderApiKeys(rows, "stt");
+  if (migratedLlm || migratedStt) {
+    await liveQueryClient.execute(`PRAGMA wal_checkpoint(TRUNCATE)`);
+  }
 }
 
 export function parseAiProviders(
@@ -183,6 +283,157 @@ function parseObjectValue(value: unknown): Record<string, unknown> {
   return value && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, unknown>)
     : {};
+}
+
+async function getProviderApiKey(
+  type: AiProviderType,
+  providerId: string,
+): Promise<string | null> {
+  const result = await store2Commands.getSecret(
+    PROVIDER_SECRET_SCOPE,
+    providerRowId(type, providerId),
+  );
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+  return result.data;
+}
+
+async function setProviderApiKey(
+  type: AiProviderType,
+  providerId: string,
+  apiKey: string,
+): Promise<void> {
+  const key = providerRowId(type, providerId);
+  const result = apiKey
+    ? await store2Commands.setSecret(PROVIDER_SECRET_SCOPE, key, apiKey)
+    : await store2Commands.deleteSecret(PROVIDER_SECRET_SCOPE, key);
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+}
+
+async function migratePlaintextProviderApiKeys(
+  rows: AppSettingRow[],
+  type: AiProviderType,
+): Promise<boolean> {
+  const legacyRow = rows.find((row) => row.id === LEGACY_SETTINGS_ID);
+  const legacyProviders = parseAiProviders(legacyRow ? [legacyRow] : [], type);
+  const directProviders = parseAiProviders(
+    rows.filter((row) => row.id.startsWith(providerStorageId(type, ""))),
+    type,
+  );
+  const rowIds = new Set([
+    ...Object.keys(legacyProviders),
+    ...Object.keys(directProviders),
+  ]);
+  const providerIds: string[] = [];
+
+  for (const rowId of rowIds) {
+    const providerId = rowId.slice(`${type}:`.length);
+    const directApiKey = directProviders[rowId]?.api_key.trim() ?? "";
+    const legacyApiKey = legacyProviders[rowId]?.api_key.trim() ?? "";
+    if (!directApiKey && !legacyApiKey) continue;
+
+    const existingApiKey = await getProviderApiKey(type, providerId);
+    if (!existingApiKey) {
+      await setProviderApiKey(type, providerId, directApiKey || legacyApiKey);
+    }
+    providerIds.push(providerId);
+  }
+
+  if (providerIds.length > 0) {
+    await redactPlaintextProviderApiKeys(rows, type, providerIds);
+  }
+
+  return providerIds.length > 0;
+}
+
+async function redactPlaintextProviderApiKeys(
+  rows: AppSettingRow[],
+  type: AiProviderType,
+  providerIds: string[],
+): Promise<void> {
+  const migrated = new Set(providerIds);
+  const now = new Date().toISOString();
+  const statements = rows.flatMap((row) => {
+    const prefix = providerStorageId(type, "");
+    if (!row.id.startsWith(prefix)) {
+      return [];
+    }
+
+    const providerId = row.id.slice(prefix.length);
+    const config = parseProviderValue(row.value_json, type);
+    if (!migrated.has(providerId) || !config?.api_key) {
+      return [];
+    }
+
+    return [
+      {
+        sql: `
+          UPDATE app_settings
+          SET value_json = ?, updated_at = ?
+          WHERE id = ? AND value_json = ?
+        `,
+        params: [
+          JSON.stringify({ ...config, api_key: "" }),
+          now,
+          row.id,
+          row.value_json,
+        ],
+      },
+    ];
+  });
+
+  const legacyRow = rows.find((row) => row.id === LEGACY_SETTINGS_ID);
+  if (legacyRow) {
+    let redactedLegacy = legacyRow.value_json;
+    for (const providerId of providerIds) {
+      redactedLegacy =
+        redactLegacyProviderApiKey(redactedLegacy, type, providerId) ??
+        redactedLegacy;
+    }
+    if (redactedLegacy !== legacyRow.value_json) {
+      statements.push({
+        sql: `
+          UPDATE app_settings
+          SET value_json = ?, updated_at = ?
+          WHERE id = ?
+        `,
+        params: [redactedLegacy, now, LEGACY_SETTINGS_ID],
+      });
+    }
+  }
+
+  if (statements.length > 0) {
+    await executeTransaction([
+      { sql: `PRAGMA secure_delete = ON`, params: [] },
+      ...statements,
+    ]);
+  }
+}
+
+function redactLegacyProviderApiKey(
+  valueJson: string | undefined,
+  type: AiProviderType,
+  providerId: string,
+): string | null {
+  if (!valueJson) return null;
+
+  try {
+    const document = JSON.parse(valueJson) as Record<string, unknown>;
+    const ai = parseObjectValue(document.ai);
+    const providers = parseObjectValue(ai[type]);
+    const provider = parseObjectValue(providers[providerId]);
+    if (typeof provider.api_key !== "string" || !provider.api_key) {
+      return null;
+    }
+
+    provider.api_key = "";
+    return JSON.stringify(document);
+  } catch {
+    return null;
+  }
 }
 
 function providerStorageId(type: AiProviderType, providerId: string): string {

--- a/apps/desktop/src/settings/queries.test.tsx
+++ b/apps/desktop/src/settings/queries.test.tsx
@@ -163,6 +163,31 @@ describe("SQLite settings", () => {
     );
   });
 
+  it("repairs a selected external transcription provider with no model", async () => {
+    let rows = [
+      {
+        id: "current_stt_provider",
+        value_json: JSON.stringify("deepgram"),
+      },
+      { id: "current_stt_model", value_json: JSON.stringify("") },
+    ];
+    mocks.execute.mockImplementation(async () => rows);
+    mocks.executeTransaction.mockImplementation(async (statements) => {
+      rows = statements.map((statement) => ({
+        id: String(statement.params[0]),
+        value_json: String(statement.params[1]),
+      }));
+      return statements.map(() => 1);
+    });
+
+    await initializeApplicationSettings();
+
+    const statements = mocks.executeTransaction.mock.calls[0][0];
+    expect(statements.map((statement) => statement.params.slice(0, 2))).toEqual(
+      [["current_stt_model", JSON.stringify("nova-3-general")]],
+    );
+  });
+
   it("updates against the latest SQLite value inside the write queue", async () => {
     mocks.execute.mockResolvedValue([
       {

--- a/apps/desktop/src/settings/queries.ts
+++ b/apps/desktop/src/settings/queries.ts
@@ -24,7 +24,10 @@ import {
   isConfiguredSttModel,
   isHyprnoteLocalSttModel,
 } from "~/stt/capabilities";
-import { normalizeStoredSttModel } from "~/stt/model-selection";
+import {
+  getDefaultSttModel,
+  normalizeStoredSttModel,
+} from "~/stt/model-selection";
 
 type AppSettingRow = { id: string; value_json: string };
 
@@ -93,25 +96,29 @@ export async function initializeApplicationSettings(): Promise<void> {
   const languageResult = await detectCommands
     .getPreferredLanguages()
     .catch(() => null);
-  const languageUpdates: SettingValues = {};
+  const updates: SettingValues = {};
 
   if (languageResult?.status === "ok" && languageResult.data.length > 0) {
     if (!stored.hasValues.has("ai_language")) {
-      languageUpdates.ai_language = languageResult.data[0];
+      updates.ai_language = languageResult.data[0];
     }
     if (!stored.hasValues.has("spoken_languages")) {
-      languageUpdates.spoken_languages = JSON.stringify(languageResult.data);
+      updates.spoken_languages = JSON.stringify(languageResult.data);
     }
   }
 
-  if (Object.keys(languageUpdates).length > 0) {
-    await setSettingValues(languageUpdates);
+  if (!stored.values.current_stt_model) {
+    const defaultModel = getDefaultSttModel(stored.values.current_stt_provider);
+    if (defaultModel) {
+      updates.current_stt_model = defaultModel;
+    }
   }
 
+  if (Object.keys(updates).length > 0) {
+    await setSettingValues(updates);
+  }
   const current =
-    Object.keys(languageUpdates).length > 0
-      ? await getStoredSettingValues()
-      : stored;
+    Object.keys(updates).length > 0 ? await getStoredSettingValues() : stored;
   applySettingSideEffects(current.values);
 }
 

--- a/apps/desktop/src/stt/model-selection.ts
+++ b/apps/desktop/src/stt/model-selection.ts
@@ -8,6 +8,25 @@ type PreferredProviderModelOptions = {
   keepUnavailableSavedModel?: boolean;
 };
 
+const DEFAULT_EXTERNAL_STT_MODELS: Record<string, string> = {
+  deepgram: "nova-3-general",
+  assemblyai: "universal-3-pro",
+  openai: "gpt-4o-transcribe-diarize",
+  cartesia: "ink-2",
+  cloudflare_workers_ai: "nova-3",
+  gladia: "solaria-1",
+  soniox: "stt-rt-v5",
+  elevenlabs: "scribe_v2",
+  mistral: "voxtral-mini-2602",
+  pyannote: "parakeet-tdt-0.6b-v3",
+  aquavoice: "avalon-v1-en",
+  fireworks: "Default",
+};
+
+export function getDefaultSttModel(provider?: string | null) {
+  return provider ? DEFAULT_EXTERNAL_STT_MODELS[provider] : undefined;
+}
+
 export function normalizeStoredSttModel(
   provider: string | undefined,
   model: string | undefined,

--- a/plugins/store2/Cargo.toml
+++ b/plugins/store2/Cargo.toml
@@ -24,6 +24,7 @@ tauri-plugin-store = { workspace = true }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 
 hypr-storage = { workspace = true }
+keyring = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 specta = { workspace = true }

--- a/plugins/store2/build.rs
+++ b/plugins/store2/build.rs
@@ -6,6 +6,9 @@ const COMMANDS: &[&str] = &[
     "set_bool",
     "get_number",
     "set_number",
+    "get_secret",
+    "set_secret",
+    "delete_secret",
 ];
 
 fn main() {

--- a/plugins/store2/js/bindings.gen.ts
+++ b/plugins/store2/js/bindings.gen.ts
@@ -61,6 +61,30 @@ async setNumber(scope: string, key: string, value: number) : Promise<Result<null
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async getSecret(scope: string, key: string) : Promise<Result<string | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:store2|get_secret", { scope, key }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async setSecret(scope: string, key: string, value: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:store2|set_secret", { scope, key, value }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async deleteSecret(scope: string, key: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:store2|delete_secret", { scope, key }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/plugins/store2/permissions/autogenerated/commands/delete_secret.toml
+++ b/plugins/store2/permissions/autogenerated/commands/delete_secret.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-delete-secret"
+description = "Enables the delete_secret command without any pre-configured scope."
+commands.allow = ["delete_secret"]
+
+[[permission]]
+identifier = "deny-delete-secret"
+description = "Denies the delete_secret command without any pre-configured scope."
+commands.deny = ["delete_secret"]

--- a/plugins/store2/permissions/autogenerated/commands/get_secret.toml
+++ b/plugins/store2/permissions/autogenerated/commands/get_secret.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-secret"
+description = "Enables the get_secret command without any pre-configured scope."
+commands.allow = ["get_secret"]
+
+[[permission]]
+identifier = "deny-get-secret"
+description = "Denies the get_secret command without any pre-configured scope."
+commands.deny = ["get_secret"]

--- a/plugins/store2/permissions/autogenerated/commands/set_secret.toml
+++ b/plugins/store2/permissions/autogenerated/commands/set_secret.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-set-secret"
+description = "Enables the set_secret command without any pre-configured scope."
+commands.allow = ["set_secret"]
+
+[[permission]]
+identifier = "deny-set-secret"
+description = "Denies the set_secret command without any pre-configured scope."
+commands.deny = ["set_secret"]

--- a/plugins/store2/permissions/autogenerated/reference.md
+++ b/plugins/store2/permissions/autogenerated/reference.md
@@ -5,11 +5,14 @@ Default permissions for the plugin
 #### This default permission set includes the following:
 
 - `allow-save`
+- `allow-delete-secret`
 - `allow-get-bool`
 - `allow-get-number`
+- `allow-get-secret`
 - `allow-get-str`
 - `allow-set-bool`
 - `allow-set-number`
+- `allow-set-secret`
 - `allow-set-str`
 
 ## Permission Table
@@ -20,6 +23,32 @@ Default permissions for the plugin
 <th>Description</th>
 </tr>
 
+
+<tr>
+<td>
+
+`store2:allow-delete-secret`
+
+</td>
+<td>
+
+Enables the delete_secret command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`store2:deny-delete-secret`
+
+</td>
+<td>
+
+Denies the delete_secret command without any pre-configured scope.
+
+</td>
+</tr>
 
 <tr>
 <td>
@@ -69,6 +98,32 @@ Enables the get_number command without any pre-configured scope.
 <td>
 
 Denies the get_number command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`store2:allow-get-secret`
+
+</td>
+<td>
+
+Enables the get_secret command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`store2:deny-get-secret`
+
+</td>
+<td>
+
+Denies the get_secret command without any pre-configured scope.
 
 </td>
 </tr>
@@ -173,6 +228,32 @@ Enables the set_number command without any pre-configured scope.
 <td>
 
 Denies the set_number command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`store2:allow-set-secret`
+
+</td>
+<td>
+
+Enables the set_secret command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`store2:deny-set-secret`
+
+</td>
+<td>
+
+Denies the set_secret command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/store2/permissions/default.toml
+++ b/plugins/store2/permissions/default.toml
@@ -1,3 +1,3 @@
 [default]
 description = "Default permissions for the plugin"
-permissions = ["allow-save", "allow-get-bool", "allow-get-number", "allow-get-str", "allow-set-bool", "allow-set-number", "allow-set-str"]
+permissions = ["allow-save", "allow-delete-secret", "allow-get-bool", "allow-get-number", "allow-get-secret", "allow-get-str", "allow-set-bool", "allow-set-number", "allow-set-secret", "allow-set-str"]

--- a/plugins/store2/permissions/schemas/schema.json
+++ b/plugins/store2/permissions/schemas/schema.json
@@ -295,6 +295,18 @@
       "type": "string",
       "oneOf": [
         {
+          "description": "Enables the delete_secret command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-delete-secret",
+          "markdownDescription": "Enables the delete_secret command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the delete_secret command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-delete-secret",
+          "markdownDescription": "Denies the delete_secret command without any pre-configured scope."
+        },
+        {
           "description": "Enables the get_bool command without any pre-configured scope.",
           "type": "string",
           "const": "allow-get-bool",
@@ -317,6 +329,18 @@
           "type": "string",
           "const": "deny-get-number",
           "markdownDescription": "Denies the get_number command without any pre-configured scope."
+        },
+        {
+          "description": "Enables the get_secret command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-get-secret",
+          "markdownDescription": "Enables the get_secret command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the get_secret command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-get-secret",
+          "markdownDescription": "Denies the get_secret command without any pre-configured scope."
         },
         {
           "description": "Enables the get_str command without any pre-configured scope.",
@@ -367,6 +391,18 @@
           "markdownDescription": "Denies the set_number command without any pre-configured scope."
         },
         {
+          "description": "Enables the set_secret command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-set-secret",
+          "markdownDescription": "Enables the set_secret command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the set_secret command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-set-secret",
+          "markdownDescription": "Denies the set_secret command without any pre-configured scope."
+        },
+        {
           "description": "Enables the set_str command without any pre-configured scope.",
           "type": "string",
           "const": "allow-set-str",
@@ -379,10 +415,10 @@
           "markdownDescription": "Denies the set_str command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-save`\n- `allow-get-bool`\n- `allow-get-number`\n- `allow-get-str`\n- `allow-set-bool`\n- `allow-set-number`\n- `allow-set-str`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-save`\n- `allow-delete-secret`\n- `allow-get-bool`\n- `allow-get-number`\n- `allow-get-secret`\n- `allow-get-str`\n- `allow-set-bool`\n- `allow-set-number`\n- `allow-set-secret`\n- `allow-set-str`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-save`\n- `allow-get-bool`\n- `allow-get-number`\n- `allow-get-str`\n- `allow-set-bool`\n- `allow-set-number`\n- `allow-set-str`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-save`\n- `allow-delete-secret`\n- `allow-get-bool`\n- `allow-get-number`\n- `allow-get-secret`\n- `allow-get-str`\n- `allow-set-bool`\n- `allow-set-number`\n- `allow-set-secret`\n- `allow-set-str`"
         }
       ]
     }

--- a/plugins/store2/src/commands.rs
+++ b/plugins/store2/src/commands.rs
@@ -1,5 +1,21 @@
 use crate::Store2PluginExt;
 
+const SECURE_STORE_SUFFIX: &str = "secure-store";
+
+fn secret_entry<R: tauri::Runtime>(
+    app: &tauri::AppHandle<R>,
+    scope: &str,
+    key: &str,
+) -> Result<keyring::Entry, String> {
+    if scope.trim().is_empty() || key.trim().is_empty() {
+        return Err("secure-store scope and key must not be empty".to_string());
+    }
+
+    let service = format!("{}.{}", app.config().identifier, SECURE_STORE_SUFFIX);
+    let account = format!("{scope}:{key}");
+    keyring::Entry::new(&service, &account).map_err(|error| error.to_string())
+}
+
 #[tauri::command]
 #[specta::specta]
 pub(crate) async fn save<R: tauri::Runtime>(app: tauri::AppHandle<R>) -> Result<(), String> {
@@ -101,4 +117,59 @@ pub(crate) async fn set_number<R: tauri::Runtime>(
         .map_err(|e| e.to_string())?;
 
     store.set(key, value).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn get_secret<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    scope: String,
+    key: String,
+) -> Result<Option<String>, String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let entry = secret_entry(&app, &scope, &key)?;
+        match entry.get_password() {
+            Ok(secret) => Ok(Some(secret)),
+            Err(keyring::Error::NoEntry) => Ok(None),
+            Err(error) => Err(error.to_string()),
+        }
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn set_secret<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    scope: String,
+    key: String,
+    value: String,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let entry = secret_entry(&app, &scope, &key)?;
+        entry
+            .set_password(&value)
+            .map_err(|error| error.to_string())
+    })
+    .await
+    .map_err(|error| error.to_string())?
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn delete_secret<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    scope: String,
+    key: String,
+) -> Result<(), String> {
+    tauri::async_runtime::spawn_blocking(move || {
+        let entry = secret_entry(&app, &scope, &key)?;
+        match entry.delete_credential() {
+            Ok(()) | Err(keyring::Error::NoEntry) => Ok(()),
+            Err(error) => Err(error.to_string()),
+        }
+    })
+    .await
+    .map_err(|error| error.to_string())?
 }

--- a/plugins/store2/src/lib.rs
+++ b/plugins/store2/src/lib.rs
@@ -20,6 +20,9 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::set_bool<tauri::Wry>,
             commands::get_number<tauri::Wry>,
             commands::set_number<tauri::Wry>,
+            commands::get_secret<tauri::Wry>,
+            commands::set_secret<tauri::Wry>,
+            commands::delete_secret<tauri::Wry>,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }


### PR DESCRIPTION
Persist default transcription models and move provider API keys into native OS credential storage with safe plaintext migration.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes how credentials are stored and migrated across SQLite, legacy settings, and OS keychain; failures or partial migration could affect LLM/STT connectivity until users re-enter keys.
> 
> **Overview**
> Moves **LLM and STT provider API keys** out of SQLite into **native credential storage** via new `store2` secret commands (`get_secret` / `set_secret` / `delete_secret` backed by `keyring`). Provider rows in `app_settings` now persist **base URLs only** (empty `api_key`); the UI hydrates keys from secure storage and rolls back keychain writes if the DB transaction fails.
> 
> On startup, **`migratePlaintextAiProviderApiKeys`** copies legacy/direct plaintext keys into the keychain, redacts them from SQLite (with `secure_delete` + WAL truncate), and skips overwriting secrets that already exist.
> 
> **STT selection** gains **`getDefaultSttModel`** for external providers; app init and the provider picker fill in a default model when the stored model is missing (e.g. Deepgram → `nova-3-general`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7079e7b99f9a5a1afbe77973af5d6e2711345bb3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->