### PR TITLE
Simplify granted permission checkmarks

### DIFF
--- a/apps/desktop/src/settings/general/permissions.tsx
+++ b/apps/desktop/src/settings/general/permissions.tsx
@@ -49,13 +49,14 @@ function PermissionRow({
         <p className="text-muted-foreground text-xs">{description}</p>
       </div>
       <Button
-        variant={isAuthorized ? "outline" : "default"}
+        variant={isAuthorized ? "ghost" : "default"}
         size="icon"
         onClick={handleButtonClick}
         disabled={isPending}
         className={cn([
           "size-8",
-          isAuthorized && "bg-muted text-foreground hover:bg-accent",
+          isAuthorized &&
+            "text-green-600 hover:bg-transparent hover:text-green-600",
         ])}
         aria-label={
           isAuthorized


### PR DESCRIPTION
Render authorized permissions with a plain 16px green check and no button chrome.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual-only styling in settings permissions UI; no logic or permission flow changes.
> 
> **Overview**
> **Granted permissions** in general settings now show a **green 16px check** with minimal button chrome instead of the previous outlined, muted control.
> 
> For `authorized` rows, the action control switches from `outline` with `bg-muted` / accent hover to **`ghost`** with **`text-green-600`** and **transparent hover** so the check reads as status, not a primary CTA. Request/open behavior and aria-labels are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 95351dbb811e097d175c8d7c988286c3ac7ef499. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->