### PR TITLE
Reduce microphone settings indentation

### DIFF
--- a/apps/desktop/src/settings/general/notification.tsx
+++ b/apps/desktop/src/settings/general/notification.tsx
@@ -210,7 +210,7 @@ export function NotificationSettingsView() {
             </div>
 
             {field.state.value && (
-              <div className={cn(["border-muted ml-6 border-l-2 pt-2 pl-6"])}>
+              <div className={cn(["border-muted ml-3 border-l-2 pt-2 pl-4"])}>
                 <form.Field name="mic_active_threshold">
                   {(thresholdField) => (
                     <div className="mb-4 flex items-center justify-between gap-4">


### PR DESCRIPTION
Move the nested detection controls closer to their parent while preserving the hierarchy guide.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change only; no logic, config, or behavior changes.
> 
> **Overview**
> Tightens horizontal spacing for the nested **Microphone detection** controls in `notification.tsx` when the feature toggle is on.
> 
> The bordered container that wraps detection delay and app-exclusion UI now uses `ml-3 pl-4` instead of `ml-6 pl-6`, pulling nested content closer to the parent switch while keeping the left border as a visual hierarchy cue.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 23834772fe3e248318f03a6283e33494e58ea2e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->