### PR TITLE
Parse CloudSync TTL environment values

### DIFF
--- a/apps/api/src/env.rs
+++ b/apps/api/src/env.rs
@@ -94,3 +94,25 @@ fn field_name_to_env_var(field: &str) -> String {
         .flat_map(|ch| ch.to_uppercase())
         .collect::<String>()
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Deserialize)]
+    struct SyncOnlyEnv {
+        #[serde(flatten)]
+        sync: hypr_api_sync::SyncEnv,
+    }
+
+    #[test]
+    fn deserializes_cloudsync_ttl_from_environment_string() {
+        let env: SyncOnlyEnv = envy::from_iter([(
+            "ANARLOG_CLOUDSYNC_TOKEN_TTL_SECONDS".to_string(),
+            "300".to_string(),
+        )])
+        .unwrap();
+
+        assert_eq!(env.sync.anarlog_cloudsync_token_ttl_seconds, Some(300));
+    }
+}

--- a/crates/api-sync/src/config.rs
+++ b/crates/api-sync/src/config.rs
@@ -12,8 +12,17 @@ pub struct SyncEnv {
     pub sqlitecloud_token_issuer_api_key: Option<String>,
     #[serde(default)]
     pub anarlog_cloudsync_database_id: Option<String>,
-    #[serde(default)]
+    #[serde(default, deserialize_with = "deserialize_optional_u64")]
     pub anarlog_cloudsync_token_ttl_seconds: Option<u64>,
+}
+
+fn deserialize_optional_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<String>::deserialize(deserializer)?
+        .map(|value| value.parse().map_err(serde::de::Error::custom))
+        .transpose()
 }
 
 #[derive(Clone)]


### PR DESCRIPTION
## Summary
- parse the optional CloudSync TTL from string environment values
- cover the flattened API environment path with a regression test

## Verification
- `cargo test -p api-sync`
- `cargo test -p api`
- `cargo check -p api`
- `pnpm exec dprint fmt apps/api/src/env.rs crates/api-sync/src/config.rs`

The first production canary failed before cutover because the new machine rejected the string TTL value. Production remained healthy on `0.0.55`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow env-parsing fix with a regression test; existing TTL bounds validation in `SyncConfig::from_env` is unchanged.
> 
> **Overview**
> Fixes API startup when `ANARLOG_CLOUDSYNC_TOKEN_TTL_SECONDS` is set from deployment secrets as a string (e.g. `"300"`), which previously failed serde deserialization into `Option<u64>`.
> 
> `SyncEnv` now uses a custom `deserialize_optional_u64` deserializer so optional TTL values are parsed from strings. A regression test in the API `env` module asserts the flattened `envy` path deserializes `ANARLOG_CLOUDSYNC_TOKEN_TTL_SECONDS` to `Some(300)`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 845f99938e965b530170fb66efed2366c8e2c482. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->