### PR TITLE
Prototype a hosted onboarding demo meeting

### DIFF
--- a/apps/web/public/onboarding-demo/index.html
+++ b/apps/web/public/onboarding-demo/index.html
@@ -1,0 +1,639 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Anarlog demo meeting</title>
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Rounded:opsz,wght,FILL@24,400,0&amp;icon_names=auto_awesome,back_hand,call_end,chat,closed_caption,group,info,lock_person,mic,mic_off,mood,more_horiz,more_vert,present_to_all,videocam&amp;display=block"
+      rel="stylesheet"
+    />
+    <script
+      src="https://cdn.jsdelivr.net/npm/@mux/mux-player@3.11.7"
+      defer
+    ></script>
+    <style>
+      :root {
+        color-scheme: dark;
+        font-family: Arial, Helvetica, sans-serif;
+      }
+
+      * {
+        box-sizing: border-box;
+      }
+
+      html,
+      body {
+        width: 100%;
+        height: 100%;
+        margin: 0;
+      }
+
+      body {
+        overflow: hidden;
+        background: #202124;
+        color: #fff;
+      }
+
+      button {
+        border: 0;
+        color: inherit;
+        font: inherit;
+      }
+
+      .meeting {
+        display: grid;
+        grid-template-rows: 70px minmax(0, 1fr) 80px;
+        width: 100%;
+        height: 100%;
+        background: #202124;
+      }
+
+      .top-bar {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        padding: 0 16px 0 24px;
+      }
+
+      .meeting-meta {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        font-size: 16px;
+        font-weight: 600;
+        letter-spacing: 0.01em;
+      }
+
+      .divider {
+        width: 1px;
+        height: 20px;
+        background: #9aa0a6;
+      }
+
+      .info-icon {
+        display: grid;
+        width: 20px;
+        height: 20px;
+        place-items: center;
+        color: #bdc1c6;
+      }
+
+      .top-actions {
+        display: flex;
+        align-items: center;
+        gap: 10px;
+      }
+
+      .participant-count {
+        display: flex;
+        height: 38px;
+        align-items: center;
+        gap: 7px;
+        padding: 4px 11px 4px 4px;
+        border-radius: 20px;
+        background: #3c4043;
+        color: #e8eaed;
+        font-size: 13px;
+      }
+
+      .avatar {
+        position: relative;
+        display: grid;
+        overflow: hidden;
+        width: 30px;
+        height: 30px;
+        place-items: center;
+        border-radius: 50%;
+        background: #70584b;
+        color: #fff;
+        font-size: 12px;
+        font-weight: 600;
+      }
+
+      .avatar-photo {
+        position: absolute;
+        inset: 0;
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+      }
+
+      .top-action,
+      .corner-action {
+        display: grid;
+        place-items: center;
+        background: transparent;
+        color: #e8eaed;
+      }
+
+      .top-action {
+        width: 40px;
+        height: 40px;
+        border-radius: 50%;
+        background: #3c4043;
+      }
+
+      .material-symbols-rounded {
+        display: inline-block;
+        font-family: "Material Symbols Rounded";
+        font-size: 24px;
+        font-style: normal;
+        font-variation-settings:
+          "FILL" 0,
+          "wght" 400,
+          "GRAD" 0,
+          "opsz" 24;
+        font-weight: normal;
+        letter-spacing: normal;
+        line-height: 1;
+        text-transform: none;
+        white-space: nowrap;
+        word-wrap: normal;
+      }
+
+      .stage {
+        display: grid;
+        min-height: 0;
+        place-items: center;
+        padding: 0 28px;
+      }
+
+      .tile {
+        position: relative;
+        overflow: hidden;
+        width: min(100%, calc((100vh - 150px) * 16 / 9));
+        height: min(100%, calc((100vw - 56px) * 9 / 16));
+        max-height: 100%;
+        aspect-ratio: 16 / 9;
+        border-radius: 20px;
+        background: #3c4043;
+      }
+
+      mux-player {
+        display: block;
+        width: 100%;
+        height: 100%;
+        background: #3c4043;
+        --controls: none;
+        --dialog: none;
+        --loading-indicator: none;
+        --media-object-fit: cover;
+        --media-object-position: center;
+      }
+
+      .participant-name {
+        position: absolute;
+        bottom: 18px;
+        left: 18px;
+        color: #fff;
+        font-size: 14px;
+        font-weight: 500;
+        text-shadow: 0 1px 4px rgb(0 0 0 / 80%);
+      }
+
+      .join-layer,
+      .ended-layer,
+      .error-layer {
+        position: absolute;
+        inset: 0;
+        display: grid;
+        place-items: center;
+        background: rgb(32 33 36 / 72%);
+        backdrop-filter: blur(10px);
+      }
+
+      .dialog {
+        display: grid;
+        max-width: 400px;
+        justify-items: center;
+        gap: 14px;
+        padding: 32px;
+        text-align: center;
+      }
+
+      .dialog h1 {
+        margin: 0;
+        font-size: 28px;
+        font-weight: 500;
+        letter-spacing: -0.02em;
+      }
+
+      .dialog p {
+        margin: 0 0 8px;
+        color: #e8eaed;
+        font-size: 15px;
+        line-height: 1.5;
+      }
+
+      .primary-button {
+        min-width: 130px;
+        padding: 12px 24px;
+        border-radius: 24px;
+        background: #8ab4f8;
+        color: #202124;
+        cursor: pointer;
+        font-weight: 600;
+      }
+
+      .primary-button:hover {
+        background: #aecbfa;
+      }
+
+      .primary-button:disabled {
+        cursor: wait;
+        opacity: 0.6;
+      }
+
+      .bottom-bar {
+        position: relative;
+        display: grid;
+        grid-template-columns: 1fr auto 1fr;
+        align-items: center;
+        padding: 0 24px;
+      }
+
+      .bottom-left,
+      .bottom-right,
+      .controls {
+        display: flex;
+        align-items: center;
+      }
+
+      .bottom-left {
+        justify-self: start;
+      }
+
+      .bottom-right {
+        justify-self: end;
+        gap: 14px;
+      }
+
+      .controls {
+        justify-self: center;
+        gap: 10px;
+      }
+
+      .control,
+      .muted-badge {
+        display: grid;
+        place-items: center;
+        border-radius: 50%;
+        background: #3c4043;
+        color: #e8eaed;
+      }
+
+      .control {
+        width: 48px;
+        height: 48px;
+        cursor: default;
+      }
+
+      .control.more {
+        margin-right: -8px;
+        background: transparent;
+      }
+
+      .control.leave {
+        width: 72px;
+        border-radius: 24px;
+        background: #ea4335;
+        cursor: pointer;
+      }
+
+      .control.leave:hover {
+        background: #d93025;
+      }
+
+      .muted-badge {
+        width: 40px;
+        height: 40px;
+      }
+
+      .muted-badge .material-symbols-rounded {
+        font-size: 21px;
+      }
+
+      .corner-action {
+        width: 32px;
+        height: 40px;
+      }
+
+      [hidden] {
+        display: none !important;
+      }
+
+      @media (max-width: 820px) {
+        .meeting {
+          grid-template-rows: 58px minmax(0, 1fr) 72px;
+        }
+
+        .top-bar,
+        .bottom-bar {
+          padding-inline: 14px;
+        }
+
+        .stage {
+          padding-inline: 12px;
+        }
+
+        .tile {
+          width: min(100%, calc((100vh - 130px) * 16 / 9));
+          height: min(100%, calc((100vw - 24px) * 9 / 16));
+          border-radius: 14px;
+        }
+
+        .meeting-meta {
+          gap: 8px;
+          font-size: 14px;
+        }
+
+        .participant-count,
+        .top-action,
+        .bottom-left,
+        .bottom-right,
+        .control.more,
+        .control.reaction,
+        .control.caption,
+        .control.hand {
+          display: none;
+        }
+
+        .controls {
+          gap: 8px;
+        }
+
+        .control {
+          width: 44px;
+          height: 44px;
+        }
+
+        .control.leave {
+          width: 62px;
+        }
+      }
+    </style>
+  </head>
+  <body>
+    <main class="meeting">
+      <header class="top-bar">
+        <div class="meeting-meta">
+          <time class="current-time">6:13 PM</time>
+          <span class="divider" aria-hidden="true"></span>
+          <span class="meeting-code">anarlog-demo</span>
+          <span
+            class="material-symbols-rounded info-icon"
+            aria-label="Meeting details"
+          >info</span>
+        </div>
+
+        <div class="top-actions">
+          <div class="participant-count" aria-label="One participant">
+            <span class="avatar">
+              <span class="avatar-initials">J</span>
+              <img
+                class="avatar-photo"
+                src="https://anarlog.so/api/assets/team/john.png"
+                alt=""
+                decoding="async"
+              />
+            </span>
+            <span>1</span>
+          </div>
+          <button class="top-action" type="button" aria-label="Visual effects">
+            <span class="material-symbols-rounded" aria-hidden="true">auto_awesome</span>
+          </button>
+        </div>
+      </header>
+
+      <section class="stage">
+        <div class="tile">
+          <mux-player
+            playsinline
+            preload="metadata"
+            stream-type="on-demand"
+            nohotkeys
+          ></mux-player>
+          <div class="participant-name">John Jeong</div>
+
+          <div class="join-layer">
+            <div class="dialog">
+              <h1>Ready to join?</h1>
+              <p>
+                This is a private, prerecorded demo meeting. Your microphone and
+                camera are not connected.
+              </p>
+              <button class="primary-button join-button" type="button" disabled>
+                Join now
+              </button>
+            </div>
+          </div>
+
+          <div class="ended-layer" hidden>
+            <div class="dialog">
+              <h1>You left the meeting</h1>
+              <p>You can return to Anarlog to review the transcript and notes.</p>
+              <button class="primary-button replay-button" type="button">
+                Rejoin
+              </button>
+            </div>
+          </div>
+
+          <div class="error-layer" hidden>
+            <div class="dialog">
+              <h1>Couldn't join the meeting</h1>
+              <p class="error-message">The demo video could not be loaded.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <footer class="bottom-bar">
+        <div class="bottom-left">
+          <div class="muted-badge" aria-label="Microphone muted">
+            <span class="material-symbols-rounded" aria-hidden="true">mic_off</span>
+          </div>
+        </div>
+
+        <div class="controls">
+          <button class="control more" type="button" aria-label="More controls">
+            <span class="material-symbols-rounded" aria-hidden="true">more_horiz</span>
+          </button>
+          <button class="control" type="button" aria-label="Microphone">
+            <span class="material-symbols-rounded" aria-hidden="true">mic</span>
+          </button>
+          <button class="control" type="button" aria-label="Camera">
+            <span class="material-symbols-rounded" aria-hidden="true">videocam</span>
+          </button>
+          <button class="control" type="button" aria-label="Present now">
+            <span class="material-symbols-rounded" aria-hidden="true">present_to_all</span>
+          </button>
+          <button class="control reaction" type="button" aria-label="Send a reaction">
+            <span class="material-symbols-rounded" aria-hidden="true">mood</span>
+          </button>
+          <button class="control caption" type="button" aria-label="Turn on captions">
+            <span class="material-symbols-rounded" aria-hidden="true">closed_caption</span>
+          </button>
+          <button class="control hand" type="button" aria-label="Raise hand">
+            <span class="material-symbols-rounded" aria-hidden="true">back_hand</span>
+          </button>
+          <button class="control" type="button" aria-label="More options">
+            <span class="material-symbols-rounded" aria-hidden="true">more_vert</span>
+          </button>
+          <button class="control leave" type="button" aria-label="Leave call">
+            <span class="material-symbols-rounded" aria-hidden="true">call_end</span>
+          </button>
+        </div>
+
+        <div class="bottom-right">
+          <button class="corner-action" type="button" aria-label="Chat with everyone">
+            <span class="material-symbols-rounded" aria-hidden="true">chat</span>
+          </button>
+          <button class="corner-action" type="button" aria-label="People">
+            <span class="material-symbols-rounded" aria-hidden="true">group</span>
+          </button>
+          <button class="corner-action" type="button" aria-label="Host controls">
+            <span class="material-symbols-rounded" aria-hidden="true">lock_person</span>
+          </button>
+        </div>
+      </footer>
+    </main>
+
+    <script>
+      const video = document.querySelector("mux-player");
+      const joinLayer = document.querySelector(".join-layer");
+      const endedLayer = document.querySelector(".ended-layer");
+      const errorLayer = document.querySelector(".error-layer");
+      const errorMessage = document.querySelector(".error-message");
+      const participantName = document.querySelector(".participant-name");
+      const meetingCode = document.querySelector(".meeting-code");
+      const joinButton = document.querySelector(".join-button");
+      const avatarPhoto = document.querySelector(".avatar-photo");
+      const params = new URLSearchParams(window.location.search);
+
+      function updateTime() {
+        document.querySelector(".current-time").textContent = new Intl.DateTimeFormat(
+          undefined,
+          { hour: "numeric", minute: "2-digit" },
+        ).format(new Date());
+      }
+
+      function getVideoUrl(source) {
+        const url = new URL(source, window.location.href);
+        const isLocal = ["localhost", "127.0.0.1"].includes(url.hostname);
+        if (url.protocol !== "https:" && !isLocal && url.protocol !== "file:") {
+          throw new Error("The demo video must be served over HTTPS.");
+        }
+        return url;
+      }
+
+      function getPlaybackId(value) {
+        if (typeof value !== "string" || !/^[A-Za-z0-9]+$/.test(value)) {
+          throw new Error("The Mux playback ID is invalid.");
+        }
+        return value;
+      }
+
+      function showError(message) {
+        joinLayer.hidden = true;
+        endedLayer.hidden = true;
+        errorMessage.textContent = message;
+        errorLayer.hidden = false;
+      }
+
+      function showJoin() {
+        errorLayer.hidden = true;
+        endedLayer.hidden = true;
+        joinLayer.hidden = false;
+        joinButton.disabled = false;
+      }
+
+      async function loadDemo() {
+        try {
+          await customElements.whenDefined("mux-player");
+
+          const videoOverride = params.get("video");
+          if (videoOverride) {
+            video.src = getVideoUrl(videoOverride).toString();
+            showJoin();
+            return;
+          }
+
+          const response = await fetch("./manifest.json", { cache: "no-store" });
+          if (!response.ok) {
+            throw new Error("The demo configuration could not be loaded.");
+          }
+
+          const manifest = await response.json();
+          const playbackId = getPlaybackId(manifest.playback_id);
+          video.playbackId = playbackId;
+          video.metadata = {
+            video_id: playbackId,
+            video_title: manifest.title,
+            player_name: "Anarlog onboarding demo",
+          };
+          participantName.textContent = manifest.speaker;
+          meetingCode.textContent = manifest.meeting_code ?? "anarlog-demo";
+          document.querySelector(".avatar-initials").textContent = manifest.speaker
+            .split(/\s+/)
+            .map((part) => part[0])
+            .join("")
+            .slice(0, 2);
+          showJoin();
+        } catch (error) {
+          showError(error.message);
+        }
+      }
+
+      async function playFromStart() {
+        endedLayer.hidden = true;
+        errorLayer.hidden = true;
+        joinLayer.hidden = true;
+        video.currentTime = 0;
+        try {
+          await video.play();
+        } catch (error) {
+          showError(
+            error?.name === "NotAllowedError"
+              ? "Your browser blocked playback. Allow media playback and join again."
+              : "The demo video could not be played. Check your connection and try again.",
+          );
+        }
+      }
+
+      function closeMeeting() {
+        window.close();
+        window.setTimeout(() => {
+          errorLayer.hidden = true;
+          joinLayer.hidden = true;
+          endedLayer.hidden = false;
+        }, 150);
+      }
+
+      updateTime();
+      window.setInterval(updateTime, 30_000);
+
+      avatarPhoto.addEventListener("error", () => {
+        avatarPhoto.hidden = true;
+      });
+
+      video.addEventListener("error", () => {
+        if (errorLayer.hidden) {
+          showError("The demo video could not be loaded.");
+        }
+      });
+      video.addEventListener("ended", () => {
+        closeMeeting();
+      });
+
+      joinButton.addEventListener("click", playFromStart);
+      document.querySelector(".replay-button").addEventListener("click", playFromStart);
+      document.querySelector(".leave").addEventListener("click", () => {
+        video.pause();
+        closeMeeting();
+      });
+
+      loadDemo();
+    </script>
+  </body>
+</html>

--- a/apps/web/public/onboarding-demo/manifest.json
+++ b/apps/web/public/onboarding-demo/manifest.json
@@ -1,0 +1,6 @@
+{
+  "playback_id": "LE57bZiqFQQaQaUE00IzPJiaKtrV01p01Qnodx4hKvhZZo",
+  "title": "Getting started with Anarlog",
+  "speaker": "John Jeong",
+  "meeting_code": "anarlog-demo"
+}


### PR DESCRIPTION
Add a browser-based meeting simulation with server-controlled video metadata, audible join playback, and replay handling.

<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6004
- <kbd>&nbsp;1&nbsp;</kbd> #6003 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> New public static assets only; no auth, API, or app routing changes in this diff.
> 
> **Overview**
> Adds a **static hosted onboarding demo** under `apps/web/public/onboarding-demo/` that simulates a video call UI and plays a prerecorded session after the user clicks **Join now**.
> 
> `manifest.json` supplies the Mux `playback_id`, title, speaker, and meeting code; the page loads it with `fetch` (no-store) and configures `mux-player` from the CDN. A `?video=` query param can override playback with a validated HTTPS (or local) URL for testing.
> 
> The UI includes join, error, and “you left the meeting” overlays with **Rejoin**, leave/end handling (pause, attempt `window.close()`, then ended state), and basic validation for playback IDs and video URLs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1edcc3f4bad96d90ed0ae794be2b18ac074281e7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->