### PR TITLE
Fail closed on CloudSync account admission

### DIFF
--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -1,13 +1,15 @@
-import type { Session } from "@supabase/supabase-js";
+import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
 import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 
 import {
+  claimCloudsyncAccount,
   configureCloudsyncToken,
   logoutCloudsync,
   suspendCloudsync,
 } from "@hypr/plugin-db";
 
 import {
+  claimCloudsyncAccountForAuth,
   handleCloudsyncAuthChange,
   prepareCloudsyncSignOut,
 } from "./cloudsync";
@@ -48,6 +50,7 @@ describe("CloudSync auth lifecycle", () => {
     vi.setSystemTime(NOW);
     await handleCloudsyncAuthChange("SIGNED_OUT", null);
     vi.clearAllMocks();
+    vi.mocked(claimCloudsyncAccount).mockResolvedValue(true);
     vi.mocked(configureCloudsyncToken).mockResolvedValue(true);
     vi.mocked(logoutCloudsync).mockResolvedValue(undefined);
   });
@@ -57,6 +60,13 @@ describe("CloudSync auth lifecycle", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
     vi.useRealTimers();
+  });
+
+  test("claims the local account without a token exchange", async () => {
+    await expect(claimCloudsyncAccountForAuth("user-id")).resolves.toBe(true);
+
+    expect(claimCloudsyncAccount).toHaveBeenCalledWith("user-id");
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
   });
 
   test("exchanges the Supabase token and refreshes before expiry", async () => {
@@ -231,6 +241,25 @@ describe("CloudSync auth lifecycle", () => {
     );
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
   });
+
+  test.each<AuthChangeEvent>(["PASSWORD_RECOVERY", "MFA_CHALLENGE_VERIFIED"])(
+    "restarts sync after %s",
+    async (event) => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn(() => Promise.resolve(credentialsResponse())),
+      );
+
+      await handleCloudsyncAuthChange(event, session());
+
+      expect(configureCloudsyncToken).toHaveBeenCalledWith(
+        "database-id",
+        "sqlite-token",
+        "user-id",
+      );
+      expect(suspendCloudsync).toHaveBeenCalledTimes(1);
+    },
+  );
 
   test("checks for unsent changes before signing out", async () => {
     const fetchMock = vi.fn(() => Promise.resolve(credentialsResponse()));

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -1,6 +1,7 @@
 import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
 
 import {
+  claimCloudsyncAccount,
   configureCloudsyncToken,
   logoutCloudsync,
   suspendCloudsync,
@@ -46,6 +47,12 @@ function enqueuePluginOperation<T>(operation: () => Promise<T>) {
     () => {},
   );
   return next;
+}
+
+export async function claimCloudsyncAccountForAuth(
+  accountUserId: string,
+): Promise<boolean> {
+  return enqueuePluginOperation(() => claimCloudsyncAccount(accountUserId));
 }
 
 async function suspendCloudsyncForGeneration(activeGeneration: number) {
@@ -291,7 +298,7 @@ export async function prepareCloudsyncSignOut(session: Session): Promise<void> {
 }
 
 export async function handleCloudsyncAuthChange(
-  event: AuthChangeEvent,
+  _event: AuthChangeEvent,
   session: Session | null,
 ): Promise<CloudsyncAuthChangeResult> {
   if (!session) {
@@ -299,14 +306,5 @@ export async function handleCloudsyncAuthChange(
     return "ok";
   }
 
-  if (
-    event === "SIGNED_IN" ||
-    event === "INITIAL_SESSION" ||
-    event === "TOKEN_REFRESHED" ||
-    event === "USER_UPDATED"
-  ) {
-    return activateCloudsync(session);
-  }
-
-  return "ok";
+  return activateCloudsync(session);
 }

--- a/apps/desktop/src/auth/context.test.tsx
+++ b/apps/desktop/src/auth/context.test.tsx
@@ -16,12 +16,14 @@ const mocks = vi.hoisted(() => ({
   authCallback: null as
     | ((event: AuthChangeEvent, session: Session | null) => void)
     | null,
+  claimCloudsyncAccountForAuth: vi.fn(),
   clearAuthStorage: vi.fn(),
   getSession: vi.fn(),
   handleCloudsyncAuthChange: vi.fn(),
   isFatalSessionError: vi.fn(),
   persistAuthSession: vi.fn(),
   prepareCloudsyncSignOut: vi.fn(),
+  refreshSession: vi.fn(),
   signOut: vi.fn(),
   startAutoRefresh: vi.fn(),
   stopAutoRefresh: vi.fn(),
@@ -46,7 +48,7 @@ vi.mock("./client", () => ({
           };
         },
       ),
-      refreshSession: vi.fn(),
+      refreshSession: mocks.refreshSession,
       setSession: vi.fn(),
       signOut: mocks.signOut,
       startAutoRefresh: mocks.startAutoRefresh,
@@ -56,6 +58,7 @@ vi.mock("./client", () => ({
 }));
 
 vi.mock("./cloudsync", () => ({
+  claimCloudsyncAccountForAuth: mocks.claimCloudsyncAccountForAuth,
   handleCloudsyncAuthChange: mocks.handleCloudsyncAuthChange,
   prepareCloudsyncSignOut: mocks.prepareCloudsyncSignOut,
 }));
@@ -148,10 +151,14 @@ function makeSession(userId: string): Session {
 }
 
 function SessionProbe() {
-  const { session, signOut } = useAuth();
+  const { refreshSession, session, signOut } = useAuth();
   return (
     <>
       <div data-testid="session">{session?.user.id ?? "none"}</div>
+      <div data-testid="access-token">{session?.access_token ?? "none"}</div>
+      <button onClick={() => void refreshSession().catch(() => {})}>
+        Refresh
+      </button>
       <button onClick={() => void signOut().catch(() => {})}>Sign out</button>
     </>
   );
@@ -177,21 +184,28 @@ function renderAuthProvider() {
 describe("AuthProvider", () => {
   beforeEach(() => {
     mocks.authCallback = null;
+    mocks.claimCloudsyncAccountForAuth.mockReset();
     mocks.clearAuthStorage.mockReset();
     mocks.getSession.mockReset();
     mocks.handleCloudsyncAuthChange.mockReset();
     mocks.isFatalSessionError.mockReset();
     mocks.persistAuthSession.mockReset();
     mocks.prepareCloudsyncSignOut.mockReset();
+    mocks.refreshSession.mockReset();
     mocks.signOut.mockReset();
     mocks.startAutoRefresh.mockReset();
     mocks.stopAutoRefresh.mockReset();
     mocks.clearAuthStorage.mockResolvedValue(undefined);
+    mocks.claimCloudsyncAccountForAuth.mockResolvedValue(true);
     mocks.getSession.mockImplementation(() => new Promise(() => {}));
     mocks.handleCloudsyncAuthChange.mockResolvedValue("ok");
     mocks.isFatalSessionError.mockReturnValue(false);
     mocks.persistAuthSession.mockResolvedValue(undefined);
     mocks.prepareCloudsyncSignOut.mockResolvedValue(undefined);
+    mocks.refreshSession.mockResolvedValue({
+      data: { session: null },
+      error: null,
+    });
     mocks.signOut.mockResolvedValue({ error: null });
     mocks.startAutoRefresh.mockResolvedValue(undefined);
     mocks.stopAutoRefresh.mockResolvedValue(undefined);
@@ -199,6 +213,148 @@ describe("AuthProvider", () => {
 
   afterEach(() => {
     cleanup();
+  });
+
+  it("keeps a session hidden until its local account claim succeeds", async () => {
+    const nextSession = makeSession("bound-account");
+    const claim = deferred<boolean>();
+    mocks.claimCloudsyncAccountForAuth.mockReturnValue(claim.promise);
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", nextSession);
+    });
+
+    await waitFor(() => {
+      expect(mocks.claimCloudsyncAccountForAuth).toHaveBeenCalledWith(
+        nextSession.user.id,
+      );
+    });
+    expect(screen.getByTestId("session").textContent).toBe("none");
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
+    expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalledWith(
+      "SIGNED_IN",
+      nextSession,
+    );
+
+    await act(async () => {
+      claim.resolve(true);
+      await claim.promise;
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("session").textContent).toBe(
+        nextSession.user.id,
+      );
+    });
+  });
+
+  it("keeps a refreshed session hidden until admission succeeds", async () => {
+    const currentSession = makeSession("bound-account");
+    const refreshedSession = {
+      ...currentSession,
+      access_token: "refreshed-access-token",
+    };
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", currentSession);
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token").textContent).toBe(
+        currentSession.access_token,
+      );
+    });
+
+    const claim = deferred<boolean>();
+    mocks.claimCloudsyncAccountForAuth.mockReturnValueOnce(claim.promise);
+    mocks.refreshSession.mockImplementationOnce(async () => {
+      mocks.authCallback?.("TOKEN_REFRESHED", refreshedSession);
+      return { data: { session: refreshedSession }, error: null };
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Refresh" }));
+
+    await waitFor(() => {
+      expect(mocks.claimCloudsyncAccountForAuth).toHaveBeenCalledTimes(2);
+    });
+    expect(screen.getByTestId("access-token").textContent).toBe(
+      currentSession.access_token,
+    );
+
+    await act(async () => {
+      claim.resolve(true);
+      await claim.promise;
+    });
+    await waitFor(() => {
+      expect(screen.getByTestId("access-token").textContent).toBe(
+        refreshedSession.access_token,
+      );
+    });
+  });
+
+  it("rejects a different local database account before admission", async () => {
+    const foreignSession = makeSession("foreign-account");
+    mocks.claimCloudsyncAccountForAuth.mockResolvedValue(false);
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", foreignSession);
+    });
+
+    await waitFor(() => {
+      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("session").textContent).toBe("none");
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
+    expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalledWith(
+      "SIGNED_IN",
+      foreignSession,
+    );
+  });
+
+  it("fails closed when the local database account cannot be verified", async () => {
+    const nextSession = makeSession("unverified-account");
+    mocks.claimCloudsyncAccountForAuth.mockRejectedValue(
+      new Error("database unavailable"),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    renderAuthProvider();
+
+    await waitFor(() => {
+      expect(mocks.authCallback).not.toBeNull();
+    });
+
+    act(() => {
+      mocks.authCallback?.("SIGNED_IN", nextSession);
+    });
+
+    await waitFor(() => {
+      expect(mocks.clearAuthStorage).toHaveBeenCalledTimes(1);
+    });
+    expect(screen.getByTestId("session").textContent).toBe("none");
+    expect(mocks.persistAuthSession).not.toHaveBeenCalled();
+    expect(mocks.handleCloudsyncAuthChange).not.toHaveBeenCalledWith(
+      "SIGNED_IN",
+      nextSession,
+    );
   });
 
   it("restores a newer accepted session when stale mismatch cleanup was already running", async () => {

--- a/apps/desktop/src/auth/context.tsx
+++ b/apps/desktop/src/auth/context.tsx
@@ -28,6 +28,7 @@ import { deriveBillingInfo } from "@hypr/supabase";
 
 import { persistAuthSession, supabase } from "./client";
 import {
+  claimCloudsyncAccountForAuth,
   handleCloudsyncAuthChange,
   prepareCloudsyncSignOut,
 } from "./cloudsync";
@@ -308,6 +309,29 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
         return;
       }
 
+      if (nextSession) {
+        try {
+          const claimed = await claimCloudsyncAccountForAuth(
+            nextSession.user.id,
+          );
+          if (transition !== authTransitionRef.current) {
+            return;
+          }
+          if (!claimed) {
+            console.warn("[auth] local database belongs to another account");
+            await rejectAuthChange(transition, true);
+            return;
+          }
+        } catch {
+          if (transition !== authTransitionRef.current) {
+            return;
+          }
+          console.warn("[auth] local database account verification failed");
+          await rejectAuthChange(transition, true);
+          return;
+        }
+      }
+
       if (nextSession && storageRevision !== authStorageRevisionRef.current) {
         try {
           await persistAuthSession(nextSession);
@@ -541,11 +565,7 @@ export function AuthProvider({ children }: { children: React.ReactNode }) {
       if (error) {
         return null;
       }
-      if (data.session) {
-        setSession(data.session);
-        return data.session;
-      }
-      return null;
+      return data.session;
     },
   });
 


### PR DESCRIPTION
## Summary

- claim the local database account before persisting or exposing an authenticated session
- enforce the binding for every plan and fail closed on mismatch or database errors
- route manual refreshes through the same admission queue and reactivate sync for every authenticated Supabase event
- serialize admission with existing CloudSync plugin operations while retaining token-time validation as defense in depth

## Verification

- `pnpm -F desktop exec vitest run src/auth/cloudsync.test.ts src/auth/context.test.tsx` (27 tests)
- `pnpm -F desktop typecheck`
- `pnpm exec dprint fmt`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes core authentication admission and local account binding; incorrect behavior could lock users out or briefly expose the wrong session state.
> 
> **Overview**
> **Auth admission now binds the local database before any session is persisted or shown in the UI.** On each auth change with a session, `AuthProvider` calls `claimCloudsyncAccountForAuth` (queued with other CloudSync plugin work); until that succeeds the UI stays logged out and `persistAuthSession` / `handleCloudsyncAuthChange` are not run for that session. A failed claim, mismatch (`false`), or DB error triggers fail-closed cleanup via `rejectAuthChange` (clear storage, local sign-out).
> 
> `refreshSession` no longer sets React session state directly—updates go through the same admission path when Supabase fires `TOKEN_REFRESHED`.
> 
> CloudSync activation no longer filters on auth event type: any non-null session runs `activateCloudsync`. Tests cover claim-only admission, delayed claim UI, foreign account rejection, and sync restart on `PASSWORD_RECOVERY` / `MFA_CHALLENGE_VERIFIED`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit eb15106755dac12afdff4f18a35be980cf387548. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->