### PR TITLE
Secure exposed Supabase tables

### DIFF
--- a/supabase/migrations/20260714134923_secure_internal_tables.sql
+++ b/supabase/migrations/20260714134923_secure_internal_tables.sql
@@ -1,0 +1,94 @@
+DO $$
+DECLARE
+  table_name text;
+BEGIN
+  FOREACH table_name IN ARRAY ARRAY[
+    'checkpoint_migrations',
+    'checkpoints',
+    'checkpoint_blobs',
+    'checkpoint_writes'
+  ]
+  LOOP
+    IF to_regclass(format('public.%I', table_name)) IS NOT NULL THEN
+      EXECUTE format('ALTER TABLE public.%I ENABLE ROW LEVEL SECURITY', table_name);
+      EXECUTE format('REVOKE ALL ON TABLE public.%I FROM anon, authenticated', table_name);
+      EXECUTE format('GRANT ALL ON TABLE public.%I TO service_role', table_name);
+      EXECUTE format('DROP POLICY IF EXISTS checkpoint_internal_only ON public.%I', table_name);
+      EXECUTE format(
+        'CREATE POLICY checkpoint_internal_only ON public.%I AS RESTRICTIVE FOR ALL TO anon, authenticated USING (false) WITH CHECK (false)',
+        table_name
+      );
+    END IF;
+  END LOOP;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF to_regclass('public.media_assets') IS NOT NULL THEN
+    ALTER TABLE public.media_assets ENABLE ROW LEVEL SECURITY;
+
+    REVOKE ALL ON TABLE public.media_assets FROM anon, authenticated;
+    GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.media_assets TO authenticated;
+    GRANT ALL ON TABLE public.media_assets TO service_role;
+
+    DROP POLICY IF EXISTS media_assets_admin_all ON public.media_assets;
+    -- This mirrors the server-side admin allowlist so existing admin media routes keep working under RLS.
+    CREATE POLICY media_assets_admin_all
+      ON public.media_assets
+      AS PERMISSIVE
+      FOR ALL
+      TO authenticated
+      USING (
+        (SELECT lower(auth.jwt() ->> 'email')) = ANY (ARRAY[
+          'yujonglee@hyprnote.com',
+          'yujonglee.dev@gmail.com',
+          'john@hyprnote.com',
+          'marketing@hyprnote.com',
+          'yunhyungjo@yonsei.ac.kr',
+          'goranmoomin@daum.net',
+          'artem@hyprnote.com',
+          'stua@fastmail.com',
+          'thestua@gmail.com'
+        ])
+      )
+      WITH CHECK (
+        (SELECT lower(auth.jwt() ->> 'email')) = ANY (ARRAY[
+          'yujonglee@hyprnote.com',
+          'yujonglee.dev@gmail.com',
+          'john@hyprnote.com',
+          'marketing@hyprnote.com',
+          'yunhyungjo@yonsei.ac.kr',
+          'goranmoomin@daum.net',
+          'artem@hyprnote.com',
+          'stua@fastmail.com',
+          'thestua@gmail.com'
+        ])
+      );
+  END IF;
+END;
+$$;
+
+DO $$
+BEGIN
+  IF to_regprocedure('public.set_updated_at()') IS NOT NULL THEN
+    ALTER FUNCTION public.set_updated_at() SET search_path = '';
+  END IF;
+
+  IF to_regprocedure('public.handle_new_user()') IS NOT NULL THEN
+    ALTER FUNCTION public.handle_new_user() SET search_path = '';
+    REVOKE EXECUTE ON FUNCTION public.handle_new_user() FROM PUBLIC, anon, authenticated;
+    GRANT EXECUTE ON FUNCTION public.handle_new_user() TO supabase_auth_admin;
+  END IF;
+
+  IF to_regprocedure('public.handle_user_email_update()') IS NOT NULL THEN
+    ALTER FUNCTION public.handle_user_email_update() SET search_path = '';
+    REVOKE EXECUTE ON FUNCTION public.handle_user_email_update() FROM PUBLIC, anon, authenticated;
+    GRANT EXECUTE ON FUNCTION public.handle_user_email_update() TO supabase_auth_admin;
+  END IF;
+
+  IF to_regprocedure('public.custom_access_token_hook(jsonb)') IS NOT NULL THEN
+    ALTER FUNCTION public.custom_access_token_hook(jsonb) SET search_path = '';
+  END IF;
+END;
+$$;

--- a/supabase/tests/006-security-advisor-hardening.sql
+++ b/supabase/tests/006-security-advisor-hardening.sql
@@ -1,0 +1,171 @@
+begin;
+select plan(10);
+
+select ok(
+  not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname in (
+        'checkpoint_migrations',
+        'checkpoints',
+        'checkpoint_blobs',
+        'checkpoint_writes',
+        'media_assets'
+      )
+      and not c.relrowsecurity
+  ),
+  'RLS is enabled on internal public tables'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    cross join unnest(array['SELECT', 'INSERT', 'UPDATE', 'DELETE']) privilege
+    where n.nspname = 'public'
+      and c.relname in (
+        'checkpoint_migrations',
+        'checkpoints',
+        'checkpoint_blobs',
+        'checkpoint_writes'
+      )
+      and has_table_privilege('anon', c.oid, privilege)
+  ),
+  'Anonymous users cannot access checkpoint tables'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    cross join unnest(array['SELECT', 'INSERT', 'UPDATE', 'DELETE']) privilege
+    where n.nspname = 'public'
+      and c.relname in (
+        'checkpoint_migrations',
+        'checkpoints',
+        'checkpoint_blobs',
+        'checkpoint_writes'
+      )
+      and has_table_privilege('authenticated', c.oid, privilege)
+  ),
+  'Authenticated users cannot access checkpoint tables'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    where n.nspname = 'public'
+      and c.relname in (
+        'checkpoint_migrations',
+        'checkpoints',
+        'checkpoint_blobs',
+        'checkpoint_writes'
+      )
+      and not exists (
+        select 1
+        from pg_policies p
+        where p.schemaname = n.nspname
+          and p.tablename = c.relname
+          and p.policyname = 'checkpoint_internal_only'
+          and p.permissive = 'RESTRICTIVE'
+          and p.cmd = 'ALL'
+      )
+  ),
+  'Checkpoint tables have an explicit deny policy for API roles'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    cross join unnest(array['SELECT', 'INSERT', 'UPDATE', 'DELETE']) privilege
+    where n.nspname = 'public'
+      and c.relname = 'media_assets'
+      and has_table_privilege('anon', c.oid, privilege)
+  ),
+  'Anonymous users cannot access media assets'
+);
+
+select ok(
+  to_regclass('public.media_assets') is null
+    or exists (
+      select 1
+      from pg_policies
+      where schemaname = 'public'
+        and tablename = 'media_assets'
+        and policyname = 'media_assets_admin_all'
+        and roles = array['authenticated']::name[]
+        and cmd = 'ALL'
+    ),
+  'Media assets have an authenticated admin policy'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_class c
+    join pg_namespace n on n.oid = c.relnamespace
+    cross join unnest(array['SELECT', 'INSERT', 'UPDATE', 'DELETE']) privilege
+    where n.nspname = 'public'
+      and c.relname in (
+        'checkpoint_migrations',
+        'checkpoints',
+        'checkpoint_blobs',
+        'checkpoint_writes',
+        'media_assets'
+      )
+      and not has_table_privilege('service_role', c.oid, privilege)
+  ),
+  'Service role access is preserved'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname in (
+        'set_updated_at',
+        'handle_new_user',
+        'handle_user_email_update',
+        'custom_access_token_hook'
+      )
+      and not ('search_path=""' = any(coalesce(p.proconfig, array[]::text[])))
+  ),
+  'Security-sensitive functions use an immutable search path'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname in ('handle_new_user', 'handle_user_email_update')
+      and has_function_privilege('anon', p.oid, 'EXECUTE')
+  ),
+  'Anonymous users cannot execute auth trigger functions'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc p
+    join pg_namespace n on n.oid = p.pronamespace
+    where n.nspname = 'public'
+      and p.proname in ('handle_new_user', 'handle_user_email_update')
+      and has_function_privilege('authenticated', p.oid, 'EXECUTE')
+  ),
+  'Authenticated users cannot execute auth trigger functions'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary
- enable RLS and revoke API-role access for internal checkpoint tables
- limit media asset access to authenticated administrators
- harden security-sensitive function search paths and execution grants
- add pgTAP regression coverage

## Verification
- local Supabase tests require Docker; CI runs `supabase db start` and `supabase test db`
- reviewed against the current Supabase security guidance and July 2026 changelog

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production database authorization for internal and media tables plus auth hooks; misconfiguration could break admin media flows or auth triggers, though behavior is guarded by tests and mirrors existing server allowlists.
> 
> **Overview**
> Adds a migration that **locks down** LangGraph-style checkpoint tables (`checkpoint_*`) by enabling RLS, revoking `anon`/`authenticated` table privileges, granting only `service_role`, and adding a **RESTRICTIVE deny-all** policy for API roles.
> 
> For **`media_assets`**, it enables RLS, blocks anonymous access, and allows **full CRUD only for authenticated users whose JWT email matches the same admin allowlist** used in app code (`ADMIN_EMAILS` in `team.ts`).
> 
> It also **hardens** `set_updated_at`, auth trigger hooks, and `custom_access_token_hook` with `search_path = ''`, and restricts execute on user/email trigger functions to `supabase_auth_admin`.
> 
> A new **pgTAP** suite (`006-security-advisor-hardening.sql`) asserts RLS, privileges, policies, function search paths, and trigger execute grants.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bb03924011a9684ad67feb35bbf48ee4bb5b56f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->