### PR TITLE
Align macOS traffic lights across builds

### DIFF
--- a/plugins/windows/src/window/v1.rs
+++ b/plugins/windows/src/window/v1.rs
@@ -86,11 +86,7 @@ impl AppWindow {
                     _ => 0,
                 };
 
-                if major >= 26 && cfg!(debug_assertions) {
-                    25.0
-                } else {
-                    19.0
-                }
+                if major >= 26 { 25.0 } else { 19.0 }
             };
 
             builder = builder


### PR DESCRIPTION
Use the macOS 26 traffic-light offset for both debug and release builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single macOS title-bar positioning tweak with no auth, data, or shared business-logic impact.
> 
> **Overview**
> **macOS window chrome:** Traffic-light vertical offset now follows OS major version only—no special case for debug builds.
> 
> On macOS 26+, both debug and release use **25.0** for `traffic_light_y`; older macOS stays at **19.0**. Previously, macOS 26+ **debug** used 25.0 while **release** still used 19.0, so traffic lights could sit differently between local dev and shipped builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 938aaa9a0ba62f3f2b0547f863757740bd9fe281. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->