### PR TITLE
Complete core CloudSync integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4815,6 +4815,7 @@ version = "0.0.0"
 dependencies = [
  "audio-actual",
  "audio-mock",
+ "db-app",
  "db-core",
  "dirs 6.0.0",
  "host",
@@ -18147,6 +18148,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tracing",
  "uuid",
 ]
 

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -86,6 +86,7 @@ tauri-plugin-windows = { workspace = true }
 
 hypr-audio-actual = { workspace = true }
 hypr-audio-mock = { workspace = true, optional = true }
+hypr-db-app = { workspace = true }
 hypr-db-core = { workspace = true }
 hypr-host = { workspace = true }
 hypr-storage = { workspace = true }

--- a/apps/desktop/src-tauri/src/db.rs
+++ b/apps/desktop/src-tauri/src/db.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 use hypr_db_core::Db;
 
 const DB_FILENAME: &str = "app.db";
+const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
 
 pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
     let db_path = desktop_db_dir(identifier).map(|dir| {
@@ -15,6 +16,69 @@ pub async fn open_desktop_db(identifier: &str) -> Arc<Db> {
         .expect("failed to open app database");
 
     Arc::new(db)
+}
+
+pub fn cloudsync_runtime_config_from_env()
+-> Result<Option<hypr_db_core::CloudsyncRuntimeConfig>, String> {
+    cloudsync_runtime_config(|key| std::env::var(key).ok())
+}
+
+fn cloudsync_runtime_config(
+    get: impl Fn(&str) -> Option<String>,
+) -> Result<Option<hypr_db_core::CloudsyncRuntimeConfig>, String> {
+    let database_id = get("ANARLOG_CLOUDSYNC_DATABASE_ID").and_then(nonempty);
+    let api_key = get("ANARLOG_CLOUDSYNC_API_KEY").and_then(nonempty);
+    let token = get("ANARLOG_CLOUDSYNC_TOKEN").and_then(nonempty);
+
+    if database_id.is_none() && api_key.is_none() && token.is_none() {
+        return Ok(None);
+    }
+
+    let database_id = database_id.ok_or_else(|| {
+        "ANARLOG_CLOUDSYNC_DATABASE_ID is required when CloudSync auth is configured".to_string()
+    })?;
+    let auth = match (api_key, token) {
+        (Some(api_key), None) => hypr_db_core::CloudsyncAuth::ApiKey { api_key },
+        (None, Some(token)) => hypr_db_core::CloudsyncAuth::Token { token },
+        (None, None) => {
+            return Err(
+                "ANARLOG_CLOUDSYNC_API_KEY or ANARLOG_CLOUDSYNC_TOKEN is required".to_string(),
+            );
+        }
+        (Some(_), Some(_)) => {
+            return Err(
+                "configure only one of ANARLOG_CLOUDSYNC_API_KEY or ANARLOG_CLOUDSYNC_TOKEN"
+                    .to_string(),
+            );
+        }
+    };
+    let sync_interval_ms = get("ANARLOG_CLOUDSYNC_INTERVAL_MS")
+        .and_then(nonempty)
+        .map(|value| {
+            value
+                .parse::<u64>()
+                .ok()
+                .filter(|value| *value > 0)
+                .ok_or_else(|| {
+                    "ANARLOG_CLOUDSYNC_INTERVAL_MS must be a positive integer".to_string()
+                })
+        })
+        .transpose()?
+        .unwrap_or(DEFAULT_CLOUDSYNC_INTERVAL_MS);
+
+    Ok(Some(hypr_db_core::CloudsyncRuntimeConfig {
+        connection_string: database_id,
+        auth,
+        tables: hypr_db_app::cloudsync_table_registry().to_vec(),
+        sync_interval_ms,
+        wait_ms: Some(5_000),
+        max_retries: Some(3),
+    }))
+}
+
+fn nonempty(value: String) -> Option<String> {
+    let value = value.trim();
+    (!value.is_empty()).then(|| value.to_string())
 }
 
 fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
@@ -33,11 +97,67 @@ fn desktop_db_dir(identifier: &str) -> Option<std::path::PathBuf> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::collections::HashMap;
 
     #[test]
     fn dev_uses_an_isolated_persistent_database() {
         let db_dir = desktop_db_dir("com.hyprnote.dev").unwrap();
 
         assert!(db_dir.ends_with("com.hyprnote.dev"));
+    }
+
+    #[test]
+    fn cloudsync_is_inert_without_environment_config() {
+        let config = cloudsync_runtime_config(|_| None).unwrap();
+
+        assert!(config.is_none());
+    }
+
+    #[test]
+    fn cloudsync_environment_config_enables_only_core_tables() {
+        let values = HashMap::from([
+            (
+                "ANARLOG_CLOUDSYNC_DATABASE_ID",
+                "managed-database-id".to_string(),
+            ),
+            ("ANARLOG_CLOUDSYNC_TOKEN", "token".to_string()),
+            ("ANARLOG_CLOUDSYNC_INTERVAL_MS", "15000".to_string()),
+        ]);
+
+        let config = cloudsync_runtime_config(|key| values.get(key).cloned())
+            .unwrap()
+            .unwrap();
+        let enabled: Vec<&str> = config
+            .tables
+            .iter()
+            .filter(|table| table.enabled)
+            .map(|table| table.table_name.as_str())
+            .collect();
+
+        assert_eq!(config.connection_string, "managed-database-id");
+        assert_eq!(config.sync_interval_ms, 15_000);
+        assert!(matches!(
+            config.auth,
+            hypr_db_core::CloudsyncAuth::Token { .. }
+        ));
+        assert_eq!(enabled.len(), 8);
+        assert!(enabled.contains(&"sessions"));
+        assert!(!enabled.contains(&"calendars"));
+    }
+
+    #[test]
+    fn cloudsync_environment_rejects_multiple_credentials() {
+        let values = HashMap::from([
+            (
+                "ANARLOG_CLOUDSYNC_DATABASE_ID",
+                "managed-database-id".to_string(),
+            ),
+            ("ANARLOG_CLOUDSYNC_API_KEY", "api-key".to_string()),
+            ("ANARLOG_CLOUDSYNC_TOKEN", "token".to_string()),
+        ]);
+
+        let error = cloudsync_runtime_config(|key| values.get(key).cloned()).unwrap_err();
+
+        assert!(error.contains("only one"));
     }
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,7 +6,7 @@ mod ext;
 mod store;
 mod supervisor;
 
-use db::open_desktop_db;
+use db::{cloudsync_runtime_config_from_env, open_desktop_db};
 use ext::*;
 use store::*;
 
@@ -106,6 +106,8 @@ pub async fn main() {
         create_audio_provider(&context.config().identifier);
 
     let db = open_desktop_db(&context.config().identifier).await;
+    let cloudsync_config =
+        cloudsync_runtime_config_from_env().expect("invalid CloudSync environment configuration");
 
     let mut builder = tauri_plugin_windows::extend_builder(tauri::Builder::default())
         .manage(audio)
@@ -132,7 +134,10 @@ pub async fn main() {
         .plugin(tauri_plugin_tracing::init())
         .plugin(tauri_plugin_analytics::init())
         .plugin(tauri_plugin_agent::init())
-        .plugin(tauri_plugin_db::init(db.clone()))
+        .plugin(tauri_plugin_db::init_with_cloudsync(
+            db.clone(),
+            cloudsync_config,
+        ))
         .plugin(tauri_plugin_bedrock::init())
         .plugin(tauri_plugin_importer::init())
         .plugin(tauri_plugin_calendar::init())

--- a/crates/db-app/Cargo.toml
+++ b/crates/db-app/Cargo.toml
@@ -15,4 +15,4 @@ default = []
 cli = []
 
 [dev-dependencies]
-tokio = { workspace = true, features = ["rt", "macros"] }
+tokio = { workspace = true, features = ["rt", "macros", "time"] }

--- a/crates/db-app/src/cloudsync.rs
+++ b/crates/db-app/src/cloudsync.rs
@@ -4,30 +4,30 @@ use hypr_db_core::CloudsyncTableSpec;
 
 static CLOUDSYNC_TABLE_REGISTRY: LazyLock<Vec<CloudsyncTableSpec>> = LazyLock::new(|| {
     [
-        "action_items",
-        "calendars",
-        "chat_groups",
-        "chat_messages",
-        "daily_notes",
-        "entity_mentions",
-        "events",
-        "humans",
-        "organizations",
-        "session_attachments",
-        "session_documents",
-        "session_participants",
-        "session_tags",
-        "sessions",
-        "tags",
-        "templates",
-        "transcripts",
+        ("action_items", true),
+        ("calendars", false),
+        ("chat_groups", false),
+        ("chat_messages", false),
+        ("daily_notes", false),
+        ("entity_mentions", false),
+        ("events", false),
+        ("humans", true),
+        ("organizations", true),
+        ("session_attachments", true),
+        ("session_documents", true),
+        ("session_participants", true),
+        ("session_tags", false),
+        ("sessions", true),
+        ("tags", false),
+        ("templates", false),
+        ("transcripts", true),
     ]
     .into_iter()
-    .map(|table_name| CloudsyncTableSpec {
+    .map(|(table_name, enabled)| CloudsyncTableSpec {
         table_name: table_name.to_string(),
         crdt_algo: None,
         init_flags: None,
-        enabled: false,
+        enabled,
     })
     .collect()
 });

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -402,23 +402,35 @@ mod tests {
     }
 
     #[test]
-    fn cloudsync_registry_declares_domain_tables_disabled_until_sync_rollout() {
+    fn cloudsync_registry_enables_only_the_initial_meeting_slice() {
         let registry = cloudsync_table_registry();
+        let enabled: Vec<&str> = registry
+            .iter()
+            .filter(|table| table.enabled)
+            .map(|table| table.table_name.as_str())
+            .collect();
 
         assert_eq!(registry.len(), 17);
-        assert!(registry.iter().all(|table| !table.enabled));
-        assert!(registry.iter().any(|table| table.table_name == "sessions"));
-        assert!(
-            registry
-                .iter()
-                .any(|table| table.table_name == "session_documents")
+        assert_eq!(
+            enabled,
+            vec![
+                "action_items",
+                "humans",
+                "organizations",
+                "session_attachments",
+                "session_documents",
+                "session_participants",
+                "sessions",
+                "transcripts",
+            ]
         );
         assert!(
             !registry
                 .iter()
                 .any(|table| table.table_name == "migration_import_runs")
         );
-        assert!(!cloudsync_alter_guard_required("sessions"));
+        assert!(cloudsync_alter_guard_required("sessions"));
+        assert!(!cloudsync_alter_guard_required("calendars"));
     }
 
     #[tokio::test]

--- a/crates/db-app/tests/cloudsync.rs
+++ b/crates/db-app/tests/cloudsync.rs
@@ -1,0 +1,100 @@
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+use db_app::{cloudsync_table_registry, prepare_schema};
+use hypr_db_core::{CloudsyncAuth, CloudsyncRuntimeConfig, Db, DbOpenOptions, DbStorage};
+
+const SYNC_TIMEOUT: Duration = Duration::from_secs(90);
+
+fn cloudsync_config() -> CloudsyncRuntimeConfig {
+    CloudsyncRuntimeConfig {
+        connection_string: std::env::var("ANARLOG_CLOUDSYNC_DATABASE_ID")
+            .expect("ANARLOG_CLOUDSYNC_DATABASE_ID must be set"),
+        auth: CloudsyncAuth::ApiKey {
+            api_key: std::env::var("ANARLOG_CLOUDSYNC_API_KEY")
+                .expect("ANARLOG_CLOUDSYNC_API_KEY must be set"),
+        },
+        tables: cloudsync_table_registry().to_vec(),
+        sync_interval_ms: 300_000,
+        wait_ms: Some(5_000),
+        max_retries: Some(3),
+    }
+}
+
+async fn setup_db() -> Db {
+    let db = Db::open(DbOpenOptions {
+        storage: DbStorage::Memory,
+        cloudsync_enabled: true,
+        journal_mode_wal: true,
+        foreign_keys: true,
+        max_connections: Some(1),
+    })
+    .await
+    .unwrap();
+
+    prepare_schema(&db).await.unwrap();
+    db.cloudsync_configure(cloudsync_config()).unwrap();
+    tokio::time::timeout(Duration::from_secs(15), db.cloudsync_start())
+        .await
+        .expect("cloudsync start timed out")
+        .unwrap();
+    db
+}
+
+#[tokio::test]
+#[ignore = "external verification only; requires the anarlog-dev SQLite Cloud credentials"]
+async fn core_session_syncs_between_two_clients() {
+    let marker = format!(
+        "anarlog-cloudsync-e2e-{}",
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos()
+    );
+    let db_a = setup_db().await;
+
+    sqlx::query("INSERT INTO sessions (id, title) VALUES (cloudsync_uuid(), ?)")
+        .bind(&marker)
+        .execute(db_a.pool())
+        .await
+        .unwrap();
+    tokio::time::timeout(SYNC_TIMEOUT, db_a.cloudsync_trigger_sync())
+        .await
+        .expect("first client sync timed out")
+        .unwrap();
+
+    let db_b = setup_db().await;
+    for _ in 0..2 {
+        tokio::time::timeout(SYNC_TIMEOUT, db_b.cloudsync_trigger_sync())
+            .await
+            .expect("second client sync timed out")
+            .unwrap();
+    }
+
+    let title: Option<String> =
+        sqlx::query_scalar("SELECT title FROM sessions WHERE title = ? LIMIT 1")
+            .bind(&marker)
+            .fetch_optional(db_b.pool())
+            .await
+            .unwrap();
+
+    assert_eq!(title.as_deref(), Some(marker.as_str()));
+
+    sqlx::query("DELETE FROM sessions WHERE title = ?")
+        .bind(&marker)
+        .execute(db_a.pool())
+        .await
+        .unwrap();
+    tokio::time::timeout(SYNC_TIMEOUT, db_a.cloudsync_trigger_sync())
+        .await
+        .expect("cleanup sync timed out")
+        .unwrap();
+
+    tokio::time::timeout(Duration::from_secs(15), db_a.cloudsync_stop())
+        .await
+        .expect("first client stop timed out")
+        .unwrap();
+    tokio::time::timeout(Duration::from_secs(15), db_b.cloudsync_stop())
+        .await
+        .expect("second client stop timed out")
+        .unwrap();
+}

--- a/crates/db-core/src/cloudsync/runtime.rs
+++ b/crates/db-core/src/cloudsync/runtime.rs
@@ -113,20 +113,7 @@ impl Db {
     }
 
     pub async fn cloudsync_stop(&self) -> Result<(), CloudsyncRuntimeError> {
-        let (task, should_cleanup) = {
-            let mut runtime = self.cloudsync_runtime.lock().unwrap();
-            runtime.running = false;
-            let should_cleanup = runtime.network_initialized;
-            runtime.network_initialized = false;
-            (runtime.task.take(), should_cleanup)
-        };
-
-        if let Some(mut task) = task {
-            if let Some(shutdown_tx) = task.shutdown_tx.take() {
-                let _ = shutdown_tx.send(());
-            }
-            let _ = task.join_handle.await;
-        }
+        let should_cleanup = self.stop_cloudsync_task().await;
 
         if !self.cloudsync_enabled {
             let mut runtime = self.cloudsync_runtime.lock().unwrap();
@@ -148,6 +135,41 @@ impl Db {
         let mut runtime = self.cloudsync_runtime.lock().unwrap();
         runtime.network_initialized = false;
         runtime.last_error = None;
+        Ok(())
+    }
+
+    pub async fn cloudsync_logout(
+        &self,
+        discard_unsent_changes: bool,
+    ) -> Result<(), CloudsyncRuntimeError> {
+        let network_initialized = self.stop_cloudsync_task().await;
+
+        if !self.cloudsync_enabled || !network_initialized {
+            self.cloudsync_runtime.lock().unwrap().config = None;
+            return Ok(());
+        }
+
+        let sync_lock = self.cloudsync_runtime.lock().unwrap().sync_lock.clone();
+        let _sync_guard = sync_lock.lock().await;
+        let has_unsent_changes = self.cloudsync_network_has_unsent_changes().await?;
+        if has_unsent_changes && !discard_unsent_changes {
+            return Err(CloudsyncRuntimeError::UnsentChanges);
+        }
+
+        self.cloudsync_network_logout().await?;
+        self.cloudsync_network_cleanup().await?;
+        if self.has_cloudsync() {
+            self.cloudsync_terminate().await?;
+        }
+
+        let mut runtime = self.cloudsync_runtime.lock().unwrap();
+        runtime.config = None;
+        runtime.network_initialized = false;
+        runtime.last_sync = None;
+        runtime.last_sync_at_ms = None;
+        runtime.last_error = None;
+        runtime.last_error_kind = None;
+        runtime.consecutive_failures = 0;
         Ok(())
     }
 
@@ -220,9 +242,33 @@ impl Db {
             return Err(CloudsyncRuntimeError::NotStarted);
         }
 
-        let result = hypr_cloudsync::network_sync(&self.pool, wait_ms, max_retries).await?;
-        record_sync_result(&self.cloudsync_runtime, result.clone());
-        Ok(result)
+        match hypr_cloudsync::network_sync(&self.pool, wait_ms, max_retries).await {
+            Ok(result) => {
+                record_sync_result(&self.cloudsync_runtime, result.clone());
+                Ok(result)
+            }
+            Err(error) => {
+                record_sync_error(&self.cloudsync_runtime, &error);
+                Err(error.into())
+            }
+        }
+    }
+
+    async fn stop_cloudsync_task(&self) -> bool {
+        let (task, network_initialized) = {
+            let mut runtime = self.cloudsync_runtime.lock().unwrap();
+            runtime.running = false;
+            (runtime.task.take(), runtime.network_initialized)
+        };
+
+        if let Some(mut task) = task {
+            if let Some(shutdown_tx) = task.shutdown_tx.take() {
+                let _ = shutdown_tx.send(());
+            }
+            let _ = task.join_handle.await;
+        }
+
+        network_initialized
     }
 }
 
@@ -233,6 +279,13 @@ fn record_sync_result(runtime: &Mutex<CloudsyncRuntimeState>, result: CloudsyncN
     runtime.last_error = None;
     runtime.last_error_kind = None;
     runtime.consecutive_failures = 0;
+}
+
+fn record_sync_error(runtime: &Mutex<CloudsyncRuntimeState>, error: &hypr_cloudsync::Error) {
+    let mut runtime = runtime.lock().unwrap();
+    runtime.consecutive_failures = runtime.consecutive_failures.saturating_add(1);
+    runtime.last_error = Some(error.to_string());
+    runtime.last_error_kind = Some(error.kind());
 }
 
 const MAX_BACKOFF_SECS: u64 = 300;

--- a/crates/db-core/src/cloudsync/types.rs
+++ b/crates/db-core/src/cloudsync/types.rs
@@ -61,6 +61,8 @@ pub enum CloudsyncRuntimeError {
     RestartRequired,
     #[error("cloudsync sync interval must be greater than 0")]
     InvalidSyncInterval,
+    #[error("cloudsync has unsent local changes; sync first or explicitly discard them")]
+    UnsentChanges,
     #[error(transparent)]
     Cloudsync(#[from] hypr_cloudsync::Error),
 }

--- a/crates/db-core/src/lib.rs
+++ b/crates/db-core/src/lib.rs
@@ -389,6 +389,8 @@ mod tests {
         assert!(!status.network_initialized);
         assert!(!status.cloudsync_enabled);
 
+        db.cloudsync_logout(false).await.unwrap();
+        assert!(!db.cloudsync_status().await.unwrap().configured);
         db.cloudsync_stop().await.unwrap();
     }
 

--- a/plugins/db/Cargo.toml
+++ b/plugins/db/Cargo.toml
@@ -28,6 +28,7 @@ tauri = { workspace = true, features = ["test"] }
 tauri-specta = { workspace = true, features = ["derive", "typescript"] }
 thiserror = { workspace = true }
 tokio = { workspace = true, features = ["sync"] }
+tracing = { workspace = true }
 uuid = { workspace = true, features = ["v4"] }
 
 [dev-dependencies]

--- a/plugins/db/build.rs
+++ b/plugins/db/build.rs
@@ -12,6 +12,12 @@ const COMMANDS: &[&str] = &[
     "run_legacy_import",
     "subscribe",
     "unsubscribe",
+    "configure_cloudsync",
+    "start_cloudsync",
+    "stop_cloudsync",
+    "get_cloudsync_status",
+    "sync_cloudsync_now",
+    "logout_cloudsync",
 ];
 
 fn main() {

--- a/plugins/db/js/bindings.gen.ts
+++ b/plugins/db/js/bindings.gen.ts
@@ -109,6 +109,54 @@ async unsubscribe(subscriptionId: string) : Promise<Result<null, string>> {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
 }
+},
+async configureCloudsync(configJson: string) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|configure_cloudsync", { configJson }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async startCloudsync() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|start_cloudsync") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async stopCloudsync() : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|stop_cloudsync") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async getCloudsyncStatus() : Promise<Result<JsonValue, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|get_cloudsync_status") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async syncCloudsyncNow() : Promise<Result<JsonValue, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|sync_cloudsync_now") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async logoutCloudsync(discardUnsentChanges: boolean) : Promise<Result<null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|logout_cloudsync", { discardUnsentChanges }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
 }
 }
 

--- a/plugins/db/js/index.ts
+++ b/plugins/db/js/index.ts
@@ -42,6 +42,56 @@ export type TransactionStatement = {
   expectedRowsAffected?: number;
 };
 
+export type CloudsyncAuth =
+  | { type: "none" }
+  | { type: "api_key"; api_key: string }
+  | { type: "token"; token: string };
+
+export type CloudsyncTableSpec = {
+  table_name: string;
+  crdt_algo?: string;
+  init_flags?: number;
+  enabled: boolean;
+};
+
+export type CloudsyncRuntimeConfig = {
+  connection_string: string;
+  auth: CloudsyncAuth;
+  tables: CloudsyncTableSpec[];
+  sync_interval_ms: number;
+  wait_ms?: number;
+  max_retries?: number;
+};
+
+export type CloudsyncNetworkResult = {
+  send?: {
+    status: string;
+    localVersion: number;
+    serverVersion: number;
+    lastFailure?: unknown;
+  };
+  receive?: {
+    rows: number;
+    tables: string[];
+    error?: string;
+    lastFailure?: unknown;
+  };
+};
+
+export type CloudsyncStatus = {
+  cloudsync_enabled: boolean;
+  extension_loaded: boolean;
+  configured: boolean;
+  running: boolean;
+  network_initialized: boolean;
+  last_sync: CloudsyncNetworkResult | null;
+  last_sync_at_ms: number | null;
+  has_unsent_changes: boolean | null;
+  last_error: string | null;
+  last_error_kind: "transient" | "auth" | "fatal" | null;
+  consecutive_failures: number;
+};
+
 export type QueryEvent<T = Record<string, unknown>> =
   | { event: "result"; data: T[] }
   | { event: "error"; data: string };
@@ -105,6 +155,36 @@ export async function cleanupLegacyFiles(): Promise<LegacyCleanupResult> {
 
 export async function runLegacyImport(dryRun = false): Promise<string> {
   return invoke("plugin:db|run_legacy_import", { dryRun });
+}
+
+export async function configureCloudsync(
+  config: CloudsyncRuntimeConfig,
+): Promise<void> {
+  return invoke("plugin:db|configure_cloudsync", {
+    configJson: JSON.stringify(config),
+  });
+}
+
+export async function startCloudsync(): Promise<void> {
+  return invoke("plugin:db|start_cloudsync");
+}
+
+export async function stopCloudsync(): Promise<void> {
+  return invoke("plugin:db|stop_cloudsync");
+}
+
+export async function getCloudsyncStatus(): Promise<CloudsyncStatus> {
+  return invoke("plugin:db|get_cloudsync_status");
+}
+
+export async function syncCloudsyncNow(): Promise<CloudsyncNetworkResult> {
+  return invoke("plugin:db|sync_cloudsync_now");
+}
+
+export async function logoutCloudsync(
+  discardUnsentChanges = false,
+): Promise<void> {
+  return invoke("plugin:db|logout_cloudsync", { discardUnsentChanges });
 }
 
 export async function subscribe<T = Record<string, unknown>>(

--- a/plugins/db/permissions/autogenerated/commands/configure_cloudsync.toml
+++ b/plugins/db/permissions/autogenerated/commands/configure_cloudsync.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-configure-cloudsync"
+description = "Enables the configure_cloudsync command without any pre-configured scope."
+commands.allow = ["configure_cloudsync"]
+
+[[permission]]
+identifier = "deny-configure-cloudsync"
+description = "Denies the configure_cloudsync command without any pre-configured scope."
+commands.deny = ["configure_cloudsync"]

--- a/plugins/db/permissions/autogenerated/commands/get_cloudsync_status.toml
+++ b/plugins/db/permissions/autogenerated/commands/get_cloudsync_status.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-get-cloudsync-status"
+description = "Enables the get_cloudsync_status command without any pre-configured scope."
+commands.allow = ["get_cloudsync_status"]
+
+[[permission]]
+identifier = "deny-get-cloudsync-status"
+description = "Denies the get_cloudsync_status command without any pre-configured scope."
+commands.deny = ["get_cloudsync_status"]

--- a/plugins/db/permissions/autogenerated/commands/logout_cloudsync.toml
+++ b/plugins/db/permissions/autogenerated/commands/logout_cloudsync.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-logout-cloudsync"
+description = "Enables the logout_cloudsync command without any pre-configured scope."
+commands.allow = ["logout_cloudsync"]
+
+[[permission]]
+identifier = "deny-logout-cloudsync"
+description = "Denies the logout_cloudsync command without any pre-configured scope."
+commands.deny = ["logout_cloudsync"]

--- a/plugins/db/permissions/autogenerated/commands/start_cloudsync.toml
+++ b/plugins/db/permissions/autogenerated/commands/start_cloudsync.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-start-cloudsync"
+description = "Enables the start_cloudsync command without any pre-configured scope."
+commands.allow = ["start_cloudsync"]
+
+[[permission]]
+identifier = "deny-start-cloudsync"
+description = "Denies the start_cloudsync command without any pre-configured scope."
+commands.deny = ["start_cloudsync"]

--- a/plugins/db/permissions/autogenerated/commands/stop_cloudsync.toml
+++ b/plugins/db/permissions/autogenerated/commands/stop_cloudsync.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-stop-cloudsync"
+description = "Enables the stop_cloudsync command without any pre-configured scope."
+commands.allow = ["stop_cloudsync"]
+
+[[permission]]
+identifier = "deny-stop-cloudsync"
+description = "Denies the stop_cloudsync command without any pre-configured scope."
+commands.deny = ["stop_cloudsync"]

--- a/plugins/db/permissions/autogenerated/commands/sync_cloudsync_now.toml
+++ b/plugins/db/permissions/autogenerated/commands/sync_cloudsync_now.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-sync-cloudsync-now"
+description = "Enables the sync_cloudsync_now command without any pre-configured scope."
+commands.allow = ["sync_cloudsync_now"]
+
+[[permission]]
+identifier = "deny-sync-cloudsync-now"
+description = "Denies the sync_cloudsync_now command without any pre-configured scope."
+commands.deny = ["sync_cloudsync_now"]

--- a/plugins/db/permissions/default.toml
+++ b/plugins/db/permissions/default.toml
@@ -12,4 +12,10 @@ permissions = [
   "allow-cleanup-legacy-files",
   "allow-subscribe",
   "allow-unsubscribe",
+  "allow-configure-cloudsync",
+  "allow-start-cloudsync",
+  "allow-stop-cloudsync",
+  "allow-get-cloudsync-status",
+  "allow-sync-cloudsync-now",
+  "allow-logout-cloudsync",
 ]

--- a/plugins/db/src/commands.rs
+++ b/plugins/db/src/commands.rs
@@ -159,3 +159,66 @@ pub(crate) async fn unsubscribe(
         .await
         .map_err(|error| error.to_string())
 }
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn configure_cloudsync(
+    state: tauri::State<'_, ManagedState>,
+    config_json: String,
+) -> Result<(), String> {
+    state
+        .configure_cloudsync(config_json)
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn start_cloudsync(state: tauri::State<'_, ManagedState>) -> Result<(), String> {
+    state
+        .start_cloudsync()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn stop_cloudsync(state: tauri::State<'_, ManagedState>) -> Result<(), String> {
+    state
+        .stop_cloudsync()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn get_cloudsync_status(
+    state: tauri::State<'_, ManagedState>,
+) -> Result<serde_json::Value, String> {
+    state
+        .cloudsync_status()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn sync_cloudsync_now(
+    state: tauri::State<'_, ManagedState>,
+) -> Result<serde_json::Value, String> {
+    state
+        .sync_cloudsync_now()
+        .await
+        .map_err(|error| error.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn logout_cloudsync(
+    state: tauri::State<'_, ManagedState>,
+    discard_unsent_changes: bool,
+) -> Result<(), String> {
+    state
+        .logout_cloudsync(discard_unsent_changes)
+        .await
+        .map_err(|error| error.to_string())
+}

--- a/plugins/db/src/error.rs
+++ b/plugins/db/src/error.rs
@@ -18,6 +18,10 @@ pub enum Error {
     Execute(#[from] hypr_db_execute::Error),
     #[error(transparent)]
     Reactive(#[from] hypr_db_reactive::Error),
+    #[error(transparent)]
+    Cloudsync(#[from] hypr_db_core::CloudsyncRuntimeError),
+    #[error(transparent)]
+    Json(#[from] serde_json::Error),
     #[error("transaction statement {statement_index} affected {actual} rows; expected {expected}")]
     UnexpectedRowsAffected {
         statement_index: usize,

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -135,12 +135,25 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::run_legacy_import,
             commands::subscribe,
             commands::unsubscribe,
+            commands::configure_cloudsync,
+            commands::start_cloudsync,
+            commands::stop_cloudsync,
+            commands::get_cloudsync_status,
+            commands::sync_cloudsync_now,
+            commands::logout_cloudsync,
         ])
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }
 
 pub fn init<R: tauri::Runtime>(
     db: std::sync::Arc<hypr_db_core::Db>,
+) -> tauri::plugin::TauriPlugin<R> {
+    init_with_cloudsync(db, None)
+}
+
+pub fn init_with_cloudsync<R: tauri::Runtime>(
+    db: std::sync::Arc<hypr_db_core::Db>,
+    startup_config: Option<hypr_db_core::CloudsyncRuntimeConfig>,
 ) -> tauri::plugin::TauriPlugin<R> {
     let specta_builder = make_specta_builder();
 
@@ -149,6 +162,16 @@ pub fn init<R: tauri::Runtime>(
         .setup(move |app, _| {
             hypr_tauri_utils::block_on(hypr_db_app::prepare_schema(db.as_ref()))?;
             hypr_tauri_utils::block_on(import::import_legacy_data(app.app_handle(), db.pool()))?;
+            if let Some(config) = startup_config.clone() {
+                db.cloudsync_configure(config)?;
+                hypr_tauri_utils::block_on(db.cloudsync_start())?;
+                let sync_db = std::sync::Arc::clone(&db);
+                tauri::async_runtime::spawn(async move {
+                    if let Err(error) = sync_db.cloudsync_trigger_sync().await {
+                        tracing::warn!(%error, "initial cloudsync failed");
+                    }
+                });
+            }
             app.manage(std::sync::Arc::new(runtime::PluginDbRuntime::new(db)));
             Ok(())
         })
@@ -454,6 +477,41 @@ mod test {
 
         let event = next_event(&events, 0).await.unwrap();
         assert!(matches!(event, QueryEvent::Result(rows) if !rows.is_empty()));
+    }
+
+    #[tokio::test]
+    async fn cloudsync_transport_stays_inert_until_configured() {
+        let (_dir, runtime) = setup_runtime().await;
+
+        let status = runtime.cloudsync_status().await.unwrap();
+        assert_eq!(status["cloudsync_enabled"], false);
+        assert_eq!(status["configured"], false);
+
+        runtime
+            .configure_cloudsync(
+                serde_json::json!({
+                    "connection_string": "managed-database-id",
+                    "auth": { "type": "token", "token": "test-token" },
+                    "tables": hypr_db_app::cloudsync_table_registry(),
+                    "sync_interval_ms": 30_000,
+                    "wait_ms": 5_000,
+                    "max_retries": 3
+                })
+                .to_string(),
+            )
+            .unwrap();
+        runtime.start_cloudsync().await.unwrap();
+
+        let status = runtime.cloudsync_status().await.unwrap();
+        assert_eq!(status["configured"], true);
+        assert_eq!(status["running"], false);
+        assert_eq!(status["network_initialized"], false);
+
+        runtime.logout_cloudsync(false).await.unwrap();
+        assert_eq!(
+            runtime.cloudsync_status().await.unwrap()["configured"],
+            false
+        );
     }
 
     #[tokio::test]

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -122,6 +122,38 @@ impl PluginDbRuntime {
     pub async fn unsubscribe(&self, subscription_id: &str) -> hypr_db_reactive::Result<()> {
         self.live_query_runtime.unsubscribe(subscription_id).await
     }
+
+    pub fn configure_cloudsync(&self, config_json: String) -> Result<()> {
+        let config = serde_json::from_str(&config_json)?;
+        self.db.cloudsync_configure(config)?;
+        Ok(())
+    }
+
+    pub async fn start_cloudsync(&self) -> Result<()> {
+        self.ensure_app_schema().await?;
+        self.db.cloudsync_start().await?;
+        Ok(())
+    }
+
+    pub async fn stop_cloudsync(&self) -> Result<()> {
+        self.db.cloudsync_stop().await?;
+        Ok(())
+    }
+
+    pub async fn cloudsync_status(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(self.db.cloudsync_status().await?)?)
+    }
+
+    pub async fn sync_cloudsync_now(&self) -> Result<serde_json::Value> {
+        Ok(serde_json::to_value(
+            self.db.cloudsync_trigger_sync().await?,
+        )?)
+    }
+
+    pub async fn logout_cloudsync(&self, discard_unsent_changes: bool) -> Result<()> {
+        self.db.cloudsync_logout(discard_unsent_changes).await?;
+        Ok(())
+    }
 }
 
 fn bind_params<'q>(
@@ -155,7 +187,7 @@ pub async fn open_app_db(db_path: Option<&Path>) -> Result<Db> {
 
     let db = Db::open(DbOpenOptions {
         storage,
-        cloudsync_enabled: false,
+        cloudsync_enabled: true,
         journal_mode_wal: true,
         foreign_keys: true,
         max_connections: Some(4),


### PR DESCRIPTION
Wire CloudSync lifecycle through the database plugin and desktop startup, expose typed controls and permissions, and validate the app schema with safe unconfigured behavior.

Depends on #5992.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6002 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #5992
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Enables cloud replication of core meeting/user data when env credentials are set, touches auth tokens and local DB sync lifecycle at desktop startup; misconfiguration can fail app startup (`expect` on invalid CloudSync env).
> 
> **Overview**
> Completes end-to-end **CloudSync** wiring: the desktop app can opt in via `ANARLOG_CLOUDSYNC_*` env vars (database id, API key or token, optional interval), builds runtime config from `hypr_db_app`’s table registry, and registers the db plugin with `init_with_cloudsync` so sync starts on launch when configured; without env vars, sync stays off.
> 
> The **db plugin** exposes configure/start/stop/status/sync-now/logout to the frontend (Rust commands, JS helpers, permissions). Plugin setup configures and starts CloudSync when a startup config is passed and triggers an initial sync in the background (failures log a warning).
> 
> **db-app** changes the CloudSync registry from “all tables declared but disabled” to an **initial meeting slice**: eight tables (`sessions`, transcripts, participants, documents, attachments, action items, humans, organizations) are **enabled**; calendars, chat, tags, etc. remain registered but disabled. Alter-guard now applies to enabled tables only.
> 
> **db-core** adds `cloudsync_logout` (optional discard of unsent changes, `UnsentChanges` error), refactors stop into `stop_cloudsync_task`, and records sync failures on manual `cloudsync_trigger_sync`. App DB open path enables the CloudSync extension (`cloudsync_enabled: true`) while runtime still requires explicit config to connect.
> 
> Adds unit tests for env parsing and plugin inert behavior, plus an ignored integration test for two-client session sync against real SQLite Cloud credentials.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fa782198bdd42781725070fd41a80917b7096e5d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->