### PR TITLE
Fail closed when CloudSync deploy secrets are missing

### DIFF
--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -71,6 +71,7 @@ jobs:
           )
 
           secrets_by_key = {}
+          cloudsync_keys = set()
           for source_path, allowed_keys in sources:
               with open(source_path) as source:
                   for secret in json.load(source):
@@ -78,9 +79,17 @@ jobs:
                       if allowed_keys is not None and key not in allowed_keys:
                           continue
                       value = secret.get("value", "")
+                      if allowed_keys is cloudsync_runtime_keys and value:
+                          cloudsync_keys.add(key)
                       if key in secrets_by_key and secrets_by_key[key] != value:
                           raise ValueError(f"Conflicting Infisical secret: {key}")
                       secrets_by_key[key] = value
+
+          missing_cloudsync_keys = sorted(cloudsync_runtime_keys - cloudsync_keys)
+          if missing_cloudsync_keys:
+              raise ValueError(
+                  "Missing required CloudSync secrets: " + ", ".join(missing_cloudsync_keys)
+              )
 
           with open(sys.argv[-1], "w") as target:
               for key, value in secrets_by_key.items():


### PR DESCRIPTION
Require all four production CloudSync variables before importing secrets into Fly. This prevents a successful deploy from silently omitting the `/sync/token` router when Infisical access is misconfigured.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only guard on secret export; no application runtime logic changes, but misconfigured Infisical will block deploys until secrets are fixed.
> 
> **Overview**
> The API CD workflow now **fails before Fly secret import** if any of the four production CloudSync variables are absent or empty in the Infisical `/anarlog/cloudsync` export.
> 
> The merge script tracks which `cloudsync_runtime_keys` were seen with non-empty values and raises `ValueError` listing any missing keys, so a deploy cannot succeed while silently omitting credentials needed for `/sync/token`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6f6b2131435019648218bd83a492bf752cf82d61. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->