### PR TITLE
Defer note serialization until change flush

### DIFF
--- a/packages/editor/src/chat/index.tsx
+++ b/packages/editor/src/chat/index.tsx
@@ -230,8 +230,8 @@ export const ChatEditor = forwardRef<ChatEditorHandle, ChatEditorProps>(
 
       return [
         reactKeys(),
-        docChangeListenerPlugin((view) => {
-          onUpdateRef.current?.(view.state.doc.toJSON() as JSONContent);
+        docChangeListenerPlugin((doc) => {
+          onUpdateRef.current?.(doc.toJSON() as JSONContent);
         }),
         keymap({
           "Mod-z": undo,

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -613,7 +613,8 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
     );
 
     const flushChange = useCallback(
-      (content: JSONContent) => {
+      (doc: PMNode) => {
+        const content = doc.toJSON() as JSONContent;
         syncTasks(content);
         if (!handleChange) {
           return;
@@ -639,9 +640,7 @@ export const NoteEditor = forwardRef<NoteEditorRef, NoteEditorProps>(
       () => [
         reactKeys(),
         createCompositionStatePlugin(setCompositionActive),
-        docChangeListenerPlugin((view) =>
-          onUpdateRef.current(view.state.doc.toJSON() as JSONContent),
-        ),
+        docChangeListenerPlugin((doc) => onUpdateRef.current(doc)),
         buildInputRules(),
         ...(enforceTitleHeading ? [titleHeadingPlugin()] : []),
         taskIdentityPlugin(),

--- a/packages/editor/src/plugins/doc-change-listener.test.ts
+++ b/packages/editor/src/plugins/doc-change-listener.test.ts
@@ -33,11 +33,10 @@ describe("docChangeListenerPlugin", () => {
     expect(onDocChanged).not.toHaveBeenCalled();
 
     const changedState = previousState.apply(previousState.tr.insertText("x"));
-    const changedView = { state: changedState } as EditorView;
-    pluginView?.update(changedView, previousState);
+    pluginView?.update({ state: changedState } as EditorView, previousState);
 
     expect(onDocChanged).toHaveBeenCalledOnce();
-    expect(onDocChanged).toHaveBeenCalledWith(changedView);
+    expect(onDocChanged).toHaveBeenCalledWith(changedState.doc);
   });
 
   it("ignores document replacement from controlled prop sync", () => {

--- a/packages/editor/src/plugins/doc-change-listener.ts
+++ b/packages/editor/src/plugins/doc-change-listener.ts
@@ -1,13 +1,11 @@
+import type { Node as PMNode } from "prosemirror-model";
 import { Plugin, PluginKey } from "prosemirror-state";
-import type { EditorView } from "prosemirror-view";
 
 const docChangedByTransactionKey = new PluginKey<boolean>(
   "docChangedByTransaction",
 );
 
-export function docChangeListenerPlugin(
-  onDocChanged: (view: EditorView) => void,
-) {
+export function docChangeListenerPlugin(onDocChanged: (doc: PMNode) => void) {
   return new Plugin({
     key: docChangedByTransactionKey,
     state: {
@@ -25,7 +23,7 @@ export function docChangeListenerPlugin(
             return;
           }
 
-          onDocChanged(view);
+          onDocChanged(view.state.doc);
         },
       };
     },


### PR DESCRIPTION
Serialize note content when the editor change buffer flushes instead of on every intermediate update.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small API change in an internal editor plugin with updated tests; behavior is intentionally deferred serialization for notes only.
> 
> **Overview**
> **`docChangeListenerPlugin`** now invokes its callback with the current **`PMNode`** document instead of the full **`EditorView`**, so consumers can work from the live doc without pulling the view.
> 
> The **note editor** wires the listener into its debounced **`flushChange`** path: it passes the **`PMNode`** through the debounce buffer and only calls **`doc.toJSON()`** when the flush runs, aligning serialization with the PR goal of not building JSON on every intermediate update. **Chat** still serializes in the listener callback for immediate **`onUpdate`** JSON.
> 
> Tests were updated to assert the callback receives **`changedState.doc`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ba4851a4da815c968986970784c5ca63fda181a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->