### PR TITLE
Compact the dictionary input

### DIFF
--- a/apps/desktop/src/settings/personalization/index.tsx
+++ b/apps/desktop/src/settings/personalization/index.tsx
@@ -237,11 +237,11 @@ export function DictionarySettings({
         <Trans>Dictionary</Trans>
       </h2>
 
-      <InputGroup className="border-border bg-card has-[[data-slot=input-group-control]:focus-visible]:border-border min-h-12 rounded-full shadow-none has-[[data-slot=input-group-control]:focus-visible]:ring-0">
+      <InputGroup className="border-border bg-card has-[[data-slot=input-group-control]:focus-visible]:border-border rounded-full shadow-none has-[[data-slot=input-group-control]:focus-visible]:ring-0">
         <form.Field name="term">
           {(field) => (
             <InputGroupInput
-              className="h-12 py-3 pr-6 pl-4"
+              className="pr-4 pl-4"
               placeholder={t`Add names, jargon, or product terms to prefer`}
               value={field.state.value}
               onChange={(event) => field.handleChange(event.target.value)}
@@ -249,7 +249,7 @@ export function DictionarySettings({
             />
           )}
         </form.Field>
-        <InputGroupAddon align="inline-end" className="pr-2.5">
+        <InputGroupAddon align="inline-end" className="pr-1.5">
           <form.Subscribe selector={(state) => state.values.term}>
             {(value) => {
               const hasInput = parseDictionaryTermsText(value).length > 0;
@@ -263,7 +263,7 @@ export function DictionarySettings({
                   variant="ghost"
                   size="sm"
                   className={cn([
-                    "h-10 rounded-full px-5",
+                    "rounded-full px-3",
                     hasInput
                       ? "bg-black text-white hover:bg-black/90 hover:text-white dark:bg-white dark:text-black dark:hover:bg-white/90 dark:hover:text-black"
                       : null,


### PR DESCRIPTION
Use the standard 36px field height with tighter input and Add button spacing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CSS-only layout tweaks on the dictionary form; no logic or data-handling changes.
> 
> **Overview**
> **Dictionary** add-term field on personalization settings is visually tightened to match the standard **36px** (`h-9`) input height instead of the previous taller **48px** styling.
> 
> The `InputGroup` no longer forces `min-h-12`, and the text field drops explicit `h-12` / vertical padding in favor of horizontal padding only (`pr-4 pl-4`). The inline **Add** control uses less end padding on the addon (`pr-1.5` vs `pr-2.5`) and a smaller button footprint (`px-3`, no fixed `h-10`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 293dd81959cd959afc183d9dfbd5452a664bc476. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->