### PR TITLE
Add token-aware summary prompt editor

### DIFF
--- a/apps/desktop/src/settings/personalization/index.test.tsx
+++ b/apps/desktop/src/settings/personalization/index.test.tsx
@@ -8,6 +8,11 @@ import {
 import type { ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
+const settingsMocks = vi.hoisted(() => ({
+  setValue: vi.fn(),
+  setValues: vi.fn(),
+}));
+
 vi.mock("@lingui/react/macro", () => ({
   Trans: ({
     children,
@@ -40,24 +45,100 @@ vi.mock("@lingui/react/macro", () => ({
   }),
 }));
 
-import { DictionarySettings, SummaryInstructionsSettings } from "./index";
+vi.mock("@hypr/editor/prompt", async () => {
+  const React = await import("react");
+
+  return {
+    PromptEditor: React.forwardRef(function PromptEditorMock(
+      {
+        ariaLabel,
+        initialValue,
+        onBlur,
+        onChange,
+      }: {
+        ariaLabel: string;
+        initialValue: string;
+        onBlur?: () => void;
+        onChange: (value: string) => void;
+      },
+      ref: React.ForwardedRef<{
+        insertToken: (name: "template") => void;
+        setValue: (value: string) => void;
+      }>,
+    ) {
+      React.useImperativeHandle(ref, () => ({
+        insertToken: () => onChange(`${initialValue}{{ template }}`),
+        setValue: onChange,
+      }));
+
+      return (
+        <textarea
+          aria-label={ariaLabel}
+          value={initialValue}
+          onBlur={onBlur}
+          onChange={(event) => onChange(event.target.value)}
+        />
+      );
+    }),
+  };
+});
+
+vi.mock("~/settings/queries", () => ({
+  useSetSettingValue: () => settingsMocks.setValue,
+  useSetSettingValues: () => settingsMocks.setValues,
+}));
+
+vi.mock("~/shared/config", () => ({
+  useConfigValue: (key: string) =>
+    key === "personalization_dictionary_terms"
+      ? []
+      : key === "custom_summary_instructions_token_aware"
+        ? false
+        : "",
+}));
+
+import {
+  DictionarySettings,
+  SettingsPersonalization,
+  SummaryInstructionsSettings,
+} from "./index";
+
+import { DEFAULT_SUMMARY_PROMPT } from "~/shared/summary-prompt";
+
+describe("SettingsPersonalization", () => {
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it("shows the dictionary before the summary instructions", () => {
+    render(<SettingsPersonalization />);
+
+    expect(
+      screen
+        .getAllByRole("heading", { level: 2 })
+        .map((heading) => heading.textContent)
+        .slice(-2),
+    ).toEqual(["Dictionary", "Summary instructions"]);
+  });
+});
 
 describe("SummaryInstructionsSettings", () => {
   afterEach(() => {
     cleanup();
   });
 
-  it("explains that instructions take priority over conflicting templates", () => {
+  it("explains how the template chip controls selected templates", () => {
     render(
       <SummaryInstructionsSettings
-        instructions="Keep it brief"
+        instructions={"Keep it brief\n\n{{ template }}"}
         onSave={vi.fn()}
       />,
     );
 
     expect(
       screen.getByText(
-        /These instructions take priority over the selected template when they conflict/,
+        /The Template chip inserts the selected template. Remove it to ignore templates/,
       ),
     ).toBeTruthy();
     expect(
@@ -66,7 +147,24 @@ describe("SummaryInstructionsSettings", () => {
           name: "Summary instructions",
         }) as HTMLTextAreaElement
       ).value,
-    ).toBe("Keep it brief");
+    ).toBe("Keep it brief\n\n{{ template }}");
+  });
+
+  it("disables reset when the built-in prompt is already active", () => {
+    render(
+      <SummaryInstructionsSettings
+        instructions={DEFAULT_SUMMARY_PROMPT}
+        onSave={vi.fn()}
+      />,
+    );
+
+    expect(
+      (
+        screen.getByRole("button", {
+          name: "Reset to default",
+        }) as HTMLButtonElement
+      ).disabled,
+    ).toBe(true);
   });
 
   it("saves trimmed instructions explicitly", async () => {
@@ -107,7 +205,50 @@ describe("SummaryInstructionsSettings", () => {
           name: "Summary instructions",
         }) as HTMLTextAreaElement
       ).value,
-    ).toBe("");
+    ).toBe(DEFAULT_SUMMARY_PROMPT);
+  });
+
+  it("warns when the template token is removed", () => {
+    render(
+      <SummaryInstructionsSettings
+        instructions="Use headings\n\n{{ template }}"
+        onSave={vi.fn()}
+      />,
+    );
+
+    fireEvent.change(
+      screen.getByRole("textbox", { name: "Summary instructions" }),
+      { target: { value: "Do not use headings." } },
+    );
+
+    expect(screen.getByText(/Selected templates will be ignored/)).toBeTruthy();
+    expect(
+      screen.queryByText(/take priority over the selected template/),
+    ).toBeNull();
+    expect(
+      (screen.getByRole("button", { name: "Template" }) as HTMLButtonElement)
+        .disabled,
+    ).toBe(false);
+  });
+
+  it("can insert the template token back into the prompt", () => {
+    render(
+      <SummaryInstructionsSettings
+        instructions="Use a short summary. "
+        onSave={vi.fn()}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Template" }));
+
+    expect(
+      (
+        screen.getByRole("textbox", {
+          name: "Summary instructions",
+        }) as HTMLTextAreaElement
+      ).value,
+    ).toContain("{{ template }}");
+    expect(screen.queryByText(/Selected templates will be ignored/)).toBeNull();
   });
 });
 

--- a/apps/desktop/src/settings/personalization/index.tsx
+++ b/apps/desktop/src/settings/personalization/index.tsx
@@ -1,7 +1,9 @@
 import { Trans, useLingui } from "@lingui/react/macro";
 import { useForm } from "@tanstack/react-form";
-import { CircleMinusIcon, PlusIcon } from "lucide-react";
+import { BracesIcon, CircleMinusIcon, PlusIcon } from "lucide-react";
+import { useRef } from "react";
 
+import { PromptEditor, type PromptEditorHandle } from "@hypr/editor/prompt";
 import { Button } from "@hypr/ui/components/ui/button";
 import {
   InputGroup,
@@ -9,31 +11,46 @@ import {
   InputGroupButton,
   InputGroupInput,
 } from "@hypr/ui/components/ui/input-group";
-import { Textarea } from "@hypr/ui/components/ui/textarea";
 import { cn } from "@hypr/utils";
 
 import { SettingsPageTitle } from "~/settings/page-title";
-import { useSetSettingValue } from "~/settings/queries";
+import { useSetSettingValue, useSetSettingValues } from "~/settings/queries";
 import { useConfigValue } from "~/shared/config";
+import {
+  DEFAULT_SUMMARY_PROMPT,
+  getTokenAwareSummaryPrompt,
+  hasSummaryTemplateToken,
+  isDefaultSummaryPrompt,
+} from "~/shared/summary-prompt";
 import { normalizeKeywordList, parseDictionaryTermsText } from "~/stt/keywords";
 
 export function SettingsPersonalization() {
   const terms = useConfigValue("personalization_dictionary_terms");
   const setTerms = useSetSettingValue("personalization_dictionary_terms");
   const summaryInstructions = useConfigValue("custom_summary_instructions");
-  const setSummaryInstructions = useSetSettingValue(
-    "custom_summary_instructions",
+  const summaryInstructionsTokenAware = useConfigValue(
+    "custom_summary_instructions_token_aware",
+  );
+  const setSummarySettings = useSetSettingValues();
+  const editableSummaryInstructions = getTokenAwareSummaryPrompt(
+    summaryInstructions,
+    summaryInstructionsTokenAware,
   );
 
   return (
     <div className="flex flex-col gap-8">
       <SettingsPageTitle title={<Trans>Personalization</Trans>} />
-      <SummaryInstructionsSettings
-        key={summaryInstructions}
-        instructions={summaryInstructions}
-        onSave={setSummaryInstructions}
-      />
       <DictionarySettings terms={terms} onSave={setTerms} />
+      <SummaryInstructionsSettings
+        key={editableSummaryInstructions}
+        instructions={editableSummaryInstructions}
+        onSave={(value) =>
+          setSummarySettings({
+            custom_summary_instructions: value,
+            custom_summary_instructions_token_aware: true,
+          })
+        }
+      />
     </div>
   );
 }
@@ -46,18 +63,23 @@ export function SummaryInstructionsSettings({
   onSave: (value: string) => void;
 }) {
   const { t } = useLingui();
+  const editorRef = useRef<PromptEditorHandle>(null);
+  const savedInstructions = instructions.trim() || DEFAULT_SUMMARY_PROMPT;
   const form = useForm({
-    defaultValues: { instructions },
+    defaultValues: { instructions: savedInstructions },
     onSubmit: ({ value }) => {
-      const nextInstructions = value.instructions.trim();
-      onSave(nextInstructions);
+      const nextInstructions =
+        value.instructions.trim() || DEFAULT_SUMMARY_PROMPT;
+      onSave(isDefaultSummaryPrompt(nextInstructions) ? "" : nextInstructions);
       form.reset({ instructions: nextInstructions });
+      editorRef.current?.setValue(nextInstructions);
     },
   });
 
   const resetToDefault = () => {
     onSave("");
-    form.reset({ instructions: "" });
+    form.reset({ instructions: DEFAULT_SUMMARY_PROMPT });
+    editorRef.current?.setValue(DEFAULT_SUMMARY_PROMPT);
   };
 
   return (
@@ -81,25 +103,67 @@ export function SummaryInstructionsSettings({
       </div>
 
       <form.Field name="instructions">
-        {(field) => (
-          <Textarea
-            aria-label={t`Summary instructions`}
-            className="bg-card min-h-40 resize-y rounded-2xl px-4 py-3 text-sm"
-            maxLength={4000}
-            placeholder={t`Example: Start with a two-sentence overview, then list decisions and action items with owners. Do not use headings.`}
-            value={field.state.value}
-            onChange={(event) => field.handleChange(event.target.value)}
-            onBlur={field.handleBlur}
-          />
-        )}
-      </form.Field>
+        {(field) => {
+          const includesTemplate = hasSummaryTemplateToken(field.state.value);
 
-      <p className="text-muted-foreground text-sm">
-        <Trans>
-          These instructions take priority over the selected template when they
-          conflict. Clear them to use templates as written.
-        </Trans>
-      </p>
+          return (
+            <div className="flex flex-col gap-3">
+              <div className="border-border bg-card overflow-hidden rounded-2xl border">
+                <div className="border-border bg-muted/40 flex items-center justify-between gap-3 border-b px-3 py-2">
+                  <span className="text-muted-foreground text-xs font-medium">
+                    Variables
+                  </span>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    size="sm"
+                    className="h-7 rounded-full px-2.5 text-xs"
+                    disabled={includesTemplate}
+                    onClick={() => editorRef.current?.insertToken("template")}
+                  >
+                    <BracesIcon className="size-3.5" />
+                    Template
+                  </Button>
+                </div>
+                <PromptEditor
+                  ref={editorRef}
+                  ariaLabel={t`Summary instructions`}
+                  className="min-h-40 px-4 py-3 text-sm leading-5"
+                  initialValue={field.state.value}
+                  maxLength={4000}
+                  placeholder={t`Example: Start with a two-sentence overview, then list decisions and action items with owners. Do not use headings.`}
+                  onChange={field.handleChange}
+                  onBlur={field.handleBlur}
+                />
+              </div>
+
+              <p className="text-muted-foreground text-sm">
+                The Template chip inserts the selected template. Remove it to
+                ignore templates and use only these instructions.
+              </p>
+
+              {includesTemplate ? (
+                <p className="text-muted-foreground text-sm">
+                  <Trans>
+                    These instructions take priority over the selected template
+                    when they conflict. Clear them to use templates as written.
+                  </Trans>
+                </p>
+              ) : null}
+
+              {!includesTemplate && field.state.value.trim() ? (
+                <p
+                  role="status"
+                  className="rounded-xl border border-amber-200 bg-amber-50 px-3 py-2 text-sm text-amber-900 dark:border-amber-900/60 dark:bg-amber-950/40 dark:text-amber-200"
+                >
+                  Template is not included. Selected templates will be ignored
+                  when summaries are generated.
+                </p>
+              ) : null}
+            </div>
+          );
+        }}
+      </form.Field>
 
       <div className="flex items-center justify-end gap-2">
         <form.Subscribe selector={(state) => state.values.instructions}>
@@ -107,7 +171,10 @@ export function SummaryInstructionsSettings({
             <Button
               type="button"
               variant="ghost"
-              disabled={value.length === 0 && instructions.length === 0}
+              disabled={
+                isDefaultSummaryPrompt(value) &&
+                isDefaultSummaryPrompt(instructions)
+              }
               onClick={resetToDefault}
             >
               <Trans>Reset to default</Trans>

--- a/apps/desktop/src/settings/schema.ts
+++ b/apps/desktop/src/settings/schema.ts
@@ -114,6 +114,11 @@ export const SETTING_DEFINITIONS = {
     path: ["personalization", "custom_summary_instructions"],
     default: "" as string,
   },
+  custom_summary_instructions_token_aware: {
+    type: "boolean",
+    path: ["personalization", "custom_summary_instructions_token_aware"],
+    default: false as boolean,
+  },
   ignored_platforms: {
     type: "string",
     path: ["notification", "ignored_platforms"],

--- a/apps/desktop/src/shared/summary-prompt.test.ts
+++ b/apps/desktop/src/shared/summary-prompt.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  DEFAULT_SUMMARY_PROMPT,
+  getTokenAwareSummaryPrompt,
+  hasSummaryTemplateToken,
+  isDefaultSummaryPrompt,
+  renderSummaryPrompt,
+} from "./summary-prompt";
+
+const template = {
+  title: "Standup",
+  description: "Daily team sync",
+  sections: [
+    { title: "Updates", description: null },
+    { title: "Blockers", description: "Call out owners" },
+  ],
+};
+
+describe("summary prompt", () => {
+  it("recognizes the template token with flexible whitespace", () => {
+    expect(hasSummaryTemplateToken("Before {{template}} after")).toBe(true);
+    expect(hasSummaryTemplateToken("Before {{  template  }} after")).toBe(true);
+    expect(hasSummaryTemplateToken("No template token")).toBe(false);
+  });
+
+  it("identifies the built-in prompt", () => {
+    expect(isDefaultSummaryPrompt(DEFAULT_SUMMARY_PROMPT)).toBe(true);
+    expect(isDefaultSummaryPrompt(`\n${DEFAULT_SUMMARY_PROMPT}\n`)).toBe(true);
+    expect(isDefaultSummaryPrompt("Write a short summary")).toBe(false);
+  });
+
+  it("adds the template token to legacy custom instructions", () => {
+    expect(getTokenAwareSummaryPrompt("Keep it brief", false)).toBe(
+      "Keep it brief\n\n{{ template }}",
+    );
+  });
+
+  it("preserves an intentional missing token after migration", () => {
+    expect(getTokenAwareSummaryPrompt("Keep it brief", true)).toBe(
+      "Keep it brief",
+    );
+  });
+
+  it("injects the selected template at every template token", () => {
+    const rendered = renderSummaryPrompt(
+      "Use this:\n{{ template }}\nAgain:\n{{template}}",
+      template,
+    );
+
+    expect(rendered).not.toContain("{{ template }}");
+    expect(rendered.match(/# Summary Template/g)).toHaveLength(2);
+    expect(rendered).toContain("Name: Standup");
+    expect(rendered).toContain("Description: Daily team sync");
+    expect(rendered).toContain("1. Updates");
+    expect(rendered).toContain("2. Blockers - Call out owners");
+  });
+
+  it("leaves prompts without a template token unchanged", () => {
+    expect(renderSummaryPrompt("Do not use headings.", template)).toBe(
+      "Do not use headings.",
+    );
+  });
+});

--- a/apps/desktop/src/shared/summary-prompt.ts
+++ b/apps/desktop/src/shared/summary-prompt.ts
@@ -1,0 +1,69 @@
+import type { EnhanceTemplate } from "@hypr/plugin-template";
+
+export const SUMMARY_TEMPLATE_TOKEN = "{{ template }}";
+
+export const DEFAULT_SUMMARY_PROMPT = `Use the selected summary template for the summary structure and section headings.
+
+${SUMMARY_TEMPLATE_TOKEN}`;
+
+const SUMMARY_TEMPLATE_TOKEN_PATTERN = /\{\{\s*template\s*\}\}/;
+const SUMMARY_TEMPLATE_TOKEN_PATTERN_GLOBAL = /\{\{\s*template\s*\}\}/g;
+
+export function hasSummaryTemplateToken(prompt: string): boolean {
+  return SUMMARY_TEMPLATE_TOKEN_PATTERN.test(prompt);
+}
+
+export function isDefaultSummaryPrompt(prompt: string): boolean {
+  return prompt.trim() === DEFAULT_SUMMARY_PROMPT;
+}
+
+export function getTokenAwareSummaryPrompt(
+  prompt: string,
+  tokenAware: boolean,
+): string {
+  const trimmed = prompt.trim();
+  if (!trimmed) {
+    return DEFAULT_SUMMARY_PROMPT;
+  }
+  if (tokenAware || hasSummaryTemplateToken(trimmed)) {
+    return trimmed;
+  }
+  return `${trimmed}\n\n${SUMMARY_TEMPLATE_TOKEN}`;
+}
+
+export function renderSummaryPrompt(
+  prompt: string,
+  template: EnhanceTemplate | null,
+): string {
+  return prompt.replace(SUMMARY_TEMPLATE_TOKEN_PATTERN_GLOBAL, () =>
+    formatSummaryTemplate(template),
+  );
+}
+
+function formatSummaryTemplate(template: EnhanceTemplate | null): string {
+  if (!template) {
+    return `# Instructions
+
+1. Analyze the content and decide the sections to use.
+2. Generate a well-formatted markdown summary.`;
+  }
+
+  const lines = ["# Summary Template"];
+
+  if (template.title.trim()) {
+    lines.push("", `Name: ${template.title.trim()}`);
+  }
+  if (template.description?.trim()) {
+    lines.push(`Description: ${template.description.trim()}`);
+  }
+
+  lines.push("", "Sections:");
+  template.sections.forEach((section, index) => {
+    const description = section.description?.trim();
+    lines.push(
+      `${index + 1}. ${section.title.trim()}${description ? ` - ${description}` : ""}`,
+    );
+  });
+
+  return lines.join("\n");
+}

--- a/apps/desktop/src/sidebar/settings.test.tsx
+++ b/apps/desktop/src/sidebar/settings.test.tsx
@@ -1,6 +1,6 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import type { ReactNode } from "react";
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
   currentTab: { type: "settings", state: { tab: "app" } } as {
@@ -74,6 +74,8 @@ vi.mock("~/store/zustand/tabs", () => ({
 import { SettingsNav } from "./settings";
 
 describe("SettingsNav", () => {
+  afterEach(cleanup);
+
   beforeEach(() => {
     mocks.currentTab = { type: "settings", state: { tab: "app" } };
     mocks.openNew.mockClear();
@@ -100,5 +102,12 @@ describe("SettingsNav", () => {
     ].forEach((label) => {
       expect(screen.getByText(label)).toBeTruthy();
     });
+  });
+
+  it("uses a smile icon for personalization", () => {
+    render(<SettingsNav />);
+
+    const button = screen.getByText("Personalization").closest("button");
+    expect(button?.querySelector(".lucide-smile")).toBeTruthy();
   });
 });

--- a/apps/desktop/src/sidebar/settings.tsx
+++ b/apps/desktop/src/sidebar/settings.tsx
@@ -8,7 +8,7 @@ import {
   CalendarIcon,
   CogIcon,
   LockIcon,
-  SlidersHorizontalIcon,
+  SmileIcon,
   SparklesIcon,
   type LucideIcon,
   UserIcon,
@@ -101,7 +101,7 @@ export function SettingsNav() {
         {
           id: "personalization",
           label: t`Personalization`,
-          icon: SlidersHorizontalIcon,
+          icon: SmileIcon,
         },
       ],
     },

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { enhanceTransform } from "./enhance-transform";
 
+import { DEFAULT_SUMMARY_PROMPT } from "~/shared/summary-prompt";
+
 const mocks = vi.hoisted(() => ({
   collectEnhanceImageContext: vi.fn(),
   getTemplateById: vi.fn(),
@@ -111,7 +113,7 @@ describe("enhanceTransform.transformArgs", () => {
     ]);
   });
 
-  it("includes custom summary instructions from personalization settings", async () => {
+  it("keeps templates in legacy custom summary instructions", async () => {
     const result = await enhanceTransform.transformArgs(
       { sessionId: "session-1", enhancedNoteId: "note-1" },
       {
@@ -120,7 +122,31 @@ describe("enhanceTransform.transformArgs", () => {
       },
     );
 
+    expect(result.customInstructions).toBe(
+      "Start with decisions.\n\n{{ template }}",
+    );
+  });
+
+  it("allows token-aware custom instructions to ignore templates", async () => {
+    const result = await enhanceTransform.transformArgs(
+      { sessionId: "session-1", enhancedNoteId: "note-1" },
+      {
+        ...settingsValues,
+        custom_summary_instructions: "Start with decisions.",
+        custom_summary_instructions_token_aware: true,
+      },
+    );
+
     expect(result.customInstructions).toBe("Start with decisions.");
+  });
+
+  it("uses the built-in summary prompt when no override is saved", async () => {
+    const result = await enhanceTransform.transformArgs(
+      { sessionId: "session-1", enhancedNoteId: "note-1" },
+      settingsValues,
+    );
+
+    expect(result.customInstructions).toBe(DEFAULT_SUMMARY_PROMPT);
   });
 
   it("falls back to generic enhancement when template loading fails", async () => {

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-transform.ts
@@ -16,6 +16,7 @@ import {
 } from "~/session/content-queries";
 import { modelSupportsImageInput } from "~/settings/ai/shared/model-capabilities";
 import type { SettingValues } from "~/settings/schema";
+import { getTokenAwareSummaryPrompt } from "~/shared/summary-prompt";
 import {
   buildRenderTranscriptRequestFromRows,
   collectAssignedHumanIdsFromTranscriptRows,
@@ -140,7 +141,10 @@ function getLanguage(settingsValues: SettingValues): string | null {
 
 function getCustomInstructions(settingsValues: SettingValues): string {
   const value = settingsValues.custom_summary_instructions;
-  return typeof value === "string" ? value.trim() : "";
+  return getTokenAwareSummaryPrompt(
+    typeof value === "string" ? value : "",
+    settingsValues.custom_summary_instructions_token_aware === true,
+  );
 }
 
 function getOptionalSettingsValue(

--- a/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
+++ b/apps/desktop/src/store/zustand/ai-task/task-configs/enhance-workflow.ts
@@ -20,6 +20,11 @@ import type { EnhanceImageContext } from "./enhance-images";
 import { createEnhanceValidator } from "./enhance-validator";
 
 import { deterministicGenerationSettings } from "~/ai/model-settings";
+import {
+  hasSummaryTemplateToken,
+  isDefaultSummaryPrompt,
+  renderSummaryPrompt,
+} from "~/shared/summary-prompt";
 import { normalizeBulletPoints } from "~/store/zustand/ai-task/shared/transform_impl";
 import { withEarlyValidationRetry } from "~/store/zustand/ai-task/shared/validate";
 import { assertCanonicalTemplateSections } from "~/templates/codec";
@@ -49,15 +54,25 @@ async function* executeWorkflow(params: {
 }) {
   const { model, args, onProgress, signal } = params;
 
-  const sections = await generateTemplateIfNeeded({
-    model,
-    args,
-    onProgress,
-    signal,
-  });
+  const usesTemplate = hasSummaryTemplateToken(args.customInstructions);
+  const sections = usesTemplate
+    ? await generateTemplateIfNeeded({
+        model,
+        args,
+        onProgress,
+        signal,
+      })
+    : null;
   const argsWithTemplate: TaskArgsMapTransformed["enhance"] = {
     ...args,
-    template: sections ? { title: "", description: null, sections } : null,
+    template:
+      usesTemplate && sections
+        ? {
+            title: args.template?.title ?? "",
+            description: args.template?.description ?? null,
+            sections,
+          }
+        : null,
   };
 
   const system = await getSystemPrompt(argsWithTemplate);
@@ -80,7 +95,10 @@ async function getSystemPrompt(args: TaskArgsMapTransformed["enhance"]) {
   const result = await templateCommands.render({
     enhanceSystem: {
       language: args.language,
-      customInstructions: args.customInstructions,
+      customInstructions: renderSummaryPrompt(
+        args.customInstructions,
+        args.template,
+      ),
     },
   });
 
@@ -250,7 +268,9 @@ async function* generateSummary(params: {
   onProgress({ type: "generating" });
 
   const validator = createEnhanceValidator(args.template, {
-    overrideTemplateFormatting: args.customInstructions.trim().length > 0,
+    overrideTemplateFormatting: !isDefaultSummaryPrompt(
+      args.customInstructions,
+    ),
   });
 
   yield* withEarlyValidationRetry(

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -11,6 +11,7 @@
     "./node-views": "./src/node-views/index.ts",
     "./note": "./src/note/index.tsx",
     "./plugins": "./src/plugins/index.ts",
+    "./prompt": "./src/prompt/index.tsx",
     "./task-storage": "./src/task-storage.tsx",
     "./tasks": "./src/tasks.ts",
     "./widgets": "./src/widgets/index.ts"

--- a/packages/editor/src/prompt/index.test.ts
+++ b/packages/editor/src/prompt/index.test.ts
@@ -1,0 +1,47 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { PromptEditor, promptDocToText, promptTextToDoc } from ".";
+
+describe("prompt editor serialization", () => {
+  afterEach(cleanup);
+
+  it("turns supported template expressions into atomic token nodes", () => {
+    const doc = promptTextToDoc("Before {{template}} after");
+    const paragraph = doc.firstChild;
+
+    expect(paragraph?.childCount).toBe(3);
+    expect(paragraph?.child(1).type.name).toBe("promptToken");
+    expect(paragraph?.child(1).attrs.name).toBe("template");
+    expect(promptDocToText(doc)).toBe("Before {{ template }} after");
+  });
+
+  it("preserves paragraphs, empty lines, and unknown expressions", () => {
+    const value = "First line\n\nKeep {{ unknown }} as text\nLast line";
+    expect(promptDocToText(promptTextToDoc(value))).toBe(value);
+  });
+
+  it("normalizes Windows line endings", () => {
+    expect(promptDocToText(promptTextToDoc("First\r\nSecond"))).toBe(
+      "First\nSecond",
+    );
+  });
+
+  it("renders template expressions as visible atomic chips", () => {
+    const { container } = render(
+      createElement(PromptEditor, {
+        ariaLabel: "Summary instructions",
+        initialValue: "Follow {{ template }}",
+        onChange: vi.fn(),
+      }),
+    );
+
+    expect(
+      screen.getByRole("textbox", { name: "Summary instructions" }),
+    ).toBeTruthy();
+    expect(
+      container.querySelector('[data-prompt-token="template"]')?.textContent,
+    ).toBe("Template");
+  });
+});

--- a/packages/editor/src/prompt/index.tsx
+++ b/packages/editor/src/prompt/index.tsx
@@ -1,0 +1,268 @@
+import "prosemirror-view/style/prosemirror.css";
+import "../styles/prosemirror.css";
+
+import {
+  ProseMirror,
+  ProseMirrorDoc,
+  reactKeys,
+  useEditorEffect,
+} from "@handlewithcare/react-prosemirror";
+import { baseKeymap } from "prosemirror-commands";
+import { history, redo, undo } from "prosemirror-history";
+import { keymap } from "prosemirror-keymap";
+import { type Node as PMNode, type NodeSpec, Schema } from "prosemirror-model";
+import { EditorState, Plugin, PluginKey } from "prosemirror-state";
+import type { EditorView } from "prosemirror-view";
+import {
+  type Ref,
+  type RefObject,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
+
+import { cn } from "@hypr/utils";
+
+import { EditorErrorBoundary } from "../editor-error-boundary";
+import { docChangeListenerPlugin, placeholderPlugin } from "../plugins";
+
+export type PromptTokenName = "template";
+
+const TOKEN_PATTERN = /\{\{\s*(template)\s*\}\}/g;
+
+const promptTokenNodeSpec: NodeSpec = {
+  group: "inline",
+  inline: true,
+  atom: true,
+  selectable: true,
+  attrs: { name: { default: "template" } },
+  parseDOM: [
+    {
+      tag: "span[data-prompt-token]",
+      getAttrs(dom) {
+        const name = (dom as HTMLElement).getAttribute("data-prompt-token");
+        return name === "template" ? { name } : false;
+      },
+    },
+  ],
+  toDOM(node) {
+    return [
+      "span",
+      {
+        class: "prompt-token",
+        contenteditable: "false",
+        "data-prompt-token": node.attrs.name,
+      },
+      "Template",
+    ];
+  },
+};
+
+export const promptSchema = new Schema({
+  nodes: {
+    doc: { content: "paragraph+" },
+    paragraph: {
+      content: "inline*",
+      group: "block",
+      parseDOM: [{ tag: "p" }],
+      toDOM() {
+        return ["p", 0];
+      },
+    },
+    text: { group: "inline" },
+    hardBreak: {
+      inline: true,
+      group: "inline",
+      selectable: false,
+      parseDOM: [{ tag: "br" }],
+      toDOM() {
+        return ["br"];
+      },
+    },
+    promptToken: promptTokenNodeSpec,
+  },
+});
+
+export function promptTextToDoc(value: string): PMNode {
+  const paragraphs = value
+    .replace(/\r\n/g, "\n")
+    .split("\n")
+    .map((line) => {
+      const content: PMNode[] = [];
+      let cursor = 0;
+
+      for (const match of line.matchAll(TOKEN_PATTERN)) {
+        const index = match.index;
+        if (index > cursor) {
+          content.push(promptSchema.text(line.slice(cursor, index)));
+        }
+        content.push(
+          promptSchema.nodes.promptToken.create({ name: "template" }),
+        );
+        cursor = index + match[0].length;
+      }
+
+      if (cursor < line.length) {
+        content.push(promptSchema.text(line.slice(cursor)));
+      }
+
+      return promptSchema.nodes.paragraph.create(null, content);
+    });
+
+  return promptSchema.nodes.doc.create(null, paragraphs);
+}
+
+export function promptDocToText(doc: PMNode): string {
+  const paragraphs: string[] = [];
+
+  doc.forEach((paragraph) => {
+    let value = "";
+    paragraph.forEach((node) => {
+      if (node.isText) {
+        value += node.text ?? "";
+      } else if (node.type.name === "promptToken") {
+        value += `{{ ${String(node.attrs.name)} }}`;
+      } else if (node.type.name === "hardBreak") {
+        value += "\n";
+      }
+    });
+    paragraphs.push(value);
+  });
+
+  return paragraphs.join("\n");
+}
+
+export interface PromptEditorHandle {
+  focus(): void;
+  insertToken(name: PromptTokenName): void;
+  setValue(value: string): void;
+}
+
+export function PromptEditor({
+  ref,
+  ariaLabel,
+  className,
+  initialValue,
+  maxLength,
+  onBlur,
+  onChange,
+  placeholder,
+}: {
+  ref?: Ref<PromptEditorHandle>;
+  ariaLabel: string;
+  className?: string;
+  initialValue: string;
+  maxLength?: number;
+  onBlur?: () => void;
+  onChange: (value: string) => void;
+  placeholder?: string;
+}) {
+  const viewRef = useRef<EditorView | null>(null);
+  const onBlurRef = useRef(onBlur);
+  onBlurRef.current = onBlur;
+  const onChangeRef = useRef(onChange);
+  onChangeRef.current = onChange;
+
+  useImperativeHandle(
+    ref,
+    () => ({
+      focus() {
+        viewRef.current?.focus();
+      },
+      insertToken(name) {
+        const view = viewRef.current;
+        if (!view) return;
+
+        const token = promptSchema.nodes.promptToken.create({ name });
+        view.dispatch(
+          view.state.tr.replaceSelectionWith(token).scrollIntoView(),
+        );
+        view.focus();
+      },
+      setValue(value) {
+        const view = viewRef.current;
+        if (!view) return;
+
+        const doc = promptTextToDoc(value);
+        view.dispatch(
+          view.state.tr.replaceWith(
+            0,
+            view.state.doc.content.size,
+            doc.content,
+          ),
+        );
+      },
+    }),
+    [],
+  );
+
+  const plugins = useMemo(
+    () => [
+      reactKeys(),
+      docChangeListenerPlugin((doc) => {
+        onChangeRef.current(promptDocToText(doc));
+      }),
+      keymap({ "Mod-z": undo, "Mod-Shift-z": redo, "Mod-y": redo }),
+      keymap(baseKeymap),
+      history(),
+      placeholderPlugin(() => placeholder ?? ""),
+      new Plugin({
+        key: new PluginKey("promptEditorEvents"),
+        filterTransaction(transaction) {
+          return (
+            !transaction.docChanged ||
+            !maxLength ||
+            promptDocToText(transaction.doc).length <= maxLength
+          );
+        },
+        props: {
+          handleDOMEvents: {
+            blur() {
+              onBlurRef.current?.();
+              return false;
+            },
+          },
+        },
+      }),
+    ],
+    [maxLength, placeholder],
+  );
+
+  const defaultState = useMemo(
+    () =>
+      EditorState.create({
+        doc: promptTextToDoc(initialValue),
+        plugins,
+      }),
+    [initialValue, plugins],
+  );
+  const editorKey = `${maxLength ?? ""}:${placeholder ?? ""}`;
+
+  return (
+    <EditorErrorBoundary>
+      <ProseMirror
+        key={editorKey}
+        defaultState={defaultState}
+        attributes={{
+          "aria-label": ariaLabel,
+          autoCapitalize: "sentences",
+          autoComplete: "off",
+          autoCorrect: "on",
+          class: cn(["prosemirror-editor prompt-editor", className]),
+          role: "textbox",
+          spellCheck: "true",
+        }}
+      >
+        <ProseMirrorDoc />
+        <ViewCapture viewRef={viewRef} />
+      </ProseMirror>
+    </EditorErrorBoundary>
+  );
+}
+
+function ViewCapture({ viewRef }: { viewRef: RefObject<EditorView | null> }) {
+  useEditorEffect((view) => {
+    if (view && viewRef.current !== view) viewRef.current = view;
+  });
+  return null;
+}

--- a/packages/editor/src/styles/prosemirror.css
+++ b/packages/editor/src/styles/prosemirror.css
@@ -16,6 +16,30 @@
 @import "./prosemirror/dark.css";
 @import "./prosemirror/mention.css";
 
+.ProseMirror.prompt-editor {
+  padding-bottom: 0;
+}
+
+.ProseMirror .prompt-token {
+  display: inline-flex;
+  align-items: center;
+  border: 1px solid hsl(var(--border));
+  border-radius: 9999px;
+  background: hsl(var(--accent));
+  color: hsl(var(--accent-foreground));
+  padding: 0.05rem 0.45rem;
+  font-size: 0.75rem;
+  font-weight: 500;
+  line-height: 1.25rem;
+  vertical-align: baseline;
+  white-space: nowrap;
+}
+
+.ProseMirror .prompt-token.ProseMirror-selectednode {
+  outline: 2px solid hsl(var(--ring));
+  outline-offset: 1px;
+}
+
 .ProseMirror .is-editor-empty:first-child::before {
   content: attr(data-placeholder);
   float: left;


### PR DESCRIPTION
Move Dictionary first, render template variables as removable editor chips, and ignore templates when the template token is removed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how meeting summaries are built (template injection, skipping template work when the token is removed) and migrates existing personalization settings, though behavior is covered by new unit tests.
> 
> **Overview**
> Summary instructions on Personalization now use a **PromptEditor** with a **Template** variable chip instead of a plain textarea. **Dictionary** appears above summary instructions, and saves set `custom_summary_instructions_token_aware` so intentional edits (including removing the token) are preserved.
> 
> A shared **`summary-prompt`** module defines the default prompt, detects `{{ template }}`, migrates legacy text by appending the token once, and **renders** tokens into formatted template content at generation time. The **enhance** pipeline only runs template-section analysis when the token is present; without it, selected templates are ignored. Reset/save treat the built-in default as clearing the stored override.
> 
> **`@hypr/editor/prompt`** adds ProseMirror-based editing with atomic template chips. Settings nav uses a smile icon for Personalization.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 60e2b745e8386d8b88d83d922bbbafb76918ecd6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->