### PR TITLE
Fix CloudSync transaction hook coexistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4502,6 +4502,7 @@ dependencies = [
 name = "db-change"
 version = "0.1.0"
 dependencies = [
+ "cloudsync",
  "sqlx",
  "tokio",
 ]

--- a/crates/cloudsync/src/close.rs
+++ b/crates/cloudsync/src/close.rs
@@ -1,16 +1,29 @@
-use std::ffi::{c_char, c_int, c_uint, c_void};
+use std::ffi::{CStr, c_char, c_int, c_uint, c_void};
+use std::panic::{AssertUnwindSafe, catch_unwind};
 use std::ptr;
 use std::sync::OnceLock;
 
 use libsqlite3_sys::{
-    SQLITE_OK, SQLITE_TRACE_CLOSE, sqlite3, sqlite3_api_routines, sqlite3_auto_extension,
-    sqlite3_exec, sqlite3_trace_v2,
+    SQLITE_OK, SQLITE_TRACE_CLOSE, SQLITE_TRACE_PROFILE, SQLITE_TRACE_STMT, sqlite3,
+    sqlite3_api_routines, sqlite3_auto_extension, sqlite3_db_handle, sqlite3_exec,
+    sqlite3_get_autocommit, sqlite3_sql, sqlite3_stmt, sqlite3_trace_v2, sqlite3_wal_checkpoint,
+    sqlite3_wal_hook,
 };
+use sqlx::sqlite::LockedSqliteHandle;
 
 use crate::Error;
 
 static REGISTRATION_RESULT: OnceLock<c_int> = OnceLock::new();
 const TERMINATE_SQL: &[u8] = b"SELECT cloudsync_terminate()\0";
+const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: c_int = 1_000;
+
+struct TransactionObserver {
+    on_commit: Box<dyn FnMut() + Send>,
+    on_rollback: Box<dyn FnMut() + Send>,
+    active_statement: *mut sqlite3_stmt,
+    active_rollback: bool,
+    closing: bool,
+}
 
 pub(crate) fn install_terminate_on_close() -> Result<(), Error> {
     let result = *REGISTRATION_RESULT.get_or_init(|| {
@@ -37,31 +50,200 @@ unsafe extern "C" fn register_close_trace(
         sqlite3_trace_v2(
             db,
             SQLITE_TRACE_CLOSE,
-            Some(terminate_cloudsync),
+            Some(trace_cloudsync_connection),
             ptr::null_mut(),
         )
     }
 }
 
+pub fn install_transaction_observer(
+    handle: &mut LockedSqliteHandle<'_>,
+    on_commit: impl FnMut() + Send + 'static,
+    on_rollback: impl FnMut() + Send + 'static,
+) -> Result<(), Error> {
+    let observer = Box::new(TransactionObserver {
+        on_commit: Box::new(on_commit),
+        on_rollback: Box::new(on_rollback),
+        active_statement: ptr::null_mut(),
+        active_rollback: false,
+        closing: false,
+    });
+    let observer = Box::into_raw(observer);
+
+    #[allow(unsafe_code)]
+    let result = unsafe {
+        sqlite3_trace_v2(
+            handle.as_raw_handle().as_ptr(),
+            SQLITE_TRACE_CLOSE | SQLITE_TRACE_PROFILE | SQLITE_TRACE_STMT,
+            Some(trace_cloudsync_connection),
+            observer.cast(),
+        )
+    };
+    if result == SQLITE_OK {
+        #[allow(unsafe_code)]
+        unsafe {
+            sqlite3_wal_hook(
+                handle.as_raw_handle().as_ptr(),
+                Some(observe_wal_commit),
+                observer.cast(),
+            );
+        }
+        Ok(())
+    } else {
+        #[allow(unsafe_code)]
+        unsafe {
+            drop(Box::from_raw(observer));
+        }
+        Err(Error::TransactionObserverRegistration(result))
+    }
+}
+
 #[allow(unsafe_code)]
-unsafe extern "C" fn terminate_cloudsync(
+unsafe extern "C" fn trace_cloudsync_connection(
     event: c_uint,
-    _context: *mut c_void,
-    connection: *mut c_void,
+    context: *mut c_void,
+    object: *mut c_void,
     _statement: *mut c_void,
 ) -> c_int {
-    if event == SQLITE_TRACE_CLOSE && !connection.is_null() {
-        // SQLite invokes this trace before checking for the statements held by SQLite Sync.
+    match event {
+        SQLITE_TRACE_STMT if !context.is_null() && !object.is_null() => unsafe {
+            let observer = &mut *context.cast::<TransactionObserver>();
+            if !observer.closing && observer.active_statement.is_null() {
+                let statement = object.cast::<sqlite3_stmt>();
+                let database = sqlite3_db_handle(statement);
+                if !database.is_null() && sqlite3_get_autocommit(database) != 0 {
+                    invoke_observer(observer.on_rollback.as_mut());
+                }
+                observer.active_statement = statement;
+                observer.active_rollback = statement_is_full_rollback(statement);
+            }
+        },
+        SQLITE_TRACE_PROFILE if !context.is_null() && !object.is_null() => unsafe {
+            let observer = &mut *context.cast::<TransactionObserver>();
+            let statement = object.cast::<sqlite3_stmt>();
+            if observer.active_statement == statement {
+                let database = sqlite3_db_handle(statement);
+                if observer.active_rollback
+                    && !database.is_null()
+                    && sqlite3_get_autocommit(database) != 0
+                {
+                    invoke_observer(observer.on_rollback.as_mut());
+                }
+                observer.active_statement = ptr::null_mut();
+                observer.active_rollback = false;
+            }
+        },
+        SQLITE_TRACE_CLOSE if !object.is_null() => unsafe {
+            let database = object.cast::<sqlite3>();
+            if context.is_null() {
+                terminate_cloudsync(database);
+            } else {
+                let observer = &mut *context.cast::<TransactionObserver>();
+                observer.closing = true;
+                sqlite3_wal_hook(database, None, ptr::null_mut());
+                let trace_unregistered =
+                    sqlite3_trace_v2(database, 0, None, ptr::null_mut()) == SQLITE_OK;
+                terminate_cloudsync(database);
+                invoke_observer(observer.on_rollback.as_mut());
+
+                if trace_unregistered {
+                    drop(Box::from_raw(context.cast::<TransactionObserver>()));
+                }
+            }
+        },
+        _ => {}
+    }
+
+    SQLITE_OK
+}
+
+#[allow(unsafe_code)]
+unsafe extern "C" fn observe_wal_commit(
+    context: *mut c_void,
+    database: *mut sqlite3,
+    database_name: *const c_char,
+    frame_count: c_int,
+) -> c_int {
+    if !context.is_null() {
+        let observer = unsafe { &mut *context.cast::<TransactionObserver>() };
+        if !observer.closing {
+            invoke_observer(observer.on_commit.as_mut());
+        }
+    }
+
+    // Registering a WAL hook replaces SQLite's default autocheckpoint callback.
+    if !database.is_null() && frame_count >= DEFAULT_WAL_AUTOCHECKPOINT_PAGES {
         unsafe {
-            sqlite3_exec(
-                connection.cast(),
-                TERMINATE_SQL.as_ptr().cast(),
-                None,
-                ptr::null_mut(),
-                ptr::null_mut(),
-            );
+            sqlite3_wal_checkpoint(database, database_name);
         }
     }
 
     SQLITE_OK
+}
+
+fn invoke_observer(callback: &mut (dyn FnMut() + Send)) {
+    let _ = catch_unwind(AssertUnwindSafe(|| callback()));
+}
+
+#[allow(unsafe_code)]
+unsafe fn statement_is_full_rollback(statement: *mut sqlite3_stmt) -> bool {
+    let sql = unsafe { sqlite3_sql(statement) };
+    if sql.is_null() {
+        return false;
+    }
+
+    let sql = unsafe { CStr::from_ptr(sql) }.to_str().unwrap_or_default();
+    is_full_rollback(sql)
+}
+
+fn is_full_rollback(sql: &str) -> bool {
+    let Some(tail) = strip_keyword(sql, "ROLLBACK") else {
+        return false;
+    };
+    let tail = strip_keyword(tail, "TRANSACTION").unwrap_or(tail);
+    strip_keyword(tail, "TO").is_none()
+}
+
+fn strip_keyword<'a>(sql: &'a str, keyword: &str) -> Option<&'a str> {
+    let sql = sql.trim_start();
+    let prefix = sql.get(..keyword.len())?;
+    if !prefix.eq_ignore_ascii_case(keyword) {
+        return None;
+    }
+
+    let tail = &sql[keyword.len()..];
+    tail.chars()
+        .next()
+        .is_none_or(|next| next.is_ascii_whitespace() || next == ';')
+        .then_some(tail)
+}
+
+#[allow(unsafe_code)]
+unsafe fn terminate_cloudsync(connection: *mut sqlite3) {
+    // SQLite invokes this trace before checking for the statements held by SQLite Sync.
+    unsafe {
+        sqlite3_exec(
+            connection,
+            TERMINATE_SQL.as_ptr().cast(),
+            None,
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn distinguishes_full_and_savepoint_rollbacks() {
+        assert!(is_full_rollback("ROLLBACK"));
+        assert!(is_full_rollback(" rollback transaction;"));
+        assert!(!is_full_rollback("ROLLBACK TO savepoint_name"));
+        assert!(!is_full_rollback(
+            "ROLLBACK TRANSACTION TO SAVEPOINT savepoint_name"
+        ));
+        assert!(!is_full_rollback("SELECT 1"));
+    }
 }

--- a/crates/cloudsync/src/error.rs
+++ b/crates/cloudsync/src/error.rs
@@ -28,6 +28,10 @@ pub enum Error {
     MissingCacheDir,
     #[error("failed to register the cloudsync close hook: sqlite error {0}")]
     CloseHookRegistration(i32),
+    #[error("failed to register the cloudsync transaction observer: sqlite error {0}")]
+    TransactionObserverRegistration(i32),
+    #[error("CloudSync requires WAL journal mode for commit-safe change notifications")]
+    WalRequired,
     #[error(
         "the bundled cloudsync extension is not available for this target; supported targets: {SUPPORTED_CLOUDSYNC_TARGETS}"
     )]

--- a/crates/cloudsync/src/lib.rs
+++ b/crates/cloudsync/src/lib.rs
@@ -15,6 +15,7 @@ pub use api::{
     terminate, uuid, version,
 };
 pub use bundle::bundled_extension_path;
+pub use close::install_transaction_observer;
 pub use error::{Error, ErrorKind};
 pub use network::{
     NetworkReceiveResult, NetworkResult, NetworkSendResult, network_check_changes, network_cleanup,

--- a/crates/db-change/Cargo.toml
+++ b/crates/db-change/Cargo.toml
@@ -4,5 +4,7 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
+hypr-cloudsync = { workspace = true }
+
 sqlx = { workspace = true, features = ["runtime-tokio", "sqlite"] }
 tokio = { workspace = true, features = ["sync"] }

--- a/crates/db-change/src/notifier.rs
+++ b/crates/db-change/src/notifier.rs
@@ -16,11 +16,32 @@ pub struct ChangeNotifier {
 
 impl ChangeNotifier {
     pub fn new() -> (Self, SqlitePoolOptions) {
+        Self::build(Some(false))
+    }
+
+    pub fn new_with_cloudsync() -> (Self, SqlitePoolOptions) {
+        Self::build(Some(true))
+    }
+
+    pub fn disabled() -> (Self, SqlitePoolOptions) {
+        Self::build(None)
+    }
+
+    fn build(cloudsync_enabled: Option<bool>) -> (Self, SqlitePoolOptions) {
         let (table_change_tx, _) = broadcast::channel(256);
         let change_tracker = Arc::new(ChangeTracker::default());
 
-        let callback_tx = table_change_tx.clone();
-        let callback_tracker = Arc::clone(&change_tracker);
+        let notifier = Self {
+            table_change_tx,
+            change_tracker,
+        };
+
+        let Some(cloudsync_enabled) = cloudsync_enabled else {
+            return (notifier, SqlitePoolOptions::new());
+        };
+
+        let callback_tx = notifier.table_change_tx.clone();
+        let callback_tracker = Arc::clone(&notifier.change_tracker);
 
         let pool_options = SqlitePoolOptions::new().after_connect(move |conn, _| {
             let callback_tx = callback_tx.clone();
@@ -32,6 +53,9 @@ impl ChangeNotifier {
 
                 let update_state = Arc::clone(&hook_state);
                 handle.set_update_hook(move |update| {
+                    if cloudsync_enabled && update.database != "main" {
+                        return;
+                    }
                     let kind = match update.operation {
                         SqliteOperation::Insert => TableChangeKind::Insert,
                         SqliteOperation::Update => TableChangeKind::Update,
@@ -42,23 +66,27 @@ impl ChangeNotifier {
                 });
 
                 let commit_state = Arc::clone(&hook_state);
-                handle.set_commit_hook(move || {
-                    commit_state.flush();
-                    true
-                });
+                if cloudsync_enabled {
+                    hypr_cloudsync::install_transaction_observer(
+                        &mut handle,
+                        move || commit_state.flush(),
+                        move || hook_state.clear(),
+                    )
+                    .map_err(|error| sqlx::Error::Configuration(Box::new(error)))?;
+                } else {
+                    handle.set_commit_hook(move || {
+                        commit_state.flush();
+                        true
+                    });
 
-                handle.set_rollback_hook(move || {
-                    hook_state.clear();
-                });
+                    handle.set_rollback_hook(move || {
+                        hook_state.clear();
+                    });
+                }
 
                 Ok(())
             })
         });
-
-        let notifier = Self {
-            table_change_tx,
-            change_tracker,
-        };
 
         (notifier, pool_options)
     }

--- a/crates/db-core/src/lib.rs
+++ b/crates/db-core/src/lib.rs
@@ -86,7 +86,18 @@ impl Drop for Db {
 
 impl Db {
     pub async fn open(options: DbOpenOptions<'_>) -> Result<Self, DbOpenError> {
-        let (change_notifier, pool_options) = hypr_db_change::ChangeNotifier::new();
+        if options.cloudsync_enabled
+            && matches!(options.storage, DbStorage::Local(_))
+            && !options.journal_mode_wal
+        {
+            return Err(hypr_cloudsync::Error::WalRequired.into());
+        }
+
+        let (change_notifier, pool_options) = match (options.cloudsync_enabled, options.storage) {
+            (true, DbStorage::Local(_)) => hypr_db_change::ChangeNotifier::new_with_cloudsync(),
+            (true, DbStorage::Memory) => hypr_db_change::ChangeNotifier::disabled(),
+            (false, _) => hypr_db_change::ChangeNotifier::new(),
+        };
         connect_with_options(&options, pool_options, change_notifier).await
     }
 
@@ -100,13 +111,15 @@ impl Db {
         }
         let options = apply_internal_connect_policy(SqliteConnectOptions::new())
             .filename(path)
-            .create_if_missing(true);
+            .create_if_missing(true)
+            .pragma("journal_mode", "WAL");
         let (options, cloudsync_path) = hypr_cloudsync::apply(options)?;
-        let (change_notifier, pool_options) = hypr_db_change::ChangeNotifier::new();
+        let (change_notifier, pool_options) = hypr_db_change::ChangeNotifier::new_with_cloudsync();
         let pool = pool_options
             .connect_with(options)
             .await
             .map_err(hypr_cloudsync::Error::from)?;
+        ensure_cloudsync_wal(&pool).await?;
 
         Ok(Self {
             cloudsync_enabled: true,
@@ -123,7 +136,7 @@ impl Db {
         let options =
             apply_internal_connect_policy(SqliteConnectOptions::from_str("sqlite::memory:")?);
         let (options, cloudsync_path) = hypr_cloudsync::apply(options)?;
-        let (change_notifier, pool_options) = hypr_db_change::ChangeNotifier::new();
+        let (change_notifier, pool_options) = hypr_db_change::ChangeNotifier::disabled();
         let pool = pool_options
             .max_connections(1)
             .connect_with(options)
@@ -254,6 +267,9 @@ async fn connect_with_options(
         }
     };
     let pool = pool_options.connect_with(connect_options).await?;
+    if options.cloudsync_enabled && matches!(options.storage, DbStorage::Local(_)) {
+        ensure_cloudsync_wal(&pool).await?;
+    }
 
     Ok(Db {
         cloudsync_enabled: options.cloudsync_enabled,
@@ -268,6 +284,17 @@ async fn connect_with_options(
 
 fn apply_internal_connect_policy(connect_options: SqliteConnectOptions) -> SqliteConnectOptions {
     connect_options.busy_timeout(SQLITE_BUSY_TIMEOUT)
+}
+
+async fn ensure_cloudsync_wal(pool: &SqlitePool) -> Result<(), hypr_cloudsync::Error> {
+    let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+        .fetch_one(pool)
+        .await?;
+    if journal_mode.eq_ignore_ascii_case("wal") {
+        Ok(())
+    } else {
+        Err(hypr_cloudsync::Error::WalRequired)
+    }
 }
 
 #[cfg(test)]
@@ -418,6 +445,226 @@ mod tests {
 
         let error = db.cloudsync_start().await.unwrap_err();
         assert!(matches!(error, CloudsyncRuntimeError::NotConfigured));
+    }
+
+    #[tokio::test]
+    async fn memory_cloudsync_does_not_install_change_hooks() {
+        let db = Db::connect_memory().await.unwrap();
+        sqlx::query("CREATE TABLE events (id TEXT PRIMARY KEY NOT NULL)")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let mut changes = db.change_notifier().subscribe();
+
+        sqlx::query("INSERT INTO events (id) VALUES ('a')")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        assert_eq!(db.change_notifier().current_seq(), 0);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), changes.recv())
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn cloudsync_and_change_notifier_share_transaction_lifecycle() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(DbOpenOptions {
+            storage: DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap();
+        let journal_mode: String = sqlx::query_scalar("PRAGMA journal_mode")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(journal_mode.to_lowercase(), "wal");
+
+        sqlx::query(
+            "CREATE TABLE test_sync (\
+                id TEXT PRIMARY KEY NOT NULL, \
+                value TEXT NOT NULL DEFAULT ''\
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE other_events (\
+                id TEXT PRIMARY KEY NOT NULL, \
+                value TEXT NOT NULL DEFAULT ''\
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        db.cloudsync_init("test_sync", None, None).await.unwrap();
+
+        let notifier = db.change_notifier();
+        let mut changes = notifier.subscribe();
+
+        sqlx::query("INSERT INTO test_sync (id, value) VALUES ('a', 'one')")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let first_version: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(first_version, 1);
+        let first_change = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let change = changes.recv().await.unwrap();
+                if change.table == "test_sync" {
+                    break change;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(first_change.kind, hypr_db_change::TableChangeKind::Insert);
+        while changes.try_recv().is_ok() {}
+
+        let mut transaction = db.pool().begin().await.unwrap();
+        sqlx::query("UPDATE test_sync SET value = 'two' WHERE id = 'a'")
+            .execute(&mut *transaction)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO other_events (id, value) VALUES ('a', 'two')")
+            .execute(&mut *transaction)
+            .await
+            .unwrap();
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), changes.recv())
+                .await
+                .is_err()
+        );
+        transaction.commit().await.unwrap();
+
+        let (sync_change, other_change) =
+            tokio::time::timeout(std::time::Duration::from_secs(1), async {
+                let mut sync_change = None;
+                let mut other_change = None;
+                while sync_change.is_none() || other_change.is_none() {
+                    let change = changes.recv().await.unwrap();
+                    match change.table.as_str() {
+                        "test_sync" => sync_change = Some(change),
+                        "other_events" => other_change = Some(change),
+                        _ => {}
+                    }
+                }
+                (sync_change.unwrap(), other_change.unwrap())
+            })
+            .await
+            .unwrap();
+        assert_eq!(sync_change.kind, hypr_db_change::TableChangeKind::Update);
+        assert_eq!(sync_change.seq, other_change.seq);
+        let second_version: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(second_version, 2);
+        while changes.try_recv().is_ok() {}
+
+        let mut transaction = db.pool().begin().await.unwrap();
+        sqlx::query("UPDATE test_sync SET value = 'rolled-back' WHERE id = 'a'")
+            .execute(&mut *transaction)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE other_events SET value = 'rolled-back' WHERE id = 'a'")
+            .execute(&mut *transaction)
+            .await
+            .unwrap();
+        transaction.rollback().await.unwrap();
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), changes.recv())
+                .await
+                .is_err()
+        );
+        let version_after_rollback: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(version_after_rollback, second_version);
+
+        let failed = sqlx::query(
+            "INSERT INTO test_sync (id, value) VALUES ('b', 'temporary'), ('a', 'duplicate')",
+        )
+        .execute(db.pool())
+        .await;
+        assert!(failed.is_err());
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), changes.recv())
+                .await
+                .is_err()
+        );
+        let version_after_failure: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(version_after_failure, second_version);
+
+        sqlx::query("UPDATE test_sync SET value = 'three' WHERE id = 'a'")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let final_change = tokio::time::timeout(std::time::Duration::from_secs(1), async {
+            loop {
+                let change = changes.recv().await.unwrap();
+                if change.table == "test_sync" {
+                    break change;
+                }
+            }
+        })
+        .await
+        .unwrap();
+        assert_eq!(final_change.kind, hypr_db_change::TableChangeKind::Update);
+        let final_version: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let value: String = sqlx::query_scalar("SELECT value FROM test_sync WHERE id = 'a'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let failed_row_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM test_sync WHERE id = 'b'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(final_version, 3);
+        assert_eq!(value, "three");
+        assert_eq!(failed_row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn local_cloudsync_requires_wal() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+
+        let error = Db::open(DbOpenOptions {
+            storage: DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: false,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap_err();
+
+        assert!(matches!(
+            error,
+            DbOpenError::Cloudsync(hypr_cloudsync::Error::WalRequired)
+        ));
     }
 
     #[tokio::test]

--- a/crates/db-reactive/tests/cloudsync.rs
+++ b/crates/db-reactive/tests/cloudsync.rs
@@ -4,15 +4,25 @@ use std::time::Duration;
 
 use common::{TestEvent, TestSink, next_event};
 use db_reactive::LiveQueryRuntime;
-use hypr_db_core::Db;
+use hypr_db_core::{Db, DbOpenOptions, DbStorage};
 use serde_json::json;
 
 fn connection_string() -> String {
     std::env::var("SQLITECLOUD_URL").expect("SQLITECLOUD_URL must be set")
 }
 
-async fn setup_db() -> Db {
-    let db = Db::connect_memory().await.unwrap();
+async fn setup_db() -> (tempfile::TempDir, Db) {
+    let dir = tempfile::tempdir().unwrap();
+    let db_path = dir.path().join("cloudsync.db");
+    let db = Db::open(DbOpenOptions {
+        storage: DbStorage::Local(&db_path),
+        cloudsync_enabled: true,
+        journal_mode_wal: true,
+        foreign_keys: true,
+        max_connections: Some(1),
+    })
+    .await
+    .unwrap();
 
     sqlx::query(
         "CREATE TABLE IF NOT EXISTS test_sync (
@@ -29,7 +39,7 @@ async fn setup_db() -> Db {
         .await
         .unwrap();
 
-    db
+    (dir, db)
 }
 
 #[tokio::test]
@@ -37,8 +47,8 @@ async fn setup_db() -> Db {
 async fn cloudsync_pull_refreshes_live_query_subscriptions() {
     let marker = uuid::Uuid::new_v4().to_string();
 
-    let db_a = setup_db().await;
-    let db_b = setup_db().await;
+    let (_dir_a, db_a) = setup_db().await;
+    let (_dir_b, db_b) = setup_db().await;
     let pool_b = db_b.pool().clone();
     let runtime_b = LiveQueryRuntime::new(std::sync::Arc::new(db_b));
     let (sink, events) = TestSink::capture();


### PR DESCRIPTION
## Summary

- preserve SQLite Sync transaction hooks while emitting reactive changes only after WAL commits
- require file-backed CloudSync databases to use WAL and retain SQLite auto-checkpoint behavior
- cover commits, rollbacks, failed writes, and file-backed live-query sync setup

## Verification

- `cargo test -p cloudsync -p db-change -p db-core --lib`
- `cargo check -p cloudsync -p db-change -p db-core -p db-reactive -p db-app`
- `pnpm exec dprint check`
- dev Pro/Lite/Free entitlement gate and two-workspace sync/isolation/delete smoke test

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Unsafe SQLite trace/WAL hook integration affects transaction lifecycle, CloudSync versioning, and reactive notifications on the critical database path.
> 
> **Overview**
> Fixes **CloudSync** and the reactive **change notifier** fighting over SQLite transaction hooks by routing CloudSync-enabled pools through a new **`install_transaction_observer`** path instead of sqlx commit/rollback hooks.
> 
> That observer uses **`sqlite3_trace_v2`** plus a **WAL hook** so table-change broadcasts flush only after a WAL commit, rollbacks clear pending changes (including full vs savepoint `ROLLBACK`), and the existing close-time **`cloudsync_terminate()`** behavior stays intact. The WAL hook also re-applies the default **autocheckpoint** threshold so registering a custom hook does not disable checkpointing.
> 
> **`db-change`** gains CloudSync-specific notifier wiring (`new_with_cloudsync` / `disabled`), ignores non-`main` update events when CloudSync is on, and **`db-core`** now **requires WAL** for file-backed CloudSync (open-time check + `WalRequired` error), forces WAL for `connect_local`, skips change hooks on in-memory CloudSync, and adds integration tests for commit/rollback/failed writes vs `cloudsync_db_version()`. The ignored **db-reactive** CloudSync test now uses a local WAL database instead of memory.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 38872bf1706a8d5ff89818064e8ed0de17882963. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->