### PR TITLE
Keep completed summaries visible

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -159,6 +159,41 @@ describe("EnhancedEditor", () => {
     });
   });
 
+  it("keeps the editor mounted outside layout while hidden", () => {
+    render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+        isHidden
+      />,
+    );
+
+    const dropTarget = screen.getByText("Note editor").parentElement;
+
+    expect(dropTarget?.classList.contains("hidden")).toBe(true);
+  });
+
+  it("does not rerender the editor when its props are unchanged", () => {
+    const view = render(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    view.rerender(
+      <EnhancedEditor
+        sessionId="session-1"
+        enhancedNoteId="note-1"
+        content={hoisted.content}
+      />,
+    );
+
+    expect(hoisted.noteEditorProps).toHaveLength(1);
+  });
+
   it("persists content and updates the session title from the first line", () => {
     render(
       <EnhancedEditor

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -1,5 +1,5 @@
 import type { EditorView } from "prosemirror-view";
-import { forwardRef, useCallback, useMemo } from "react";
+import { forwardRef, memo, useCallback, useMemo } from "react";
 
 import { parseJsonContent } from "@hypr/editor/markdown";
 import {
@@ -7,6 +7,7 @@ import {
   type JSONContent,
   type NoteEditorRef,
 } from "@hypr/editor/note";
+import { cn } from "@hypr/utils";
 
 import { AudioDropTarget } from "../audio-drop-target";
 import { useNoteFileHandlerConfig } from "../file-handler";
@@ -25,7 +26,7 @@ import {
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
 
-export const EnhancedEditor = forwardRef<
+const EnhancedEditorInner = forwardRef<
   NoteEditorRef,
   {
     sessionId: string;
@@ -33,6 +34,7 @@ export const EnhancedEditor = forwardRef<
     enhancedNoteId: string;
     content: string;
     contentOverride?: JSONContent;
+    isHidden?: boolean;
     onNavigateToTitle?: (pixelWidth?: number) => void;
     onViewReady?: (view: EditorView) => void;
     onViewDisposed?: (view: EditorView) => void;
@@ -45,6 +47,7 @@ export const EnhancedEditor = forwardRef<
       enhancedNoteId,
       content,
       contentOverride,
+      isHidden = false,
       onNavigateToTitle,
       onViewReady,
       onViewDisposed,
@@ -89,7 +92,7 @@ export const EnhancedEditor = forwardRef<
 
     return (
       <AudioDropTarget
-        className="h-full"
+        className={cn(["h-full", isHidden && "hidden"])}
         targetProps={audioDropTargetProps}
         isActive={isAudioDragActive}
       >
@@ -118,3 +121,5 @@ export const EnhancedEditor = forwardRef<
     );
   },
 );
+
+export const EnhancedEditor = memo(EnhancedEditorInner);

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen } from "@testing-library/react";
+import { useState } from "react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { Enhanced as SessionEnhanced } from "./index";
@@ -32,6 +33,7 @@ const hoisted = vi.hoisted(() => ({
   content: "",
   noteExists: true,
   sessionTitle: "",
+  enhancedEditorMountCount: 0,
 }));
 
 vi.mock("@hypr/ui/components/ui/spinner", () => ({
@@ -71,10 +73,16 @@ vi.mock("./editor", () => ({
   EnhancedEditor: ({
     content,
     contentOverride,
+    isHidden = false,
   }: {
     content: string;
     contentOverride?: { content?: unknown[] };
+    isHidden?: boolean;
   }) => {
+    const [mountId] = useState(() => {
+      hoisted.enhancedEditorMountCount += 1;
+      return hoisted.enhancedEditorMountCount;
+    });
     const collectText = (value: unknown): string => {
       if (!value || typeof value !== "object") {
         return "";
@@ -92,7 +100,11 @@ vi.mock("./editor", () => ({
     };
 
     return (
-      <div>
+      <div
+        data-testid="enhanced-editor"
+        data-mount-id={mountId}
+        hidden={isHidden}
+      >
         <span>Enhanced editor</span>
         <span>{content}</span>
         {contentOverride ? <span>{collectText(contentOverride)}</span> : null}
@@ -137,6 +149,7 @@ describe("Enhanced", () => {
     hoisted.content = "";
     hoisted.noteExists = true;
     hoisted.sessionTitle = "";
+    hoisted.enhancedEditorMountCount = 0;
   });
 
   it("renders an empty editor before the auto-enhance task is visible", () => {
@@ -159,7 +172,7 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.queryByText("Enhanced editor")).toBeNull();
+    expect(screen.getByTestId("enhanced-editor").hidden).toBe(true);
     expect(screen.getByRole("status")).not.toBeNull();
     expect(screen.getByText("Analyzing structure...")).not.toBeNull();
     expect(
@@ -178,11 +191,90 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.queryByText("Enhanced editor")).toBeNull();
+    expect(screen.getByTestId("enhanced-editor").hidden).toBe(true);
     expect(screen.getByText("Streaming summary")).not.toBeNull();
     expect(screen.getByTestId("summary-title-space")).not.toBeNull();
     expect(screen.getByText("Generating title...")).not.toBeNull();
     expect(screen.queryByRole("status")).toBeNull();
+  });
+
+  it("keeps the completed stream visible until SQLite content arrives", () => {
+    hoisted.enhanceTask = {
+      status: "success",
+      error: undefined,
+      streamedText: "Generated summary",
+      currentStep: undefined,
+      isGenerating: false,
+    };
+
+    const view = render(
+      <Enhanced sessionId="session-1" enhancedNoteId="note-1" />,
+    );
+
+    const editor = screen.getByTestId("enhanced-editor");
+    expect(editor.hidden).toBe(true);
+    expect(screen.getByText("Generated summary")).not.toBeNull();
+
+    hoisted.content = "Stored summary";
+    view.rerender(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByTestId("enhanced-editor")).toBe(editor);
+    expect(editor.hidden).toBe(false);
+    expect(screen.getByText("Stored summary")).not.toBeNull();
+    expect(hoisted.enhancedEditorMountCount).toBe(1);
+  });
+
+  it("preserves the editor instance across the streaming handoff", () => {
+    hoisted.content = "Stored summary";
+    const view = render(
+      <Enhanced sessionId="session-1" enhancedNoteId="note-1" />,
+    );
+    const editor = screen.getByTestId("enhanced-editor");
+
+    hoisted.enhanceTask = {
+      status: "generating",
+      error: undefined,
+      streamedText: "Streaming summary",
+      currentStep: undefined,
+      isGenerating: true,
+    };
+    view.rerender(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByTestId("enhanced-editor")).toBe(editor);
+    expect(editor.hidden).toBe(true);
+
+    hoisted.content = "Updated summary";
+    hoisted.enhanceTask = {
+      status: "success",
+      error: undefined,
+      streamedText: "Streaming summary",
+      currentStep: undefined,
+      isGenerating: false,
+    };
+    view.rerender(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByTestId("enhanced-editor")).toBe(editor);
+    expect(editor.hidden).toBe(false);
+    expect(hoisted.enhancedEditorMountCount).toBe(1);
+  });
+
+  it("keeps the completed stream visible over an empty stored document", () => {
+    hoisted.content = JSON.stringify({
+      type: "doc",
+      content: [{ type: "paragraph" }],
+    });
+    hoisted.enhanceTask = {
+      status: "success",
+      error: undefined,
+      streamedText: "Generated summary",
+      currentStep: undefined,
+      isGenerating: false,
+    };
+
+    render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
+
+    expect(screen.getByTestId("enhanced-editor").hidden).toBe(true);
+    expect(screen.getByText("Generated summary")).not.toBeNull();
   });
 
   it("keeps the title row while streaming for an already titled session", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -10,6 +10,7 @@ import { StreamingView } from "./streaming";
 
 import { useAITaskTask } from "~/ai/hooks";
 import { useLLMConnectionStatus } from "~/ai/hooks";
+import { hasStoredNoteContent } from "~/session/components/shared";
 import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnhancedNote } from "~/session/queries";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
@@ -38,11 +39,14 @@ export const Enhanced = forwardRef<
   ) => {
     const taskId = createTaskId(enhancedNoteId, "enhance");
     const llmStatus = useLLMConnectionStatus();
-    const { status, error } = useAITaskTask(taskId, "enhance");
+    const { status, error, streamedText } = useAITaskTask(taskId, "enhance");
     const enhancedNote = useEnhancedNote(enhancedNoteId);
     const content = enhancedNote?.content;
 
-    const hasContent = typeof content === "string" && content.trim().length > 0;
+    const hasContent = hasStoredNoteContent(content);
+    const isAwaitingPersistedContent =
+      status === "success" && streamedText.trim().length > 0 && !hasContent;
+    const showStreaming = status === "generating" || isAwaitingPersistedContent;
 
     if (status === "error") {
       return (
@@ -54,18 +58,14 @@ export const Enhanced = forwardRef<
       );
     }
 
-    if (status === "generating") {
-      return (
+    if (!enhancedNote) {
+      return showStreaming ? (
         <StreamingView
           sessionId={sessionId}
           sessionTitle={sessionTitle}
           enhancedNoteId={enhancedNoteId}
         />
-      );
-    }
-
-    if (!enhancedNote) {
-      return null;
+      ) : null;
     }
 
     const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
@@ -75,16 +75,28 @@ export const Enhanced = forwardRef<
     }
 
     return (
-      <EnhancedEditor
-        ref={ref}
-        sessionId={sessionId}
-        sessionTitle={sessionTitle}
-        enhancedNoteId={enhancedNoteId}
-        content={enhancedNote.content}
-        onNavigateToTitle={onNavigateToTitle}
-        onViewReady={onViewReady}
-        onViewDisposed={onViewDisposed}
-      />
+      <>
+        {showStreaming ? (
+          <StreamingView
+            key="streaming"
+            sessionId={sessionId}
+            sessionTitle={sessionTitle}
+            enhancedNoteId={enhancedNoteId}
+          />
+        ) : null}
+        <EnhancedEditor
+          key="editor"
+          ref={showStreaming ? null : ref}
+          sessionId={sessionId}
+          sessionTitle={sessionTitle}
+          enhancedNoteId={enhancedNoteId}
+          content={enhancedNote.content}
+          isHidden={showStreaming}
+          onNavigateToTitle={onNavigateToTitle}
+          onViewReady={onViewReady}
+          onViewDisposed={onViewDisposed}
+        />
+      </>
     );
   },
 );


### PR DESCRIPTION
Wait for semantically non-empty SQLite content before replacing the generated summary stream, with regression coverage for transient empty refreshes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the enhanced-note streaming-to-editor lifecycle and mount/ref forwarding; behavior is well covered by tests but incorrect timing could still affect editor focus or persistence.
> 
> **Overview**
> Fixes a flash where the completed AI summary disappeared before SQLite caught up, including when the stored note was only an empty ProseMirror doc.
> 
> **Enhanced note UI** now keeps `StreamingView` visible while generation runs **or** after success when there is streamed text but no semantically stored content (`hasStoredNoteContent`). The real `EnhancedEditor` stays mounted the whole time and is toggled with `isHidden` instead of unmounting during streaming, so the same editor instance survives the handoff when persisted content arrives.
> 
> **EnhancedEditor** is wrapped in `React.memo` and accepts `isHidden` to apply a layout `hidden` class on the drop target. Tests cover hidden mounting, memo stability, stream-to-SQLite transitions, empty-document refreshes, and editor instance preservation.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0b370ee5dbf9ba3ef1465dd9aca5005767f7bc9f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->