### PR TITLE
Keep floating bar visible when expanding transcript

### DIFF
--- a/apps/desktop/src/meeting-float/host.component.test.tsx
+++ b/apps/desktop/src/meeting-float/host.component.test.tsx
@@ -1,0 +1,124 @@
+import { cleanup, render, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  settings: {
+    current: {
+      floating_bar_opacity: 0.78,
+      live_caption_opacity: 0.3,
+      live_caption_width: 440,
+      live_caption_line_count: 1,
+      live_caption_position: "topCenter",
+      live_caption_minimized: true,
+    },
+  },
+  floatingBarShow: vi.fn(async () => ({ status: "ok", data: null })),
+  floatingBarHide: vi.fn(async () => ({ status: "ok", data: null })),
+  floatingBarUpdate: vi.fn(async () => ({ status: "ok", data: null })),
+  liveCaptionHide: vi.fn(async () => ({ status: "ok", data: null })),
+  windowShow: vi.fn(async () => ({ status: "ok", data: null })),
+  listen: vi.fn(async () => vi.fn()),
+  setSettingValue: vi.fn(async () => undefined),
+  setSettingValues: vi.fn(),
+  subscribeMeetingFloatData: vi.fn(async () => vi.fn(async () => undefined)),
+  listenerState: {
+    live: {
+      status: "active",
+      sessionId: "session-1",
+      amplitude: { mic: 0, speaker: 0 },
+      degraded: null,
+      lastError: null,
+      liveTranscriptionActive: true,
+    },
+    liveSegments: [],
+    stop: vi.fn(),
+  },
+  subscribeListener: vi.fn(() => vi.fn()),
+}));
+
+vi.mock("@hypr/plugin-windows", () => ({
+  commands: {
+    floatingBarShow: mocks.floatingBarShow,
+    floatingBarHide: mocks.floatingBarHide,
+    floatingBarUpdate: mocks.floatingBarUpdate,
+    liveCaptionHide: mocks.liveCaptionHide,
+    windowShow: mocks.windowShow,
+  },
+  events: {
+    floatingBarOpenMain: { listen: mocks.listen },
+    floatingBarSettingsChange: { listen: mocks.listen },
+    floatingBarStop: { listen: mocks.listen },
+  },
+}));
+
+vi.mock("./hooks", () => ({
+  createMeetingFloatLabelContext: vi.fn(() => undefined),
+  loadMeetingFloatData: vi.fn(async () => ({ sessions: {}, humanNames: {} })),
+  subscribeMeetingFloatData: mocks.subscribeMeetingFloatData,
+}));
+
+vi.mock("~/settings/queries", () => ({
+  getStoredSettingValues: vi.fn(async () => ({
+    values: mocks.settings.current,
+    hasValues: new Set(Object.keys(mocks.settings.current)),
+  })),
+  setSettingValue: mocks.setSettingValue,
+  useSetSettingValues: () => mocks.setSettingValues,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: () => true,
+  useConfigValues: () => mocks.settings.current,
+}));
+
+vi.mock("~/store/zustand/listener/instance", () => ({
+  listenerStore: {
+    getState: () => mocks.listenerState,
+    subscribe: mocks.subscribeListener,
+  },
+}));
+
+import { FloatingMeetingWindowHost } from "./host";
+
+describe("FloatingMeetingWindowHost", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.settings.current = {
+      floating_bar_opacity: 0.78,
+      live_caption_opacity: 0.3,
+      live_caption_width: 440,
+      live_caption_line_count: 1,
+      live_caption_position: "topCenter",
+      live_caption_minimized: true,
+    };
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("updates overlay settings without hiding the active floating panel", async () => {
+    const view = render(<FloatingMeetingWindowHost />);
+
+    await waitFor(() => {
+      expect(mocks.floatingBarShow).toHaveBeenCalledOnce();
+      expect(mocks.floatingBarUpdate).toHaveBeenLastCalledWith(
+        expect.objectContaining({ liveCaptionMinimized: true }),
+      );
+    });
+
+    mocks.settings.current = {
+      ...mocks.settings.current,
+      live_caption_minimized: false,
+    };
+    view.rerender(<FloatingMeetingWindowHost />);
+
+    await waitFor(() => {
+      expect(mocks.floatingBarUpdate).toHaveBeenLastCalledWith(
+        expect.objectContaining({ liveCaptionMinimized: false }),
+      );
+    });
+    expect(mocks.floatingBarShow).toHaveBeenCalledOnce();
+    expect(mocks.floatingBarHide).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/meeting-float/host.tsx
+++ b/apps/desktop/src/meeting-float/host.tsx
@@ -1,3 +1,5 @@
+import { useRef } from "react";
+
 import {
   commands as windowsCommands,
   events as windowsEvents,
@@ -18,6 +20,7 @@ import {
 } from "~/settings/queries";
 import type { SettingValues } from "~/settings/schema";
 import { useConfigValue, useConfigValues } from "~/shared/config";
+import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { listenerStore } from "~/store/zustand/listener/instance";
 import { SegmentKeyUtils, type RenderLabelContext } from "~/stt/live-segment";
@@ -134,10 +137,7 @@ export function FloatingMeetingWindowHost() {
       <FloatingOverlaySettingsEventSync />
       <LiveCaptionDefaultVisibilitySync />
       {floatingBarEnabled ? (
-        <FloatingMeetingWindowSync
-          key={JSON.stringify(overlaySettings)}
-          settings={overlaySettings}
-        />
+        <FloatingMeetingWindowSync settings={overlaySettings} />
       ) : (
         <FloatingMeetingWindowDisabled />
       )}
@@ -273,12 +273,15 @@ function FloatingMeetingWindowSync({
 }: {
   settings: FloatingOverlaySettings;
 }) {
+  const settingsRef = useLatestRef(settings);
+  const refreshSettingsRef = useRef<() => void>(() => {});
+
   useMountEffect(() => {
     let meetingData: MeetingFloatData = { sessions: {}, humanNames: {} };
     let routeState = getCurrentFloatingRouteState(
       listenerStore.getState(),
       undefined,
-      settings,
+      settingsRef.current,
       getFloatingLiveCaptionToggleVisible(listenerStore.getState()),
       meetingData,
     );
@@ -303,12 +306,13 @@ function FloatingMeetingWindowSync({
         getCurrentFloatingRouteState(
           listenerStore.getState(),
           undefined,
-          settings,
+          settingsRef.current,
           getFloatingLiveCaptionToggleVisible(listenerStore.getState()),
           meetingData,
         ),
       );
     };
+    refreshSettingsRef.current = refreshCurrentRouteState;
 
     const sync = async () => {
       if (!shouldContinue()) {
@@ -386,14 +390,14 @@ function FloatingMeetingWindowSync({
       const colorScheme = getCurrentFloatingBarColorScheme();
       const nextRouteState = getFloatingRouteState(state, {
         colorScheme,
-        settings,
+        settings: settingsRef.current,
         liveCaptionToggleVisible: getFloatingLiveCaptionToggleVisible(state),
         sessionTitle: getFloatingSessionTitle(state, meetingData),
         speakerLabelContext: getFloatingSpeakerLabelContext(state, meetingData),
       });
       const previousRouteState = getFloatingRouteState(previousState, {
         colorScheme,
-        settings,
+        settings: settingsRef.current,
         liveCaptionToggleVisible:
           getFloatingLiveCaptionToggleVisible(previousState),
         sessionTitle: getFloatingSessionTitle(previousState, meetingData),
@@ -434,6 +438,7 @@ function FloatingMeetingWindowSync({
 
     return () => {
       cancelled = true;
+      refreshSettingsRef.current = () => {};
       unsubscribe();
       unsubscribeAppliedTheme();
       void unsubscribeMeetingData?.();
@@ -442,6 +447,20 @@ function FloatingMeetingWindowSync({
     };
   });
 
+  return (
+    <FloatingMeetingWindowSettingsSync
+      key={JSON.stringify(settings)}
+      onSettingsChange={() => refreshSettingsRef.current()}
+    />
+  );
+}
+
+function FloatingMeetingWindowSettingsSync({
+  onSettingsChange,
+}: {
+  onSettingsChange: () => void;
+}) {
+  useMountEffect(onSettingsChange);
   return null;
 }
 


### PR DESCRIPTION
Update overlay settings in place and cover active-panel expansion with a regression test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized meeting-float host refactor with a regression test; no auth, data, or API surface changes.
> 
> **Overview**
> Fixes the floating meeting bar disappearing when users expand the live transcript (e.g. toggling **`live_caption_minimized`**).
> 
> **`FloatingMeetingWindowSync`** no longer remounts when overlay settings change—the **`key={JSON.stringify(overlaySettings)}`** on that component is removed so the native sync lifecycle stays mounted. Settings are read through **`useLatestRef`**, and a small **`FloatingMeetingWindowSettingsSync`** child (keyed by settings) runs **`refreshCurrentRouteState`** on change so the panel gets **`floatingBarUpdate`** instead of hide/show.
> 
> Adds **`host.component.test.tsx`** to assert that changing minimized state triggers update only once for show and never calls hide.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1a07e890c50555b6901f4ab2f601d57de4f27574. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->