### PR TITLE
Make transcript recovery actions visible

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -518,7 +518,7 @@ describe("Header", () => {
 
     expect(
       menu.map((item) => ("text" in item ? item.text : "separator")),
-    ).toEqual(["Copy", "Regenerate", "Delete recording"]);
+    ).toEqual(["Copy", "Re-transcribe", "Delete recording"]);
     expect(menu.find(isMenuItem)?.disabled).toBe(false);
     expect(
       menu.find(

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -792,7 +792,7 @@ function HeaderViewTranscriptActive({
     if (audioExists) {
       items.push({
         id: `regenerate-transcript-${sessionId}`,
-        text: "Regenerate",
+        text: "Re-transcribe",
         action: () => {
           void regenerate();
         },

--- a/apps/desktop/src/session/components/note-input/transcript/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.test.tsx
@@ -4,12 +4,21 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Transcript } from "./index";
 
-const { useListenerMock, useAudioPlayerMock, useSessionTranscriptsMock } =
-  vi.hoisted(() => ({
-    useListenerMock: vi.fn(),
-    useAudioPlayerMock: vi.fn(),
-    useSessionTranscriptsMock: vi.fn(),
-  }));
+const {
+  useListenerMock,
+  useAudioPlayerMock,
+  useSessionTranscriptsMock,
+  regenerateTranscriptMock,
+} = vi.hoisted(() => ({
+  useListenerMock: vi.fn(),
+  useAudioPlayerMock: vi.fn(),
+  useSessionTranscriptsMock: vi.fn(),
+  regenerateTranscriptMock: vi.fn(),
+}));
+
+vi.mock("./actions", () => ({
+  useRegenerateTranscript: () => regenerateTranscriptMock,
+}));
 
 vi.mock("~/stt/queries", () => ({
   useSessionTranscripts: useSessionTranscriptsMock,

--- a/apps/desktop/src/session/components/note-input/transcript/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/index.tsx
@@ -3,6 +3,7 @@ import { useCallback } from "react";
 
 import { Spinner } from "@hypr/ui/components/ui/spinner";
 
+import { useRegenerateTranscript } from "./actions";
 import { TranscriptViewer } from "./renderer";
 import { BatchState } from "./screens/batch";
 import { TranscriptEmptyState } from "./screens/empty";
@@ -21,6 +22,7 @@ export function Transcript({
 }) {
   const screen = useTranscriptScreen({ sessionId });
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
+  const regenerateTranscript = useRegenerateTranscript(sessionId);
   const stopTranscription = useListener((state) => state.stopTranscription);
   const handleStopTranscription = useCallback(() => {
     void stopTranscription(sessionId);
@@ -52,6 +54,7 @@ export function Transcript({
           isBatching={false}
           hasAudio={screen.hasAudio}
           error={screen.error}
+          onRetranscribe={regenerateTranscript}
           onUploadAudio={uploadAudio}
           onUploadTranscript={uploadTranscript}
         />

--- a/apps/desktop/src/session/components/note-input/transcript/screens/batch.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/batch.tsx
@@ -16,17 +16,22 @@ export function BatchState({
     "Recording continues and audio will be saved when you stop.";
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-8">
-      <DancingSticks
-        amplitude={Math.min(Math.hypot(amplitude.mic, amplitude.speaker), 1)}
-        color="#a3a3a3"
-        height={56}
-        width={120}
-        stickWidth={3.5}
-        gap={4}
-      />
-      <div className="flex max-w-sm flex-col items-center gap-2 text-center">
-        <p className="text-muted-foreground text-base font-semibold">
+    <div
+      role="status"
+      className="flex h-full min-h-[400px] flex-col items-center justify-center px-6 text-center"
+    >
+      <div className="mb-5">
+        <DancingSticks
+          amplitude={Math.min(Math.hypot(amplitude.mic, amplitude.speaker), 1)}
+          color="#a3a3a3"
+          height={36}
+          width={80}
+          stickWidth={3}
+          gap={3}
+        />
+      </div>
+      <div className="flex max-w-md flex-col gap-2">
+        <p className="text-base font-medium">
           {isFallbackFromLive
             ? "Live transcription stopped"
             : "Recording continues"}

--- a/apps/desktop/src/session/components/note-input/transcript/screens/empty.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/empty.test.tsx
@@ -31,4 +31,50 @@ describe("TranscriptEmptyState", () => {
       screen.queryByRole("button", { name: "Stop transcription" }),
     ).toBeNull();
   });
+
+  it("uses the same error hierarchy and offers re-transcription", () => {
+    const onRetranscribe = vi.fn();
+
+    render(
+      <TranscriptEmptyState
+        error="The transcription provider timed out."
+        onRetranscribe={onRetranscribe}
+      />,
+    );
+
+    expect(screen.getByRole("alert")).not.toBeNull();
+    expect(screen.getByText("Transcription failed").className).toContain(
+      "text-base",
+    );
+    expect(
+      screen.getByText("The transcription provider timed out.").className,
+    ).toContain("text-sm");
+
+    fireEvent.click(screen.getByRole("button", { name: "Re-transcribe" }));
+    expect(onRetranscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it("offers re-transcription instead of replacing existing audio", () => {
+    const onRetranscribe = vi.fn();
+
+    render(
+      <TranscriptEmptyState
+        hasAudio
+        onRetranscribe={onRetranscribe}
+        onUploadAudio={vi.fn()}
+        onUploadTranscript={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Re-transcribe" }));
+
+    expect(onRetranscribe).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Upload transcript" }),
+    ).not.toBeNull();
+    expect(screen.getByText("Audio available")).not.toBeNull();
+    expect(screen.getByText(/Re-transcribe this audio/)).not.toBeNull();
+    expect(screen.queryByText(/refresh button/i)).toBeNull();
+  });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/empty.tsx
@@ -1,4 +1,9 @@
-import { AlertCircleIcon, AudioLinesIcon, SquareIcon } from "lucide-react";
+import {
+  AlertCircleIcon,
+  AudioLinesIcon,
+  RefreshCwIcon,
+  SquareIcon,
+} from "lucide-react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 import { Spinner } from "@hypr/ui/components/ui/spinner";
@@ -9,6 +14,7 @@ export function TranscriptEmptyState({
   percentage,
   phase,
   error,
+  onRetranscribe,
   onUploadAudio,
   onUploadTranscript,
   onStopTranscription,
@@ -18,82 +24,108 @@ export function TranscriptEmptyState({
   percentage?: number;
   phase?: "importing" | "transcribing";
   error?: string | null;
+  onRetranscribe?: () => void;
   onUploadAudio?: () => void;
   onUploadTranscript?: () => void;
   onStopTranscription?: () => void;
 }) {
   if (error) {
     return (
-      <div className="flex h-full flex-col items-center justify-center gap-3 text-center">
-        <AlertCircleIcon className="h-8 w-8 text-red-400" />
-        <div className="flex max-w-md flex-col gap-1">
-          <p className="text-muted-foreground text-sm font-medium">
-            Batch transcription failed
+      <div
+        role="alert"
+        className="flex h-full min-h-[400px] flex-col items-center justify-center px-6 text-center"
+      >
+        <AlertCircleIcon
+          aria-hidden
+          className="text-muted-foreground mb-5 size-9 stroke-[1.5]"
+        />
+        <div className="mb-6 flex max-w-md flex-col gap-2">
+          <p className="text-base font-medium">Transcription failed</p>
+          <p className="text-muted-foreground text-sm leading-relaxed">
+            {error}
           </p>
-          <p className="text-muted-foreground text-xs">{error}</p>
         </div>
+        {onRetranscribe && (
+          <Button size="sm" className="gap-2" onClick={onRetranscribe}>
+            <RefreshCwIcon className="size-4" />
+            Re-transcribe
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (isBatching) {
+    const hasProgress = typeof percentage === "number" && percentage > 0;
+
+    return (
+      <div
+        role="status"
+        className="flex h-full min-h-[400px] flex-col items-center justify-center px-6 text-center"
+      >
+        <div className="text-muted-foreground mb-5">
+          <Spinner size={36} />
+        </div>
+        <div className={onStopTranscription ? "mb-6" : undefined}>
+          <p className="text-base font-medium">
+            {phase === "importing"
+              ? "Importing audio..."
+              : "Generating transcript..."}
+          </p>
+          {hasProgress && (
+            <p className="text-muted-foreground mt-2 text-sm leading-relaxed tabular-nums">
+              {Math.round((percentage ?? 0) * 100)}% complete
+            </p>
+          )}
+        </div>
+        {onStopTranscription && (
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-2"
+            onClick={onStopTranscription}
+          >
+            <SquareIcon className="size-3 fill-current" />
+            Stop transcription
+          </Button>
+        )}
       </div>
     );
   }
 
   return (
-    <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3">
-      {isBatching ? (
-        <Spinner size={28} />
-      ) : (
-        <AudioLinesIcon className="h-8 w-8" />
-      )}
-      {isBatching ? (
-        <div className="flex flex-col items-center gap-1">
-          {typeof percentage === "number" && percentage > 0 ? (
-            <p className="text-muted-foreground text-2xl font-medium tabular-nums">
-              {Math.round(percentage * 100)}%
-            </p>
-          ) : null}
-          <p className="text-sm">
-            {phase === "importing"
-              ? "Importing audio..."
-              : "Generating transcript..."}
-          </p>
-          {onStopTranscription ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              className="mt-2 gap-1.5 text-xs"
-              onClick={onStopTranscription}
-            >
-              <SquareIcon className="size-3 fill-current" />
-              Stop transcription
+    <div className="flex h-full min-h-[400px] flex-col items-center justify-center px-6 text-center">
+      <AudioLinesIcon
+        aria-hidden
+        className="text-muted-foreground mb-5 size-9 stroke-[1.5]"
+      />
+      <div className="mb-6 flex max-w-md flex-col gap-2">
+        <p className="text-base font-medium">
+          {hasAudio ? "Audio available" : "No transcript available"}
+        </p>
+        <p className="text-muted-foreground text-sm leading-relaxed">
+          {hasAudio
+            ? "Re-transcribe this audio, or upload a transcript file."
+            : "Upload audio or a transcript file to populate this note."}
+        </p>
+      </div>
+      {(onRetranscribe || onUploadAudio || onUploadTranscript) && (
+        <div className="flex items-center gap-2">
+          {hasAudio && onRetranscribe && (
+            <Button size="sm" className="gap-2" onClick={onRetranscribe}>
+              <RefreshCwIcon className="size-4" />
+              Re-transcribe
             </Button>
-          ) : null}
-        </div>
-      ) : (
-        <div className="flex max-w-sm flex-col items-center gap-1 text-center">
-          <p className="text-muted-foreground text-sm">
-            {hasAudio ? "Recording available" : "No transcript available"}
-          </p>
-          <p className="text-muted-foreground text-xs">
-            {hasAudio
-              ? "Use the refresh button above to generate a transcript, or upload a file."
-              : "Upload audio or a transcript file to populate this note."}
-          </p>
-          {(onUploadAudio || onUploadTranscript) && (
-            <div className="mt-3 flex items-center gap-2">
-              {onUploadAudio && (
-                <Button variant="outline" size="sm" onClick={onUploadAudio}>
-                  Upload audio
-                </Button>
-              )}
-              {onUploadTranscript && (
-                <Button
-                  variant="outline"
-                  size="sm"
-                  onClick={onUploadTranscript}
-                >
-                  Upload transcript
-                </Button>
-              )}
-            </div>
+          )}
+          {!hasAudio && onUploadAudio && (
+            <Button variant="outline" size="sm" onClick={onUploadAudio}>
+              Upload audio
+            </Button>
+          )}
+          {onUploadTranscript && (
+            <Button variant="outline" size="sm" onClick={onUploadTranscript}>
+              Upload transcript
+            </Button>
           )}
         </div>
       )}

--- a/apps/desktop/src/session/components/note-input/transcript/screens/listening.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/listening.tsx
@@ -10,17 +10,25 @@ export function TranscriptListeningState({
   const isFinalizing = status === "finalizing";
 
   return (
-    <div className="text-muted-foreground flex h-full flex-col items-center justify-center gap-3">
+    <div
+      role="status"
+      className="flex h-full min-h-[400px] flex-col items-center justify-center px-6 text-center"
+    >
       {isFinalizing ? (
-        <Spinner size={28} />
+        <div className="text-muted-foreground mb-5">
+          <Spinner size={36} />
+        </div>
       ) : (
-        <AudioLinesIcon className="h-8 w-8" />
+        <AudioLinesIcon
+          aria-hidden
+          className="text-muted-foreground mb-5 size-9 stroke-[1.5]"
+        />
       )}
-      <div className="flex max-w-sm flex-col items-center gap-1 text-center">
-        <p className="text-muted-foreground text-sm">
+      <div className="flex max-w-md flex-col gap-2">
+        <p className="text-base font-medium">
           {isFinalizing ? "Finalizing transcript..." : "Listening..."}
         </p>
-        <p className="text-muted-foreground text-xs">
+        <p className="text-muted-foreground text-sm leading-relaxed">
           {isFinalizing
             ? "Transcript is still being written."
             : "Transcript will appear here when the first segment arrives."}

--- a/apps/desktop/src/session/components/outer-header/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.test.tsx
@@ -22,6 +22,7 @@ const mocks = vi.hoisted(() => ({
   stopTranscription: vi.fn(),
   requestMainListenerControl: vi.fn(),
   isMainWebviewWindow: true,
+  audioExists: false,
   hasTranscriptBySession: {} as Record<string, boolean>,
   overflowProps: [] as Array<{
     allowListening?: boolean;
@@ -68,6 +69,10 @@ vi.mock("@hypr/plugin-opener2", () => ({
 
 vi.mock("~/calendar/hooks", () => ({
   useNow: () => new Date(mocks.nowMs),
+}));
+
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: () => ({ audioExists: mocks.audioExists }),
 }));
 
 vi.mock("~/contexts/shell", () => ({
@@ -131,6 +136,7 @@ describe("OuterHeader", () => {
     mocks.stopTranscription.mockClear();
     mocks.requestMainListenerControl.mockClear();
     mocks.isMainWebviewWindow = true;
+    mocks.audioExists = false;
     mocks.hasTranscriptBySession = {};
     mocks.overflowProps = [];
   });
@@ -501,6 +507,26 @@ describe("OuterHeader", () => {
     expect(resumeButton.title).toBe("Resume listening");
     expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
     expect(screen.getByTestId("recording-icon")).not.toBeNull();
+    expect(mocks.startListening).toHaveBeenCalledTimes(1);
+  });
+
+  it("shows resume when an inactive session has audio without a transcript", () => {
+    mocks.audioExists = true;
+
+    render(
+      <OuterHeader
+        sessionId="session-1"
+        currentView={{ type: "transcript" } as EditorView}
+        title={<span>Session title</span>}
+      />,
+    );
+
+    const resumeButton = screen.getByRole("button", { name: "Resume" });
+
+    fireEvent.click(resumeButton);
+
+    expect(resumeButton.title).toBe("Resume listening");
+    expect(screen.queryByRole("button", { name: "Record" })).toBeNull();
     expect(mocks.startListening).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/session/components/outer-header/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/index.tsx
@@ -14,6 +14,7 @@ import { RecordingIcon, useHasTranscript } from "../shared";
 import { MetadataButton } from "./metadata";
 import { OverflowButton } from "./overflow";
 
+import { useAudioPlayer } from "~/audio-player";
 import { useNow } from "~/calendar/hooks";
 import { useShell } from "~/contexts/shell";
 import { useEventCountdown } from "~/session/hooks/useEventCountdown";
@@ -138,6 +139,8 @@ function HeaderMeetingActionPill({
   const endedAt = event?.ended_at ? safeParseDate(event.ended_at) : null;
   const ended = !!endedAt && endedAt.getTime() <= now.getTime();
   const hasTranscript = useHasTranscript(sessionId);
+  const { audioExists } = useAudioPlayer();
+  const canResume = audioExists || hasTranscript;
   const { t } = useLingui();
   const countdown = useEventCountdown(sessionId);
   const start = useCallback(() => {
@@ -199,8 +202,8 @@ function HeaderMeetingActionPill({
     }
 
     return {
-      label: hasTranscript ? t`Resume` : t`Record`,
-      title: hasTranscript ? t`Resume listening` : t`Record`,
+      label: canResume ? t`Resume` : t`Record`,
+      title: canResume ? t`Resume listening` : t`Record`,
       icon: <RecordingIcon />,
       onClick: start,
     };

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -9,6 +9,8 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const {
   uploadAudioMock,
   uploadTranscriptMock,
+  regenerateTranscriptMock,
+  audioExists,
   currentNoteContent,
   useHasTranscriptMock,
   useListenerMock,
@@ -17,6 +19,8 @@ const {
 } = vi.hoisted(() => ({
   uploadAudioMock: vi.fn(),
   uploadTranscriptMock: vi.fn(),
+  regenerateTranscriptMock: vi.fn(),
+  audioExists: { value: false },
   currentNoteContent: { value: "" },
   useHasTranscriptMock: vi.fn(),
   useListenerMock: vi.fn(),
@@ -66,7 +70,11 @@ vi.mock("./export-modal", () => ({
 }));
 
 vi.mock("./listening", () => ({
-  Listening: () => <button type="button">Resume listening</button>,
+  Listening: ({ resume }: { resume: boolean }) => (
+    <button type="button">
+      {resume ? "Resume listening" : "Start listening"}
+    </button>
+  ),
 }));
 
 vi.mock("./misc", () => ({
@@ -75,6 +83,14 @@ vi.mock("./misc", () => ({
 
 vi.mock("~/meeting-float/host", () => ({
   openFloatingMeetingPanel: vi.fn(),
+}));
+
+vi.mock("~/audio-player", () => ({
+  useAudioPlayer: () => ({ audioExists: audioExists.value }),
+}));
+
+vi.mock("~/session/components/note-input/transcript/actions", () => ({
+  useRegenerateTranscript: () => regenerateTranscriptMock,
 }));
 
 vi.mock("@hypr/plugin-windows", () => ({
@@ -110,6 +126,7 @@ describe("OverflowButton", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    audioExists.value = false;
     currentNoteContent.value = "";
     useHasTranscriptMock.mockReturnValue(true);
     useConfigValueMock.mockReturnValue(false);
@@ -150,17 +167,44 @@ describe("OverflowButton", () => {
     expect(
       screen.queryByRole("button", { name: "Upload transcript" }),
     ).toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Resume listening" }),
+    ).not.toBeNull();
   });
 
-  it("renders one separator when no meeting actions are visible", () => {
+  it("renders one separator when meeting actions are disabled", () => {
     const { container } = render(
       <OverflowButton
+        allowListening={false}
         sessionId="session-1"
         currentView={{ type: "enhanced", id: "note-1" } as EditorView}
       />,
     );
 
     expect(container.querySelectorAll("hr")).toHaveLength(1);
+  });
+
+  it("offers resume and re-transcribe when recorded audio exists", () => {
+    audioExists.value = true;
+    useHasTranscriptMock.mockReturnValue(false);
+
+    render(
+      <OverflowButton
+        sessionId="session-1"
+        currentView={{ type: "enhanced", id: "note-1" } as EditorView}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Re-transcribe" }));
+
+    expect(
+      screen.getByRole("button", { name: "Resume listening" }),
+    ).not.toBeNull();
+    expect(regenerateTranscriptMock).toHaveBeenCalledTimes(1);
+    expect(screen.queryByRole("button", { name: "Upload audio" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Upload transcript" }),
+    ).toBeNull();
   });
 
   it("separates visible meeting actions from the static actions", () => {

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -5,6 +5,7 @@ import {
   FileTextIcon,
   MoreHorizontalIcon,
   PictureInPicture2Icon,
+  RefreshCwIcon,
   SquareArrowOutUpRightIcon,
 } from "lucide-react";
 import { useState } from "react";
@@ -24,7 +25,9 @@ import { ExportModal } from "./export-modal";
 import { Listening } from "./listening";
 import { ShowInFinder } from "./misc";
 
+import { useAudioPlayer } from "~/audio-player";
 import { openFloatingMeetingPanel } from "~/meeting-float/host";
+import { useRegenerateTranscript } from "~/session/components/note-input/transcript/actions";
 import {
   useCurrentNoteHasContent,
   useHasTranscript,
@@ -53,19 +56,28 @@ export function OverflowButton({
     sessionId,
     currentView,
   );
+  const { audioExists } = useAudioPlayer();
   const { uploadAudio, uploadTranscript } = useUploadFile(sessionId);
+  const regenerateTranscript = useRegenerateTranscript(sessionId);
   const sessionMode = useListener((state) => state.getSessionMode(sessionId));
   const floatingBarEnabled = useConfigValue("floating_bar_enabled");
   const isMeetingInProgress =
     sessionMode === "active" || sessionMode === "finalizing";
-  const showListeningAction =
-    allowListening && (!hasTranscript || isMeetingInProgress);
+  const isRetranscribing = sessionMode === "running_batch";
+  const showListeningAction = allowListening;
+  const showRetranscribeAction = audioExists && !isMeetingInProgress;
   const showUploadActions =
-    !hasTranscript && !currentNoteHasContent && !isMeetingInProgress;
+    !audioExists &&
+    !hasTranscript &&
+    !currentNoteHasContent &&
+    !isMeetingInProgress;
   const canOpenFloatingPanel =
     allowListening && floatingBarEnabled && sessionMode === "active";
   const hasMeetingActions =
-    showListeningAction || showUploadActions || canOpenFloatingPanel;
+    showListeningAction ||
+    showRetranscribeAction ||
+    showUploadActions ||
+    canOpenFloatingPanel;
   const openExportModal = () => {
     setOpen(false);
     requestAnimationFrame(() => setIsExportModalOpen(true));
@@ -77,6 +89,10 @@ export function OverflowButton({
   const handleUploadTranscript = () => {
     setOpen(false);
     uploadTranscript();
+  };
+  const handleRetranscribe = () => {
+    setOpen(false);
+    void regenerateTranscript();
   };
   const handleOpenFloatingPanel = () => {
     setOpen(false);
@@ -116,7 +132,20 @@ export function OverflowButton({
             </DropdownMenuItem>
             <DropdownMenuSeparator />
             {showListeningAction && (
-              <Listening sessionId={sessionId} hasTranscript={hasTranscript} />
+              <Listening
+                sessionId={sessionId}
+                resume={audioExists || hasTranscript}
+              />
+            )}
+            {showRetranscribeAction && (
+              <DropdownMenuItem
+                onClick={handleRetranscribe}
+                disabled={isRetranscribing}
+                className="cursor-pointer"
+              >
+                <RefreshCwIcon />
+                <span>Re-transcribe</span>
+              </DropdownMenuItem>
             )}
             {showUploadActions && (
               <>

--- a/apps/desktop/src/session/components/outer-header/overflow/listening.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/listening.test.tsx
@@ -57,16 +57,16 @@ describe("Listening", () => {
     cleanup();
   });
 
-  it("hides resume listening when a transcript already exists", () => {
-    render(<Listening sessionId="session-1" hasTranscript />);
+  it("resumes listening when the session already has content", () => {
+    render(<Listening sessionId="session-1" resume />);
 
-    expect(
-      screen.queryByRole("button", { name: "Resume listening" }),
-    ).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: "Resume listening" }));
+
+    expect(startListeningMock).toHaveBeenCalledTimes(1);
   });
 
   it("starts listening directly in the main window before transcript exists", () => {
-    render(<Listening sessionId="session-1" hasTranscript={false} />);
+    render(<Listening sessionId="session-1" resume={false} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Start listening" }));
 
@@ -77,7 +77,7 @@ describe("Listening", () => {
   it("delegates standalone start requests to the main window before transcript exists", () => {
     isMainWebviewWindowMock.mockReturnValue(false);
 
-    render(<Listening sessionId="session-1" hasTranscript={false} />);
+    render(<Listening sessionId="session-1" resume={false} />);
 
     fireEvent.click(screen.getByRole("button", { name: "Start listening" }));
 
@@ -97,7 +97,7 @@ describe("Listening", () => {
       }),
     );
 
-    render(<Listening sessionId="session-1" hasTranscript />);
+    render(<Listening sessionId="session-1" resume />);
 
     fireEvent.click(screen.getByRole("button", { name: "Stop listening" }));
 

--- a/apps/desktop/src/session/components/outer-header/overflow/listening.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/listening.tsx
@@ -11,10 +11,10 @@ import {
 
 export function Listening({
   sessionId,
-  hasTranscript,
+  resume,
 }: {
   sessionId: string;
-  hasTranscript: boolean;
+  resume: boolean;
 }) {
   const { mode, stop } = useListener((state) => ({
     mode: state.getSessionMode(sessionId),
@@ -24,10 +24,6 @@ export function Listening({
   const isFinalizing = mode === "finalizing";
   const isBatching = mode === "running_batch";
   const startListening = useStartListening(sessionId);
-
-  if (!isListening && hasTranscript) {
-    return null;
-  }
 
   const handleToggleListening = () => {
     if (isBatching) {
@@ -49,7 +45,7 @@ export function Listening({
     }
   };
 
-  const startLabel = hasTranscript ? "Resume listening" : "Start listening";
+  const startLabel = resume ? "Resume listening" : "Start listening";
 
   return (
     <DropdownMenuItem


### PR DESCRIPTION
Show resume and re-transcribe for sessions with recorded audio, and expose re-transcription directly from the empty transcript state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop session UI and menu visibility rules only; re-transcription uses the existing batch/regenerate path with added tests.
> 
> **Overview**
> Makes **resume** and **re-transcribe** easier to find when a session has saved audio but no (or failed) transcript, and aligns copy to **Re-transcribe** instead of **Regenerate** on transcript actions.
> 
> The **outer header** pill now treats **recorded audio** like an existing transcript (`canResume`), so users see **Resume** instead of **Record**. The **overflow menu** always shows listening when allowed, adds a **Re-transcribe** item when audio exists (disabled while batch runs), and stops offering **Upload audio** when audio is already on disk. **Listening** no longer hides **Resume listening** just because a transcript exists; labeling uses a `resume` flag driven by audio or transcript.
> 
> On the **transcript tab**, the empty/error states get **Re-transcribe** buttons wired to `useRegenerateTranscript`, updated copy (e.g. “Audio available”), and no longer point users at a header refresh control. Empty, batch-fallback, and listening placeholders share a tighter centered layout with `role="alert"` / `role="status"` for accessibility.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit aea76197e644775895ca8867cc70ac15fad278de. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->