### PR TITLE
Use minutes for longer action delays

### DIFF
--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -238,8 +238,8 @@ export function NotificationSettingsView() {
                           <SelectItem value="10">10 sec</SelectItem>
                           <SelectItem value="15">15 sec</SelectItem>
                           <SelectItem value="30">30 sec</SelectItem>
-                          <SelectItem value="60">60 sec</SelectItem>
-                          <SelectItem value="120">120 sec</SelectItem>
+                          <SelectItem value="60">1 min</SelectItem>
+                          <SelectItem value="120">2 min</SelectItem>
                         </SelectContent>
                       </Select>
                     </div>


### PR DESCRIPTION
Display longer delayed actions in minutes instead of large second counts.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change to select item labels; no config keys, values, or detection logic modified.
> 
> **Overview**
> Updates the **Detection delay** dropdown under microphone detection so the longest presets read as **1 min** and **2 min** instead of **60 sec** and **120 sec**. Stored values (`60` and `120` seconds) and behavior are unchanged—only the option labels in `notification.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 18b50803a7e01ffa488b3b0df6b2f8407b9d38e6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->