### PR TITLE
Seed a welcome note after onboarding

### DIFF
--- a/apps/desktop/src/main/lifecycle.tsx
+++ b/apps/desktop/src/main/lifecycle.tsx
@@ -8,6 +8,7 @@ import { useSessionTab } from "~/chat/components/use-session-tab";
 import { buildChatTools } from "~/chat/tools";
 import { searchContacts } from "~/contacts/queries";
 import { useRegisterTools } from "~/contexts/tool";
+import { takePendingWelcomeSession } from "~/onboarding/welcome-note";
 import { useSearchEngine } from "~/search/contexts/engine";
 import { initEnhancerService } from "~/services/enhancer";
 import { useConfigValue } from "~/shared/config";
@@ -22,8 +23,16 @@ export function useClassicMainLifecycle() {
     openNew({ type: "empty" });
   }, [openNew]);
 
+  const openPendingWelcomeTab = useCallback(() => {
+    const welcomeSessionId = takePendingWelcomeSession();
+    if (welcomeSessionId) {
+      openNew({ type: "sessions", id: welcomeSessionId });
+    }
+  }, [openNew]);
+
   useDesktopTabLifecycle({
     onEmpty: openDefaultEmptyTab,
+    onInitialized: openPendingWelcomeTab,
     onZeroTabs: openDefaultEmptyTab,
   });
 }

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -6,6 +6,10 @@ import { commands as openerCommands } from "@hypr/plugin-opener2";
 import { commands as sfxCommands } from "@hypr/plugin-sfx";
 
 import { OnboardingButton } from "./shared";
+import {
+  getOrCreateWelcomeSession,
+  setPendingWelcomeSession,
+} from "./welcome-note";
 
 import { flushAutomaticRelaunch } from "~/shared/relaunch";
 import { commands } from "~/types/tauri.gen";
@@ -57,7 +61,11 @@ export function FinalDescription() {
   );
 }
 
-export function FinalSection({ onContinue }: { onContinue: () => void }) {
+export function FinalSection({
+  onContinue,
+}: {
+  onContinue: (sessionId: string) => void;
+}) {
   return (
     <OnboardingButton
       className="px-6 py-2 text-sm"
@@ -68,14 +76,19 @@ export function FinalSection({ onContinue }: { onContinue: () => void }) {
   );
 }
 
-export async function finishOnboarding(onContinue?: () => void) {
+export async function finishOnboarding(
+  onContinue?: (sessionId: string) => void,
+) {
   await sfxCommands.stop("BGM").catch(console.error);
+  const welcomeSessionId = await getOrCreateWelcomeSession();
   await new Promise((resolve) => setTimeout(resolve, 100));
   await commands.setOnboardingNeeded(false).catch(console.error);
   await new Promise((resolve) => setTimeout(resolve, 100));
   await analyticsCommands.event({ event: "onboarding_completed" });
+  setPendingWelcomeSession(welcomeSessionId);
   if (await flushAutomaticRelaunch()) {
     return;
   }
-  onContinue?.();
+  setPendingWelcomeSession(null);
+  onContinue?.(welcomeSessionId);
 }

--- a/apps/desktop/src/onboarding/index.tsx
+++ b/apps/desktop/src/onboarding/index.tsx
@@ -31,19 +31,23 @@ export function TabContentOnboarding({
 }: {
   tab: Extract<Tab, { type: "onboarding" }>;
 }) {
-  const close = useTabs((state) => state.close);
-  const currentTab = useTabs((state) => state.currentTab);
+  const openCurrent = useTabs((state) => state.openCurrent);
 
-  const handleFinish = useCallback(() => {
-    if (currentTab) {
-      close(currentTab);
-    }
-  }, [close, currentTab]);
+  const handleFinish = useCallback(
+    (sessionId: string) => {
+      openCurrent({ type: "sessions", id: sessionId });
+    },
+    [openCurrent],
+  );
 
   return <OnboardingScreen onFinish={handleFinish} />;
 }
 
-function OnboardingScreen({ onFinish }: { onFinish: () => void }) {
+function OnboardingScreen({
+  onFinish,
+}: {
+  onFinish: (sessionId: string) => void;
+}) {
   return (
     <OnboardingScreenContent
       onFinish={onFinish}
@@ -56,7 +60,7 @@ function OnboardingScreen({ onFinish }: { onFinish: () => void }) {
 export function StandaloneOnboardingScreen({
   onFinish,
 }: {
-  onFinish: () => void;
+  onFinish: (sessionId: string) => void;
 }) {
   return (
     <StandaloneWindowShell>
@@ -74,7 +78,7 @@ function OnboardingScreenContent({
   headerClassName,
   headerDragRegion = false,
 }: {
-  onFinish: () => void;
+  onFinish: (sessionId: string) => void;
   headerClassName: string;
   headerDragRegion?: boolean;
 }) {
@@ -129,10 +133,13 @@ function OnboardingScreenContent({
     }
   }, []);
 
-  const handleFinish = useCallback(() => {
-    void queryClient.invalidateQueries({ queryKey: ["onboarding-needed"] });
-    onFinish();
-  }, [onFinish, queryClient]);
+  const handleFinish = useCallback(
+    (sessionId: string) => {
+      void queryClient.invalidateQueries({ queryKey: ["onboarding-needed"] });
+      onFinish(sessionId);
+    },
+    [onFinish, queryClient],
+  );
 
   return (
     <div className="bg-card relative flex h-full min-h-0 flex-col overflow-hidden">

--- a/apps/desktop/src/onboarding/welcome-note.test.ts
+++ b/apps/desktop/src/onboarding/welcome-note.test.ts
@@ -1,0 +1,59 @@
+import { beforeEach, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  createSession: vi.fn(),
+  execute: vi.fn(),
+}));
+
+vi.mock("~/db", () => ({
+  liveQueryClient: { execute: mocks.execute },
+}));
+
+vi.mock("~/session/queries", () => ({
+  createSession: mocks.createSession,
+}));
+
+import {
+  getOrCreateWelcomeSession,
+  setPendingWelcomeSession,
+  takePendingWelcomeSession,
+} from "./welcome-note";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  const values = new Map<string, string>();
+  vi.stubGlobal("localStorage", {
+    getItem: (key: string) => values.get(key) ?? null,
+    removeItem: (key: string) => values.delete(key),
+    setItem: (key: string, value: string) => values.set(key, value),
+  });
+});
+
+it("reuses an existing onboarding welcome note", async () => {
+  mocks.execute.mockResolvedValueOnce([{ id: "welcome-session" }]);
+
+  await expect(getOrCreateWelcomeSession()).resolves.toBe("welcome-session");
+  expect(mocks.createSession).not.toHaveBeenCalled();
+});
+
+it("creates a prerecorded demo note with normal meeting metadata", async () => {
+  mocks.execute.mockResolvedValueOnce([]);
+  mocks.createSession.mockResolvedValueOnce("welcome-session");
+
+  await expect(getOrCreateWelcomeSession()).resolves.toBe("welcome-session");
+
+  const [title, , initial] = mocks.createSession.mock.calls[0];
+  const event = JSON.parse(initial.event_json);
+  expect(title).toBe("Welcome to Anarlog");
+  expect(event.meeting_link).toBe("https://anarlog.so/onboarding-demo/");
+  expect(event.tracking_id).toBe("anarlog-onboarding-demo-v1");
+  expect(initial.raw_md).toContain("prerecorded demo meeting");
+  expect(initial.raw_md).toContain("Join & record");
+});
+
+it("carries the welcome note across a one-time onboarding relaunch", () => {
+  setPendingWelcomeSession("welcome-session");
+
+  expect(takePendingWelcomeSession()).toBe("welcome-session");
+  expect(takePendingWelcomeSession()).toBeNull();
+});

--- a/apps/desktop/src/onboarding/welcome-note.ts
+++ b/apps/desktop/src/onboarding/welcome-note.ts
@@ -1,0 +1,77 @@
+import { md2json } from "@hypr/editor/markdown";
+import type { SessionEvent } from "@hypr/store";
+
+import { liveQueryClient } from "~/db";
+import { createSession } from "~/session/queries";
+import { DEFAULT_USER_ID } from "~/shared/utils";
+
+const DEMO_URL = "https://anarlog.so/onboarding-demo/";
+const PENDING_WELCOME_SESSION_KEY = "anarlog.pending-welcome-session";
+const TRACKING_ID = "anarlog-onboarding-demo-v1";
+
+const WELCOME_NOTE = `Welcome to Anarlog 👋
+
+This note is a quick way to see how Anarlog works.
+
+Click **Join & record** in the top-right corner. It will open a private, prerecorded demo meeting, so you don't have to worry about your camera or microphone. Anarlog will listen, transcribe the conversation, and turn it into notes just like a real meeting.
+
+When the video ends, come back here to review the transcript and notes.`;
+
+let pendingWelcomeSession: Promise<string> | null = null;
+
+export function getOrCreateWelcomeSession(): Promise<string> {
+  if (!pendingWelcomeSession) {
+    pendingWelcomeSession = findOrCreateWelcomeSession().finally(() => {
+      pendingWelcomeSession = null;
+    });
+  }
+  return pendingWelcomeSession;
+}
+
+export function setPendingWelcomeSession(sessionId: string | null) {
+  if (sessionId) {
+    localStorage.setItem(PENDING_WELCOME_SESSION_KEY, sessionId);
+  } else {
+    localStorage.removeItem(PENDING_WELCOME_SESSION_KEY);
+  }
+}
+
+export function takePendingWelcomeSession(): string | null {
+  const sessionId = localStorage.getItem(PENDING_WELCOME_SESSION_KEY);
+  localStorage.removeItem(PENDING_WELCOME_SESSION_KEY);
+  return sessionId;
+}
+
+async function findOrCreateWelcomeSession(): Promise<string> {
+  const rows = await liveQueryClient.execute<{ id: string }>(
+    `
+      SELECT id
+      FROM sessions
+      WHERE owner_user_id = ?
+        AND deleted_at IS NULL
+        AND json_extract(event_json, '$.tracking_id') = ?
+      ORDER BY created_at, id
+      LIMIT 1
+    `,
+    [DEFAULT_USER_ID, TRACKING_ID],
+  );
+  if (rows[0]) return rows[0].id;
+
+  const now = new Date().toISOString();
+  const event: SessionEvent = {
+    tracking_id: TRACKING_ID,
+    calendar_id: "",
+    title: "Welcome to Anarlog",
+    started_at: now,
+    ended_at: "",
+    is_all_day: false,
+    has_recurrence_rules: false,
+    meeting_link: DEMO_URL,
+    description: "A private, prerecorded introduction to Anarlog.",
+  };
+
+  return createSession("Welcome to Anarlog", DEFAULT_USER_ID, {
+    event_json: JSON.stringify(event),
+    raw_md: JSON.stringify(md2json(WELCOME_NOTE)),
+  });
+}

--- a/apps/desktop/src/routes/app/onboarding.tsx
+++ b/apps/desktop/src/routes/app/onboarding.tsx
@@ -4,6 +4,7 @@ import { useCallback } from "react";
 import { resolveShellEntryPath } from "./-resolve-entry-path";
 
 import { StandaloneOnboardingScreen } from "~/onboarding";
+import { useTabs } from "~/store/zustand/tabs";
 
 export const Route = createFileRoute("/app/onboarding")({
   component: Component,
@@ -11,12 +12,17 @@ export const Route = createFileRoute("/app/onboarding")({
 
 function Component() {
   const navigate = useNavigate();
+  const openCurrent = useTabs((state) => state.openCurrent);
 
-  const handleFinish = useCallback(() => {
-    void (async () => {
-      await navigate({ to: await resolveShellEntryPath() });
-    })();
-  }, [navigate]);
+  const handleFinish = useCallback(
+    (sessionId: string) => {
+      openCurrent({ type: "sessions", id: sessionId });
+      void (async () => {
+        await navigate({ to: await resolveShellEntryPath() });
+      })();
+    },
+    [navigate, openCurrent],
+  );
 
   return <StandaloneOnboardingScreen onFinish={handleFinish} />;
 }

--- a/apps/desktop/src/session/queries.test.ts
+++ b/apps/desktop/src/session/queries.test.ts
@@ -29,6 +29,7 @@ vi.mock("~/db", () => ({
 import {
   addSessionParticipant,
   buildSessionTombstoneStatements,
+  createSession,
   deleteEnhancedNote,
   getOrCreateSessionForEventId,
   isSessionEmpty,
@@ -109,6 +110,22 @@ describe("session SQLite operations", () => {
     expect(statements).toHaveLength(2);
     expect(statements[0].sql).toContain("UPDATE sessions");
     expect(statements[0].params).toContain("Updated title");
+    expect(statements[1].sql).toContain("session_documents");
+    expect(statements[1].params).toContain('{"type":"doc"}');
+  });
+
+  it("creates a session with its initial event and note content atomically", async () => {
+    await createSession("Welcome", "user-1", {
+      event_json: '{"tracking_id":"welcome"}',
+      raw_md: '{"type":"doc"}',
+    });
+
+    const statements = mocks.executeTransaction.mock.calls[0][0] as Array<{
+      sql: string;
+      params: unknown[];
+    }>;
+    expect(statements[0].sql).toContain("event_json");
+    expect(statements[0].params).toContain('{"tracking_id":"welcome"}');
     expect(statements[1].sql).toContain("session_documents");
     expect(statements[1].params).toContain('{"type":"doc"}');
   });

--- a/apps/desktop/src/session/queries.ts
+++ b/apps/desktop/src/session/queries.ts
@@ -588,6 +588,7 @@ export function updateSession(
 export async function createSession(
   title = "",
   userId = DEFAULT_USER_ID,
+  initial?: Pick<SessionChanges, "event_json" | "raw_md">,
 ): Promise<string> {
   const sessionId = id();
   const participantId = id();
@@ -597,12 +598,19 @@ export async function createSession(
     {
       sql: `
         INSERT INTO sessions (
-          id, owner_user_id, title, created_at, updated_at, deleted_at
-        ) VALUES (?, ?, ?, ?, ?, NULL)
+          id, owner_user_id, title, event_json, created_at, updated_at,
+          deleted_at
+        ) VALUES (?, ?, ?, ?, ?, ?, NULL)
       `,
-      params: [sessionId, userId, title, now, now],
+      params: [sessionId, userId, title, initial?.event_json ?? "", now, now],
     },
-    createEmptyNoteStatement(sessionId, userId, now),
+    createEmptyNoteStatement(
+      sessionId,
+      userId,
+      now,
+      false,
+      initial?.raw_md ?? "",
+    ),
     {
       sql: `
         INSERT INTO humans (id, owner_user_id, updated_at, deleted_at)
@@ -943,6 +951,7 @@ function createEmptyNoteStatement(
   userId: string,
   now: string,
   onlyIfSessionExists = false,
+  body = "",
 ) {
   return {
     sql: `
@@ -950,12 +959,12 @@ function createEmptyNoteStatement(
         id, session_id, kind, body_format, body, created_by, updated_by,
         created_at, updated_at, deleted_at
       )
-      ${onlyIfSessionExists ? "SELECT ?, ?, 'note', 'prosemirror_json', '', ?, ?, ?, ?, NULL" : "VALUES (?, ?, 'note', 'prosemirror_json', '', ?, ?, ?, ?, NULL)"}
+      ${onlyIfSessionExists ? "SELECT ?, ?, 'note', 'prosemirror_json', ?, ?, ?, ?, ?, NULL" : "VALUES (?, ?, 'note', 'prosemirror_json', ?, ?, ?, ?, ?, NULL)"}
       ${onlyIfSessionExists ? "WHERE EXISTS (SELECT 1 FROM sessions WHERE id = ? AND deleted_at IS NULL)" : ""}
     `,
     params: onlyIfSessionExists
-      ? [sessionId, sessionId, userId, userId, now, now, sessionId]
-      : [sessionId, sessionId, userId, userId, now, now],
+      ? [sessionId, sessionId, body, userId, userId, now, now, sessionId]
+      : [sessionId, sessionId, body, userId, userId, now, now],
   };
 }
 

--- a/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.test.ts
@@ -75,6 +75,25 @@ describe("desktop tab lifecycle", () => {
       expect(openNew).not.toHaveBeenCalled();
       expect(onZeroTabs).toHaveBeenCalledTimes(1);
     });
+
+    it("runs startup work even when pinned tabs were restored", async () => {
+      const tabs = [createSessionTab({ id: "restored-session" })];
+      const onInitialized = vi.fn();
+      const onZeroTabs = vi.fn();
+
+      await initializeDesktopTabs({
+        getTabs: () => tabs,
+        setRecentlyOpenedSessionIds: vi.fn(),
+        restorePinnedTabs: vi.fn().mockResolvedValue(undefined),
+        restoreRecentlyOpenedSessionIds: vi.fn().mockResolvedValue(undefined),
+        onInitialized,
+        onZeroTabs,
+        isTauriEnv: true,
+      });
+
+      expect(onInitialized).toHaveBeenCalledTimes(1);
+      expect(onZeroTabs).not.toHaveBeenCalled();
+    });
   });
 
   describe("createSessionTabCloseHandler", () => {

--- a/apps/desktop/src/shared/desktop-tab-lifecycle.ts
+++ b/apps/desktop/src/shared/desktop-tab-lifecycle.ts
@@ -17,6 +17,7 @@ type InitializeDesktopTabsOptions = {
   restoreRecentlyOpenedSessionIds: (
     set: (ids: string[]) => void,
   ) => Promise<void>;
+  onInitialized?: (() => void) | null;
   onZeroTabs?: (() => void) | null;
   isTauriEnv?: boolean;
 };
@@ -33,6 +34,7 @@ export async function initializeDesktopTabs({
   setRecentlyOpenedSessionIds,
   restorePinnedTabs,
   restoreRecentlyOpenedSessionIds,
+  onInitialized,
   onZeroTabs,
   isTauriEnv = isTauri(),
 }: InitializeDesktopTabsOptions) {
@@ -43,6 +45,7 @@ export async function initializeDesktopTabs({
 
   await restorePinnedTabs();
   await restoreRecentlyOpenedSessionIds(setRecentlyOpenedSessionIds);
+  onInitialized?.();
 
   if (getTabs().length > 0) {
     return;
@@ -86,9 +89,11 @@ export function createSessionTabCloseHandler({
 
 export function useDesktopTabLifecycle({
   onEmpty,
+  onInitialized,
   onZeroTabs,
 }: {
   onEmpty?: (() => void) | null;
+  onInitialized?: (() => void) | null;
   onZeroTabs?: (() => void) | null;
 }) {
   const { registerOnEmpty, registerCanClose, registerOnClose, openNew, pin } =
@@ -110,9 +115,10 @@ export function useDesktopTabLifecycle({
       restorePinnedTabs: () =>
         restorePinnedTabsToStore(openNew, pin, () => useTabs.getState().tabs),
       restoreRecentlyOpenedSessionIds: restoreRecentlyOpenedToStore,
+      onInitialized,
       onZeroTabs,
     });
-  }, [openNew, pin, onZeroTabs]);
+  }, [onInitialized, openNew, pin, onZeroTabs]);
 
   useEffect(() => {
     registerOnEmpty(onEmpty ?? null);


### PR DESCRIPTION
Create a prerecorded demo session and open it after normal completion or an onboarding relaunch.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Onboarding and tab-routing UX changes with localized session creation; no auth or sensitive data path changes beyond existing local SQLite sessions.
> 
> **Overview**
> After onboarding finishes, the app **creates or reuses** a “Welcome to Anarlog” session (identified by `anarlog-onboarding-demo-v1`) with intro note copy and a **prerecorded demo** meeting link, then **opens that session** instead of only closing onboarding or landing on an empty shell.
> 
> **Completion paths:** In-tab onboarding and the standalone route now pass a `sessionId` into `onFinish` and switch the current tab to `{ type: "sessions", id }`. `finishOnboarding` stores the session id in **localStorage** when an automatic relaunch may run; on a normal exit it clears that stash and invokes the callback with the id. Main lifecycle **`onInitialized`** reads the pending id once (after pinned/recent tab restore) and opens a welcome session tab so relaunch still lands on the demo note.
> 
> **Data layer:** `createSession` accepts optional initial `event_json` and `raw_md` so the welcome note is inserted **atomically** with the session row. Desktop tab startup always runs **`onInitialized`** even when restored tabs exist, so pending welcome isn’t skipped.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ee0c8b8cf1803143528899241dd3ea36238cf93. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->