### PR TITLE
Terminate CloudSync before SQLite closes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3466,6 +3466,7 @@ name = "cloudsync"
 version = "0.1.0"
 dependencies = [
  "dirs 6.0.0",
+ "libsqlite3-sys",
  "serde",
  "serde_json",
  "sqlx",
@@ -4523,7 +4524,6 @@ dependencies = [
  "backon",
  "cloudsync",
  "db-change",
- "libsqlite3-sys",
  "serde",
  "sqlx",
  "tempfile",

--- a/crates/cloudsync/Cargo.toml
+++ b/crates/cloudsync/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2024"
 
 [dependencies]
 dirs = { workspace = true }
+libsqlite3-sys = "0.35"
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite", "sqlite-unbundled"] }

--- a/crates/cloudsync/src/close.rs
+++ b/crates/cloudsync/src/close.rs
@@ -1,0 +1,67 @@
+use std::ffi::{c_char, c_int, c_uint, c_void};
+use std::ptr;
+use std::sync::OnceLock;
+
+use libsqlite3_sys::{
+    SQLITE_OK, SQLITE_TRACE_CLOSE, sqlite3, sqlite3_api_routines, sqlite3_auto_extension,
+    sqlite3_exec, sqlite3_trace_v2,
+};
+
+use crate::Error;
+
+static REGISTRATION_RESULT: OnceLock<c_int> = OnceLock::new();
+const TERMINATE_SQL: &[u8] = b"SELECT cloudsync_terminate()\0";
+
+pub(crate) fn install_terminate_on_close() -> Result<(), Error> {
+    let result = *REGISTRATION_RESULT.get_or_init(|| {
+        #[allow(unsafe_code)]
+        unsafe {
+            sqlite3_auto_extension(Some(register_close_trace))
+        }
+    });
+
+    if result == SQLITE_OK {
+        Ok(())
+    } else {
+        Err(Error::CloseHookRegistration(result))
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe extern "C" fn register_close_trace(
+    db: *mut sqlite3,
+    _error: *mut *mut c_char,
+    _api: *const sqlite3_api_routines,
+) -> c_int {
+    unsafe {
+        sqlite3_trace_v2(
+            db,
+            SQLITE_TRACE_CLOSE,
+            Some(terminate_cloudsync),
+            ptr::null_mut(),
+        )
+    }
+}
+
+#[allow(unsafe_code)]
+unsafe extern "C" fn terminate_cloudsync(
+    event: c_uint,
+    _context: *mut c_void,
+    connection: *mut c_void,
+    _statement: *mut c_void,
+) -> c_int {
+    if event == SQLITE_TRACE_CLOSE && !connection.is_null() {
+        // SQLite invokes this trace before checking for the statements held by SQLite Sync.
+        unsafe {
+            sqlite3_exec(
+                connection.cast(),
+                TERMINATE_SQL.as_ptr().cast(),
+                None,
+                ptr::null_mut(),
+                ptr::null_mut(),
+            );
+        }
+    }
+
+    SQLITE_OK
+}

--- a/crates/cloudsync/src/error.rs
+++ b/crates/cloudsync/src/error.rs
@@ -26,6 +26,8 @@ pub enum Error {
     InvalidNetworkResponse(#[from] serde_json::Error),
     #[error("no cache directory is available for the bundled cloudsync extension")]
     MissingCacheDir,
+    #[error("failed to register the cloudsync close hook: sqlite error {0}")]
+    CloseHookRegistration(i32),
     #[error(
         "the bundled cloudsync extension is not available for this target; supported targets: {SUPPORTED_CLOUDSYNC_TARGETS}"
     )]

--- a/crates/cloudsync/src/lib.rs
+++ b/crates/cloudsync/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod api;
 mod bundle;
+mod close;
 mod error;
 mod network;
 
@@ -24,6 +25,7 @@ pub use network::{
 pub const CLOUDSYNC_VERSION: &str = "1.0.20";
 
 pub fn apply(options: SqliteConnectOptions) -> Result<(SqliteConnectOptions, PathBuf), Error> {
+    close::install_terminate_on_close()?;
     let extension_path = bundled_extension_path()?;
 
     #[allow(unsafe_code)]
@@ -103,6 +105,41 @@ mod tests {
             .unwrap();
 
         assert_eq!(version(&pool).await.unwrap(), CLOUDSYNC_VERSION);
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn terminates_each_pool_connection_before_close() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("cloudsync.db");
+        let options = SqliteConnectOptions::new()
+            .filename(&path)
+            .create_if_missing(true);
+        let (options, _) = apply(options).unwrap();
+        let pool = SqlitePoolOptions::new()
+            .max_connections(4)
+            .connect_with(options)
+            .await
+            .unwrap();
+
+        let mut connections = Vec::new();
+        for index in 0..4 {
+            let mut connection = pool.acquire().await.unwrap();
+            let table = format!("items_{index}");
+            let sql = format!(
+                "CREATE TABLE {table} (id INTEGER PRIMARY KEY NOT NULL, value TEXT NOT NULL DEFAULT '')"
+            );
+            sqlx::query(sqlx::AssertSqlSafe(sql.as_str()))
+                .execute(&mut *connection)
+                .await
+                .unwrap();
+            init(&mut *connection, &table, None, Some(1)).await.unwrap();
+            connections.push(connection);
+        }
+
+        for connection in connections {
+            connection.close().await.unwrap();
+        }
         pool.close().await;
     }
 }

--- a/crates/db-core/Cargo.toml
+++ b/crates/db-core/Cargo.toml
@@ -8,7 +8,6 @@ hypr-cloudsync = { workspace = true }
 hypr-db-change = { workspace = true }
 
 backon = { workspace = true }
-libsqlite3-sys = "0.35"
 serde = { workspace = true, features = ["derive"] }
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
 thiserror = { workspace = true }


### PR DESCRIPTION
Register a native close trace for every extension-enabled connection and cover multi-connection pool shutdown.

<!-- GitButler Footer Boundary Top -->
---
This is **part 3 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6028
- <kbd>&nbsp;3&nbsp;</kbd> #6027 👈 
- <kbd>&nbsp;2&nbsp;</kbd> #6026
- <kbd>&nbsp;1&nbsp;</kbd> #6025
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Unsafe SQLite C API hooks on all CloudSync connections affect sync teardown at shutdown; mis-timing could affect data integrity, though scope is limited to close paths.
> 
> **Overview**
> Ensures **CloudSync shuts down cleanly** whenever an extension-enabled SQLite connection closes, including when a **multi-connection pool** drains.
> 
> `cloudsync::apply` now registers a **SQLite auto-extension** that installs a **`SQLITE_TRACE_CLOSE`** hook on each new connection. On close, the hook runs `SELECT cloudsync_terminate()` **before** SQLite’s close checks (so Sync-held statements don’t block shutdown). Registration failures surface as **`CloseHookRegistration`**.
> 
> **`libsqlite3-sys`** moves from **`db-core`** into **`cloudsync`** for this native hooking. A new integration test initializes CloudSync on four pooled connections and closes them individually, then closes the pool.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de0284a97ceb6a04a95d00888bbdbf8ad1d877b9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->