### PR TITLE
Reduce editor compositor work

### DIFF
--- a/apps/desktop/src/session/components/note-input/audio-drop-target.tsx
+++ b/apps/desktop/src/session/components/note-input/audio-drop-target.tsx
@@ -25,7 +25,7 @@ export function AudioDropTarget({
           role="status"
           className={cn([
             "pointer-events-none absolute inset-0 z-30 flex items-center justify-center rounded-lg border border-dashed",
-            "border-border/70 bg-background/90 text-muted-foreground dark:bg-background/85 shadow-inner backdrop-blur-[1px]",
+            "border-border/70 bg-background text-muted-foreground shadow-inner",
             "[background-image:radial-gradient(circle_at_center,_rgba(113,113,122,0.34)_1px,_transparent_1px)]",
             "[background-size:18px_18px]",
           ])}

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -317,7 +317,7 @@ const NoteInputContent = forwardRef<
               "pt-2",
               renderedCurrentTab.type === "transcript"
                 ? "overflow-hidden pb-0"
-                : "scroll-fade-y overflow-auto pb-6",
+                : "overflow-auto pb-6",
             ])}
           >
             {renderedCurrentTab.type === "enhanced" && (

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -235,6 +235,7 @@ describe("RawEditor", () => {
     expect(
       screen.getByText("Drop to upload and transcribe audio"),
     ).not.toBeNull();
+    expect(screen.getByRole("status").className).not.toContain("backdrop-blur");
     expect(
       screen.getByText("WAV, MP3, OGG, MP4, M4A, FLAC, WEBM, or AAC audio"),
     ).not.toBeNull();


### PR DESCRIPTION
Remove the full editor scroll mask and drag-overlay backdrop filter while preserving editor focus and audio drop behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only CSS changes in the note editor and audio drop UI; behavior is guarded by an existing overlay test.
> 
> **Overview**
> Cuts expensive compositing on the session note editor by dropping the **`scroll-fade-y`** scroll mask on non-transcript tabs and simplifying the audio drag overlay styling.
> 
> The note input scroll area now uses plain **`overflow-auto`** instead of the fade mask. The active audio drop **`role="status"`** overlay uses a solid **`bg-background`** and no longer applies **`backdrop-blur`** or layered translucent backgrounds. A test in **`raw.test.tsx`** asserts the overlay does not include **`backdrop-blur`** while existing drag/drop and window-focus behavior stay the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0fe4d4a394937fa51827141720ff6debd81d78b2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->