### PR TITLE
Fix summary prompt editor layout

### DIFF
--- a/apps/desktop/src/settings/personalization/index.test.tsx
+++ b/apps/desktop/src/settings/personalization/index.test.tsx
@@ -150,6 +150,20 @@ describe("SummaryInstructionsSettings", () => {
     ).toBe("Keep it brief\n\n{{ template }}");
   });
 
+  it("shows variables below the editor", () => {
+    render(<SummaryInstructionsSettings instructions="" onSave={vi.fn()} />);
+
+    const editor = screen.getByRole("textbox", {
+      name: "Summary instructions",
+    });
+    const variables = screen.getByText("Variables");
+
+    expect(
+      editor.compareDocumentPosition(variables) &
+        Node.DOCUMENT_POSITION_FOLLOWING,
+    ).toBeTruthy();
+  });
+
   it("disables reset when the built-in prompt is already active", () => {
     render(
       <SummaryInstructionsSettings

--- a/apps/desktop/src/settings/personalization/index.tsx
+++ b/apps/desktop/src/settings/personalization/index.tsx
@@ -109,7 +109,17 @@ export function SummaryInstructionsSettings({
           return (
             <div className="flex flex-col gap-3">
               <div className="border-border bg-card overflow-hidden rounded-2xl border">
-                <div className="border-border bg-muted/40 flex items-center justify-between gap-3 border-b px-3 py-2">
+                <PromptEditor
+                  ref={editorRef}
+                  ariaLabel={t`Summary instructions`}
+                  className="min-h-40 px-4 py-3 text-sm leading-5"
+                  initialValue={field.state.value}
+                  maxLength={4000}
+                  placeholder={t`Example: Start with a two-sentence overview, then list decisions and action items with owners. Do not use headings.`}
+                  onChange={field.handleChange}
+                  onBlur={field.handleBlur}
+                />
+                <div className="border-border bg-muted/40 flex items-center justify-between gap-3 border-t px-3 py-2">
                   <span className="text-muted-foreground text-xs font-medium">
                     Variables
                   </span>
@@ -125,16 +135,6 @@ export function SummaryInstructionsSettings({
                     Template
                   </Button>
                 </div>
-                <PromptEditor
-                  ref={editorRef}
-                  ariaLabel={t`Summary instructions`}
-                  className="min-h-40 px-4 py-3 text-sm leading-5"
-                  initialValue={field.state.value}
-                  maxLength={4000}
-                  placeholder={t`Example: Start with a two-sentence overview, then list decisions and action items with owners. Do not use headings.`}
-                  onChange={field.handleChange}
-                  onBlur={field.handleBlur}
-                />
               </div>
 
               <p className="text-muted-foreground text-sm">

--- a/packages/editor/src/styles/prosemirror.css
+++ b/packages/editor/src/styles/prosemirror.css
@@ -23,14 +23,16 @@
 .ProseMirror .prompt-token {
   display: inline-flex;
   align-items: center;
+  box-sizing: border-box;
+  height: 1.25rem;
   border: 1px solid hsl(var(--border));
   border-radius: 9999px;
   background: hsl(var(--accent));
   color: hsl(var(--accent-foreground));
-  padding: 0.05rem 0.45rem;
+  padding: 0 0.45rem;
   font-size: 0.75rem;
   font-weight: 500;
-  line-height: 1.25rem;
+  line-height: 1;
   vertical-align: baseline;
   white-space: nowrap;
 }


### PR DESCRIPTION
Match token caret metrics to plain text and move the Variables control below the editor.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only layout and editor styling in personalization settings; no auth, data, or API changes.
> 
> **Overview**
> **Summary instructions** personalization now renders the **PromptEditor** first, with the **Variables** row (Template chip) **below** it inside the same card—the bar divider switches from `border-b` to `border-t`.
> 
> **Prompt token** chips in ProseMirror get fixed **height** (`1.25rem`), **border-box** sizing, and tighter **padding/line-height** so inline tokens align with plain text and the caret behaves consistently.
> 
> A test asserts the **Variables** label appears **after** the instructions textbox in document order.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit de2d0ae9e594ef9547906cab60e8dc973f15e124. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->