### PR TITLE
Add desktop 1.1.16 changelog

### DIFF
--- a/packages/changelog/content/1.1.16.md
+++ b/packages/changelog/content/1.1.16.md
@@ -1,0 +1,30 @@
+---
+date: "2026-07-14"
+summary: "Anarlog adds guided onboarding, safer transcription settings, smarter meeting search in chat, and smoother editing."
+---
+
+## Onboarding
+
+- New users start with a guided welcome note and a private demo meeting
+
+## Chat
+
+- Chat can now search meetings, read meeting details and transcripts, and find other meetings in the same recurring series
+
+## Reliability
+
+- Brief internet interruptions no longer stop a scheduled meeting recording early
+- Older meetings with blank titles recover their title from the summary, and titles stay visible while editing notes and summaries
+- Transcription provider API keys are moved into secure system storage
+
+## Performance
+
+- Notes respond more smoothly while typing, searching, selecting tasks, and resizing images
+- The meeting timeline updates with less background work
+
+## Polish
+
+- Permission settings always explain why each permission is needed
+- The sidebar timeline stays readable when scrolling to the bottom
+- Longer notification delays are displayed in minutes
+- Account pricing now matches the plans shown on the Anarlog website


### PR DESCRIPTION
Summarize the user-facing desktop changes released from origin/main.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only addition with no runtime or build logic changes.
> 
> **Overview**
> Adds **`packages/changelog/content/1.1.16.md`** so the in-app and web changelog can show the **1.1.16** desktop release (dated **2026-07-14**).
> 
> The entry documents user-facing changes grouped as **Onboarding** (welcome note and private demo meeting), **Chat** (meeting search, details, transcripts, recurring series), **Reliability** (recording through brief outages, title recovery/visibility, transcription API keys in secure storage), **Performance** (smoother notes and lighter timeline updates), and **Polish** (permission explanations, sidebar scrolling, notification delay display, pricing alignment with the website). Frontmatter includes a one-line **`summary`** for the changelog index, consistent with other version files under `packages/changelog/content/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c0df60f9c4f88faadf27978bab6f89b9cb67dcd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->