### PR TITLE
Restore notifier state on savepoint rollback

### DIFF
--- a/crates/cloudsync/src/close.rs
+++ b/crates/cloudsync/src/close.rs
@@ -20,9 +20,34 @@ const DEFAULT_WAL_AUTOCHECKPOINT_PAGES: c_int = 1_000;
 struct TransactionObserver {
     on_commit: Box<dyn FnMut() + Send>,
     on_rollback: Box<dyn FnMut() + Send>,
+    on_savepoint: Box<dyn FnMut(SavepointEvent) + Send>,
     active_statement: *mut sqlite3_stmt,
-    active_rollback: bool,
+    active_control: Option<TransactionControl>,
     closing: bool,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub enum SavepointEvent {
+    Begin {
+        name: String,
+        starts_transaction: bool,
+    },
+    RollbackTo(String),
+    Release {
+        name: String,
+        transaction_active: bool,
+    },
+}
+
+#[derive(Debug, PartialEq, Eq)]
+enum TransactionControl {
+    FullRollback,
+    Savepoint {
+        name: String,
+        starts_transaction: bool,
+    },
+    RollbackTo(String),
+    Release(String),
 }
 
 pub(crate) fn install_terminate_on_close() -> Result<(), Error> {
@@ -60,12 +85,14 @@ pub fn install_transaction_observer(
     handle: &mut LockedSqliteHandle<'_>,
     on_commit: impl FnMut() + Send + 'static,
     on_rollback: impl FnMut() + Send + 'static,
+    on_savepoint: impl FnMut(SavepointEvent) + Send + 'static,
 ) -> Result<(), Error> {
     let observer = Box::new(TransactionObserver {
         on_commit: Box::new(on_commit),
         on_rollback: Box::new(on_rollback),
+        on_savepoint: Box::new(on_savepoint),
         active_statement: ptr::null_mut(),
-        active_rollback: false,
+        active_control: None,
         closing: false,
     });
     let observer = Box::into_raw(observer);
@@ -111,11 +138,20 @@ unsafe extern "C" fn trace_cloudsync_connection(
             if !observer.closing && observer.active_statement.is_null() {
                 let statement = object.cast::<sqlite3_stmt>();
                 let database = sqlite3_db_handle(statement);
-                if !database.is_null() && sqlite3_get_autocommit(database) != 0 {
+                let starts_transaction =
+                    !database.is_null() && sqlite3_get_autocommit(database) != 0;
+                if starts_transaction {
                     invoke_observer(observer.on_rollback.as_mut());
                 }
                 observer.active_statement = statement;
-                observer.active_rollback = statement_is_full_rollback(statement);
+                observer.active_control = statement_transaction_control(statement);
+                if let Some(TransactionControl::Savepoint {
+                    starts_transaction: active_starts_transaction,
+                    ..
+                }) = observer.active_control.as_mut()
+                {
+                    *active_starts_transaction = starts_transaction;
+                }
             }
         },
         SQLITE_TRACE_PROFILE if !context.is_null() && !object.is_null() => unsafe {
@@ -123,14 +159,44 @@ unsafe extern "C" fn trace_cloudsync_connection(
             let statement = object.cast::<sqlite3_stmt>();
             if observer.active_statement == statement {
                 let database = sqlite3_db_handle(statement);
-                if observer.active_rollback
-                    && !database.is_null()
-                    && sqlite3_get_autocommit(database) != 0
-                {
-                    invoke_observer(observer.on_rollback.as_mut());
+                match observer.active_control.take() {
+                    Some(TransactionControl::FullRollback)
+                        if !database.is_null() && sqlite3_get_autocommit(database) != 0 =>
+                    {
+                        invoke_observer(observer.on_rollback.as_mut());
+                    }
+                    Some(TransactionControl::Savepoint {
+                        name,
+                        starts_transaction,
+                    }) => {
+                        invoke_savepoint_observer(
+                            observer.on_savepoint.as_mut(),
+                            SavepointEvent::Begin {
+                                name,
+                                starts_transaction,
+                            },
+                        );
+                    }
+                    Some(TransactionControl::RollbackTo(name)) => {
+                        invoke_savepoint_observer(
+                            observer.on_savepoint.as_mut(),
+                            SavepointEvent::RollbackTo(name),
+                        );
+                    }
+                    Some(TransactionControl::Release(name)) => {
+                        let transaction_active =
+                            database.is_null() || sqlite3_get_autocommit(database) == 0;
+                        invoke_savepoint_observer(
+                            observer.on_savepoint.as_mut(),
+                            SavepointEvent::Release {
+                                name,
+                                transaction_active,
+                            },
+                        );
+                    }
+                    _ => {}
                 }
                 observer.active_statement = ptr::null_mut();
-                observer.active_rollback = false;
             }
         },
         SQLITE_TRACE_CLOSE if !object.is_null() => unsafe {
@@ -185,37 +251,123 @@ fn invoke_observer(callback: &mut (dyn FnMut() + Send)) {
     let _ = catch_unwind(AssertUnwindSafe(|| callback()));
 }
 
+fn invoke_savepoint_observer(
+    callback: &mut (dyn FnMut(SavepointEvent) + Send),
+    event: SavepointEvent,
+) {
+    let _ = catch_unwind(AssertUnwindSafe(|| callback(event)));
+}
+
 #[allow(unsafe_code)]
-unsafe fn statement_is_full_rollback(statement: *mut sqlite3_stmt) -> bool {
+unsafe fn statement_transaction_control(
+    statement: *mut sqlite3_stmt,
+) -> Option<TransactionControl> {
     let sql = unsafe { sqlite3_sql(statement) };
     if sql.is_null() {
-        return false;
+        return None;
     }
 
     let sql = unsafe { CStr::from_ptr(sql) }.to_str().unwrap_or_default();
-    is_full_rollback(sql)
+    parse_transaction_control(sql)
 }
 
-fn is_full_rollback(sql: &str) -> bool {
-    let Some(tail) = strip_keyword(sql, "ROLLBACK") else {
-        return false;
-    };
+fn parse_transaction_control(sql: &str) -> Option<TransactionControl> {
+    if let Some(tail) = strip_keyword(sql, "SAVEPOINT") {
+        return parse_identifier(tail).map(|name| TransactionControl::Savepoint {
+            name,
+            starts_transaction: false,
+        });
+    }
+
+    if let Some(tail) = strip_keyword(sql, "RELEASE") {
+        let tail = strip_keyword(tail, "SAVEPOINT").unwrap_or(tail);
+        return parse_identifier(tail).map(TransactionControl::Release);
+    }
+
+    let tail = strip_keyword(sql, "ROLLBACK")?;
     let tail = strip_keyword(tail, "TRANSACTION").unwrap_or(tail);
-    strip_keyword(tail, "TO").is_none()
+    let Some(tail) = strip_keyword(tail, "TO") else {
+        return Some(TransactionControl::FullRollback);
+    };
+    let tail = strip_keyword(tail, "SAVEPOINT").unwrap_or(tail);
+    parse_identifier(tail).map(TransactionControl::RollbackTo)
 }
 
 fn strip_keyword<'a>(sql: &'a str, keyword: &str) -> Option<&'a str> {
-    let sql = sql.trim_start();
+    let sql = trim_sql_prefix(sql);
     let prefix = sql.get(..keyword.len())?;
     if !prefix.eq_ignore_ascii_case(keyword) {
         return None;
     }
 
     let tail = &sql[keyword.len()..];
-    tail.chars()
+    (tail
+        .chars()
         .next()
         .is_none_or(|next| next.is_ascii_whitespace() || next == ';')
-        .then_some(tail)
+        || tail.starts_with("--")
+        || tail.starts_with("/*"))
+    .then_some(tail)
+}
+
+fn trim_sql_prefix(mut sql: &str) -> &str {
+    loop {
+        sql = sql.trim_start();
+        if let Some(comment) = sql.strip_prefix("--") {
+            sql = comment
+                .split_once('\n')
+                .map_or("", |(_, remainder)| remainder);
+        } else if let Some(comment) = sql.strip_prefix("/*") {
+            sql = comment
+                .split_once("*/")
+                .map_or("", |(_, remainder)| remainder);
+        } else {
+            return sql;
+        }
+    }
+}
+
+fn parse_identifier(sql: &str) -> Option<String> {
+    let sql = trim_sql_prefix(sql);
+    let delimiter = sql.chars().next()?;
+    match delimiter {
+        '"' | '\'' | '`' => parse_quoted_identifier(sql, delimiter),
+        '[' => sql[1..]
+            .find(']')
+            .and_then(|end| sql[1..].get(..end))
+            .map(str::to_string),
+        _ => {
+            let end = sql
+                .char_indices()
+                .find_map(|(index, character)| {
+                    (character.is_ascii_whitespace()
+                        || character == ';'
+                        || sql[index..].starts_with("--")
+                        || sql[index..].starts_with("/*"))
+                    .then_some(index)
+                })
+                .unwrap_or(sql.len());
+            (end > 0).then(|| sql[..end].to_string())
+        }
+    }
+}
+
+fn parse_quoted_identifier(sql: &str, delimiter: char) -> Option<String> {
+    let mut identifier = String::new();
+    let mut characters = sql[delimiter.len_utf8()..].chars().peekable();
+    while let Some(character) = characters.next() {
+        if character != delimiter {
+            identifier.push(character);
+            continue;
+        }
+        if characters.peek() == Some(&delimiter) {
+            characters.next();
+            identifier.push(delimiter);
+            continue;
+        }
+        return Some(identifier);
+    }
+    None
 }
 
 #[allow(unsafe_code)]
@@ -237,13 +389,49 @@ mod tests {
     use super::*;
 
     #[test]
-    fn distinguishes_full_and_savepoint_rollbacks() {
-        assert!(is_full_rollback("ROLLBACK"));
-        assert!(is_full_rollback(" rollback transaction;"));
-        assert!(!is_full_rollback("ROLLBACK TO savepoint_name"));
-        assert!(!is_full_rollback(
-            "ROLLBACK TRANSACTION TO SAVEPOINT savepoint_name"
-        ));
-        assert!(!is_full_rollback("SELECT 1"));
+    fn parses_transaction_controls() {
+        assert_eq!(
+            parse_transaction_control("SAVEPOINT _sqlx_savepoint_1"),
+            Some(TransactionControl::Savepoint {
+                name: "_sqlx_savepoint_1".to_string(),
+                starts_transaction: false,
+            })
+        );
+        assert_eq!(
+            parse_transaction_control("ROLLBACK TO SAVEPOINT _sqlx_savepoint_1"),
+            Some(TransactionControl::RollbackTo(
+                "_sqlx_savepoint_1".to_string()
+            ))
+        );
+        assert_eq!(
+            parse_transaction_control("RELEASE SAVEPOINT _sqlx_savepoint_1"),
+            Some(TransactionControl::Release("_sqlx_savepoint_1".to_string()))
+        );
+        assert_eq!(
+            parse_transaction_control("SAVEPOINT \"quoted \"\" name\""),
+            Some(TransactionControl::Savepoint {
+                name: "quoted \" name".to_string(),
+                starts_transaction: false,
+            })
+        );
+        assert_eq!(
+            parse_transaction_control("ROLLBACK TRANSACTION TO [nested step]"),
+            Some(TransactionControl::RollbackTo("nested step".to_string()))
+        );
+        assert_eq!(
+            parse_transaction_control("RELEASE `nested``step`"),
+            Some(TransactionControl::Release("nested`step".to_string()))
+        );
+        assert_eq!(
+            parse_transaction_control(" rollback transaction;"),
+            Some(TransactionControl::FullRollback)
+        );
+        assert_eq!(
+            parse_transaction_control(
+                "/* outer */ ROLLBACK/* transaction */TO/* target */SAVEPOINT \"nested step\""
+            ),
+            Some(TransactionControl::RollbackTo("nested step".to_string()))
+        );
+        assert_eq!(parse_transaction_control("SELECT 1"), None);
     }
 }

--- a/crates/cloudsync/src/lib.rs
+++ b/crates/cloudsync/src/lib.rs
@@ -15,7 +15,7 @@ pub use api::{
     terminate, uuid, version,
 };
 pub use bundle::bundled_extension_path;
-pub use close::install_transaction_observer;
+pub use close::{SavepointEvent, install_transaction_observer};
 pub use error::{Error, ErrorKind};
 pub use network::{
     NetworkReceiveResult, NetworkResult, NetworkSendResult, network_check_changes, network_cleanup,

--- a/crates/db-change/src/notifier.rs
+++ b/crates/db-change/src/notifier.rs
@@ -67,10 +67,12 @@ impl ChangeNotifier {
 
                 let commit_state = Arc::clone(&hook_state);
                 if cloudsync_enabled {
+                    let savepoint_state = Arc::clone(&hook_state);
                     hypr_cloudsync::install_transaction_observer(
                         &mut handle,
                         move || commit_state.flush(),
                         move || hook_state.clear(),
+                        move |event| savepoint_state.savepoint(event),
                     )
                     .map_err(|error| sqlx::Error::Configuration(Box::new(error)))?;
                 } else {

--- a/crates/db-change/src/tracker.rs
+++ b/crates/db-change/src/tracker.rs
@@ -8,9 +8,22 @@ use crate::{TableChange, TableChangeKind};
 
 #[derive(Debug)]
 pub(crate) struct HookState {
-    pending: std::sync::Mutex<HashMap<String, TableChangeKind>>,
+    pending: std::sync::Mutex<PendingChanges>,
     tx: broadcast::Sender<TableChange>,
     change_tracker: Arc<ChangeTracker>,
+}
+
+#[derive(Debug, Default)]
+struct PendingChanges {
+    tables: HashMap<String, TableChangeKind>,
+    savepoints: Vec<Savepoint>,
+}
+
+#[derive(Debug)]
+struct Savepoint {
+    name: String,
+    starts_transaction: bool,
+    tables: HashMap<String, TableChangeKind>,
 }
 
 impl HookState {
@@ -19,18 +32,60 @@ impl HookState {
         change_tracker: Arc<ChangeTracker>,
     ) -> Self {
         Self {
-            pending: std::sync::Mutex::new(HashMap::new()),
+            pending: std::sync::Mutex::new(PendingChanges::default()),
             tx,
             change_tracker,
         }
     }
 
     pub(crate) fn record(&self, table: &str, kind: TableChangeKind) {
-        self.pending.lock().unwrap().insert(table.to_string(), kind);
+        self.pending
+            .lock()
+            .unwrap()
+            .tables
+            .insert(table.to_string(), kind);
+    }
+
+    pub(crate) fn savepoint(&self, event: hypr_cloudsync::SavepointEvent) {
+        let mut pending = self.pending.lock().unwrap();
+        match event {
+            hypr_cloudsync::SavepointEvent::Begin {
+                name,
+                starts_transaction,
+            } => {
+                let tables = pending.tables.clone();
+                pending.savepoints.push(Savepoint {
+                    name,
+                    starts_transaction,
+                    tables,
+                });
+            }
+            hypr_cloudsync::SavepointEvent::RollbackTo(name) => {
+                if let Some(index) = find_savepoint(&pending.savepoints, &name) {
+                    pending.tables = pending.savepoints[index].tables.clone();
+                    pending.savepoints.truncate(index + 1);
+                }
+            }
+            hypr_cloudsync::SavepointEvent::Release {
+                name,
+                transaction_active,
+            } => {
+                if let Some(index) = find_savepoint(&pending.savepoints, &name) {
+                    if pending.savepoints[index].starts_transaction && transaction_active {
+                        return;
+                    }
+                    pending.savepoints.truncate(index);
+                }
+            }
+        }
     }
 
     pub(crate) fn flush(&self) {
-        let pending = std::mem::take(&mut *self.pending.lock().unwrap());
+        let pending = {
+            let mut state = self.pending.lock().unwrap();
+            state.savepoints.clear();
+            std::mem::take(&mut state.tables)
+        };
         if pending.is_empty() {
             return;
         }
@@ -43,8 +98,14 @@ impl HookState {
     }
 
     pub(crate) fn clear(&self) {
-        self.pending.lock().unwrap().clear();
+        *self.pending.lock().unwrap() = PendingChanges::default();
     }
+}
+
+fn find_savepoint(savepoints: &[Savepoint], name: &str) -> Option<usize> {
+    savepoints
+        .iter()
+        .rposition(|savepoint| savepoint.name.eq_ignore_ascii_case(name))
 }
 
 #[derive(Debug, Default)]
@@ -71,5 +132,47 @@ impl ChangeTracker {
         for table in pending.keys() {
             latest.insert(table.clone(), seq);
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn repeated_savepoint_names_use_the_most_recent_frame() {
+        let (tx, _) = broadcast::channel(1);
+        let state = HookState::new(tx, Arc::new(ChangeTracker::default()));
+        let name = "_sqlx_savepoint_1".to_string();
+
+        state.record("test_sync", TableChangeKind::Insert);
+        state.savepoint(hypr_cloudsync::SavepointEvent::Begin {
+            name: name.clone(),
+            starts_transaction: false,
+        });
+        state.record("test_sync", TableChangeKind::Delete);
+        state.savepoint(hypr_cloudsync::SavepointEvent::Begin {
+            name: name.clone(),
+            starts_transaction: false,
+        });
+        state.record("other_events", TableChangeKind::Insert);
+
+        state.savepoint(hypr_cloudsync::SavepointEvent::RollbackTo(name.clone()));
+        {
+            let pending = state.pending.lock().unwrap();
+            assert_eq!(pending.tables.len(), 1);
+            assert_eq!(pending.tables["test_sync"], TableChangeKind::Delete);
+            assert_eq!(pending.savepoints.len(), 2);
+        }
+
+        state.savepoint(hypr_cloudsync::SavepointEvent::Release {
+            name: name.clone(),
+            transaction_active: true,
+        });
+        state.savepoint(hypr_cloudsync::SavepointEvent::RollbackTo(name));
+        let pending = state.pending.lock().unwrap();
+        assert_eq!(pending.tables.len(), 1);
+        assert_eq!(pending.tables["test_sync"], TableChangeKind::Insert);
+        assert_eq!(pending.savepoints.len(), 1);
     }
 }

--- a/crates/db-core/src/lib.rs
+++ b/crates/db-core/src/lib.rs
@@ -303,6 +303,7 @@ mod tests {
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
 
+    use sqlx::Acquire;
     use tokio::sync::oneshot;
 
     fn test_cloudsync_config() -> CloudsyncRuntimeConfig {
@@ -644,6 +645,158 @@ mod tests {
         assert_eq!(final_version, 3);
         assert_eq!(value, "three");
         assert_eq!(failed_row_count, 0);
+    }
+
+    #[tokio::test]
+    async fn nested_rollback_restores_pending_table_changes() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(DbOpenOptions {
+            storage: DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap();
+
+        sqlx::query("CREATE TABLE test_sync (id TEXT PRIMARY KEY NOT NULL)")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query("CREATE TABLE other_events (id TEXT PRIMARY KEY NOT NULL)")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        db.cloudsync_init("test_sync", None, None).await.unwrap();
+
+        let notifier = db.change_notifier();
+        let mut changes = notifier.subscribe();
+        let version_before: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+
+        let mut transaction = db.pool().begin().await.unwrap();
+        sqlx::query("INSERT INTO test_sync (id) VALUES ('a')")
+            .execute(&mut *transaction)
+            .await
+            .unwrap();
+
+        let mut nested = transaction.begin().await.unwrap();
+        sqlx::query("DELETE FROM test_sync WHERE id = 'a'")
+            .execute(&mut *nested)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO other_events (id) VALUES ('a')")
+            .execute(&mut *nested)
+            .await
+            .unwrap();
+        nested.rollback().await.unwrap();
+        transaction.commit().await.unwrap();
+
+        let change = tokio::time::timeout(std::time::Duration::from_secs(1), changes.recv())
+            .await
+            .unwrap()
+            .unwrap();
+        assert_eq!(change.table, "test_sync");
+        assert_eq!(change.kind, hypr_db_change::TableChangeKind::Insert);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), changes.recv())
+                .await
+                .is_err()
+        );
+
+        let version_after: i64 = sqlx::query_scalar("SELECT cloudsync_db_version()")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let synced_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM test_sync")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let other_rows: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM other_events")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(version_after, version_before + 1);
+        assert_eq!(synced_rows, 1);
+        assert_eq!(other_rows, 0);
+    }
+
+    #[tokio::test]
+    async fn failed_outer_savepoint_release_preserves_pending_snapshot() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(DbOpenOptions {
+            storage: DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap();
+
+        sqlx::query("CREATE TABLE parents (id TEXT PRIMARY KEY NOT NULL)")
+            .execute(db.pool())
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE test_sync (\
+                id TEXT PRIMARY KEY NOT NULL, \
+                parent_id TEXT NOT NULL DEFAULT '', \
+                FOREIGN KEY (parent_id) REFERENCES parents(id) \
+                    DEFERRABLE INITIALLY DEFERRED\
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        db.cloudsync_init("test_sync", None, None).await.unwrap();
+
+        let notifier = db.change_notifier();
+        let seq_before = notifier.current_seq();
+        let mut changes = notifier.subscribe();
+        let mut connection = db.pool().acquire().await.unwrap();
+
+        sqlx::query("SAVEPOINT \"outer\"")
+            .execute(&mut *connection)
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO test_sync (id, parent_id) VALUES ('a', 'missing')")
+            .execute(&mut *connection)
+            .await
+            .unwrap();
+        assert!(
+            sqlx::query("RELEASE SAVEPOINT \"outer\"")
+                .execute(&mut *connection)
+                .await
+                .is_err()
+        );
+        sqlx::query("ROLLBACK TO SAVEPOINT \"outer\"")
+            .execute(&mut *connection)
+            .await
+            .unwrap();
+        sqlx::query("RELEASE SAVEPOINT \"outer\"")
+            .execute(&mut *connection)
+            .await
+            .unwrap();
+
+        assert_eq!(notifier.current_seq(), seq_before);
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(100), changes.recv())
+                .await
+                .is_err()
+        );
+        drop(connection);
+
+        let row_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM test_sync")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(row_count, 0);
     }
 
     #[tokio::test]


### PR DESCRIPTION
running 6 tests
test network::tests::parses_full_sync_result ... ok
test network::tests::parses_scoped_network_results ... ok
test close::tests::parses_transaction_controls ... ok
test tests::loads_bundled_cloudsync ... ok
test tests::reopens_initialized_database ... ok
test tests::terminates_each_pool_connection_before_close ... ok

test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s


running 1 test
test tracker::tests::repeated_savepoint_names_use_the_most_recent_frame ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s


running 36 tests
test cloudsync::types::tests::debug_output_redacts_cloudsync_credentials ... ok
test cloudsync::runtime::tests::embedded_sync_failures_update_runtime_error_state ... ok
test cloudsync::runtime::tests::embedded_sync_in_progress_does_not_update_runtime_error_state ... ok
test cloudsync::runtime::tests::authentication_failure_cleans_up_initialized_network ... ok
test tests::connect_local_read_only_does_not_create_missing_database ... ok
test tests::configure_rejects_live_runtime_changes ... ok
test cloudsync::runtime::tests::status_and_manual_sync_wait_for_suspend_teardown ... ok
test cloudsync::runtime::tests::configure_start_and_suspend_transitions_are_serialized ... ok
test cloudsync::runtime::tests::suspend_stops_runtime_and_clears_in_memory_credentials ... ok
test tests::connect_local_plain_creates_parent_dirs ... ok
test cloudsync::runtime::tests::suspend_interrupts_active_retry_backoff ... ok
test tests::disabled_open_mode_keeps_cloudsync_inert ... ok
test tests::dropping_db_stops_background_task_best_effort ... ok
test cloudsync::runtime::tests::logout_releases_connection_after_partial_startup ... ok
test tests::local_cloudsync_requires_wal ... ok
test cloudsync::ops::tests::network_calls_reuse_one_checked_out_connection ... ok
test tests::emits_table_changes_for_local_writes ... ok
test tests::enabled_open_mode_requires_runtime_config_before_start ... ok
test cloudsync::runtime::tests::suspend_clears_runtime_state_when_native_teardown_fails ... ok
test tests::emits_update_and_delete_table_changes ... ok
test tests::reconfigure_preserves_stopped_state_when_runtime_is_inert ... ok
test tests::notifier_survives_db_drop ... ok
test tests::open_applies_requested_pragmas ... ok
test tests::emits_table_changes_across_multiple_connections ... ok
test tests::tracks_monotonic_change_sequences_per_table ... ok
test tests::connect_local_read_only_rejects_writes ... ok
test cloudsync::runtime::tests::restart_after_fatal_exit_cleans_native_state ... ok
test cloudsync::ops::tests::network_sync_waits_for_checked_out_connection ... ok
test tests::memory_cloudsync_does_not_install_change_hooks ... ok
test tests::coalesces_multiple_writes_in_a_transaction ... ok
test tests::emits_table_changes_only_after_commit ... ok
test tests::open_memory_clamps_max_connections_to_one ... ok
test tests::rollback_clears_pending_table_changes ... ok
test tests::failed_outer_savepoint_release_preserves_pending_snapshot ... ok
test tests::nested_rollback_restores_pending_table_changes ... ok
test tests::cloudsync_and_change_notifier_share_transaction_lifecycle ... ok

test result: ok. 36 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.32s (43 passed)\n- \n- scoped dprint check\n-

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes commit/rollback/savepoint lifecycle for cloudsync change hooks; incorrect edge-case handling could miss or duplicate table-change events, but behavior is covered by new unit and integration tests.
> 
> **Overview**
> Fixes **incorrect table-change notifications** when transactions use nested savepoints (e.g. SQLx nested transactions): rolled-back work was still reflected in what gets flushed on commit.
> 
> **`hypr_cloudsync`** extends `install_transaction_observer` with an **`on_savepoint`** callback and public **`SavepointEvent`** (`Begin`, `RollbackTo`, `Release`). SQLite trace handling now classifies `SAVEPOINT` / `ROLLBACK TO` / `RELEASE` (not only full `ROLLBACK`), with SQL parsing that tolerates comments and quoted savepoint names.
> 
> **`hypr_db_change`** stacks snapshots of pending per-table changes at each savepoint. **`ROLLBACK TO`** restores the matching frame; **`RELEASE`** drops frames, with a guard so a failed outer **`RELEASE`** (transaction still open) does not discard the snapshot that started the transaction. The cloudsync notifier wires the new callback into this logic.
> 
> Integration tests cover nested SQLx rollback (only the outer insert is notified) and deferred-FK **`RELEASE`** failure followed by rollback (no spurious notifications).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b8fa34f61bf11affddef4e89eab9b9de3fa99ae. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->