### PR TITLE
Match account pricing to landing page

### DIFF
--- a/packages/pricing/src/tiers.ts
+++ b/packages/pricing/src/tiers.ts
@@ -23,52 +23,6 @@ export interface PlanTierData {
   features: PlanFeature[];
 }
 
-export const PLAN_TIERS: PlanTierData[] = [
-  {
-    id: "free",
-    name: "Free",
-    price: "$0",
-    period: "/month",
-    subtitle: null,
-    features: [
-      { label: "On-device Transcription", included: true },
-      { label: "Save Audio Recordings", included: true },
-      { label: "Audio Player", included: true },
-      { label: "Bring Your Own Key (STT & LLM)", included: true },
-      { label: "Export to Various Formats", included: true },
-      { label: "Local-first", included: true },
-      { label: "Custom Default Folder", included: true },
-      { label: "Templates", included: true },
-      { label: "Shortcuts", included: true },
-      { label: "Chat", included: true },
-      { label: "Connect to Google Calendar", included: false },
-      { label: "Connect to Outlook Calendar", included: false },
-      { label: "Cloud Transcription", included: false },
-      { label: "Cloud LLM", included: false },
-      { label: "Cloud Sync", included: false },
-      { label: "Shareable Links", included: false },
-    ],
-  },
-  {
-    id: "pro",
-    name: "Pro",
-    price: "$15",
-    period: "/month",
-    subtitle: "or $150/year",
-    features: [
-      { label: "Everything in Free", included: true },
-      { label: "Cloud Transcription", included: true },
-      { label: "Cloud LLM", included: true },
-      { label: "Speaker Identification", included: "partial" },
-      { label: "Advanced Templates", included: true },
-      { label: "Connect to Google Calendar", included: true },
-      { label: "Connect to Outlook Calendar", included: true },
-      { label: "Cloud Sync", included: "partial" },
-      { label: "Shareable Links", included: "partial" },
-    ],
-  },
-];
-
 export interface MarketingPlanData {
   id: PlanTier;
   name: string;
@@ -143,6 +97,15 @@ export const MARKETING_PLAN_TIERS: MarketingPlanData[] = [
     ],
   },
 ];
+
+export const PLAN_TIERS: PlanTierData[] = MARKETING_PLAN_TIERS.map((plan) => ({
+  id: plan.id,
+  name: plan.name,
+  price: plan.price ? `$${plan.price.monthly}` : "$0",
+  period: "/month",
+  subtitle: plan.price?.yearly ? `or $${plan.price.yearly}/year` : null,
+  features: plan.features.filter((feature) => feature.included === true),
+}));
 
 export const TIER_ORDER: Record<PlanTier, number> = {
   free: 0,


### PR DESCRIPTION
Reuse the canonical pricing tier benefits so account billing copy stays aligned with the landing page.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Display-only pricing data refactor with no billing or entitlement logic changes; account UI may show a different feature list than before.
> 
> **Overview**
> **Single source of truth for tier copy:** The duplicated hardcoded `PLAN_TIERS` array is removed. `PLAN_TIERS` is now built by mapping `MARKETING_PLAN_TIERS`, formatting monthly/yearly prices into the account UI strings (`$15`, `or $150/year`, etc.).
> 
> **Account feature lists change behavior:** Each plan’s `features` on `PLAN_TIERS` only keeps entries with `included === true`, so desktop account settings will show the marketing-aligned benefit set (fully included items only), not the previous separate list that mixed in explicit “not included” rows or different labels (e.g. “Local-first” vs “Contacts View”).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 949bbba8bbeb3fbb9e285ca9ecc0203fc9681fb2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->