### PR TITLE
Require authentication for desktop session handoff

### DIFF
--- a/apps/web/src/functions/auth-session.test.ts
+++ b/apps/web/src/functions/auth-session.test.ts
@@ -1,0 +1,43 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import { mintDesktopSessionForAuthenticatedUser } from "./auth-session.ts";
+
+test("does not mint a desktop session without an authenticated user", async () => {
+  let mintedEmail: string | null = null;
+
+  const result = await mintDesktopSessionForAuthenticatedUser({
+    getUser: async () => ({
+      data: { user: null },
+      error: new Error("Not authenticated"),
+    }),
+    mintSession: async (email) => {
+      mintedEmail = email;
+      return { access_token: "access-token", refresh_token: "refresh-token" };
+    },
+  });
+
+  assert.equal(result, null);
+  assert.equal(mintedEmail, null);
+});
+
+test("mints a desktop session for the authenticated user's email", async () => {
+  let mintedEmail: string | null = null;
+
+  const result = await mintDesktopSessionForAuthenticatedUser({
+    getUser: async () => ({
+      data: { user: { email: "signed-in@example.com" } },
+      error: null,
+    }),
+    mintSession: async (email) => {
+      mintedEmail = email;
+      return { access_token: "access-token", refresh_token: "refresh-token" };
+    },
+  });
+
+  assert.equal(mintedEmail, "signed-in@example.com");
+  assert.deepEqual(result, {
+    access_token: "access-token",
+    refresh_token: "refresh-token",
+  });
+});

--- a/apps/web/src/functions/auth-session.ts
+++ b/apps/web/src/functions/auth-session.ts
@@ -1,0 +1,21 @@
+export async function mintDesktopSessionForAuthenticatedUser({
+  getUser,
+  mintSession,
+}: {
+  getUser: () => Promise<{
+    data: { user: { email?: string } | null };
+    error: unknown;
+  }>;
+  mintSession: (
+    email: string,
+  ) => Promise<{ access_token: string; refresh_token: string } | null>;
+}) {
+  const { data, error } = await getUser();
+  const email = data.user?.email;
+
+  if (error || !email) {
+    return null;
+  }
+
+  return mintSession(email);
+}

--- a/apps/web/src/functions/auth.ts
+++ b/apps/web/src/functions/auth.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 
 import { isAdminEmail } from "@/functions/admin";
 import { getRequestAppOrigin } from "@/functions/app-origin";
+import { mintDesktopSessionForAuthenticatedUser } from "@/functions/auth-session";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
 import {
   getSupabaseAdminClient,
@@ -369,9 +370,15 @@ export const exchangeOtpToken = createServerFn({ method: "POST" })
     return toSuccessTokenResponse(tokens);
   });
 
-export const createDesktopSession = createServerFn({ method: "POST" })
-  .inputValidator(z.object({ email: z.string().email() }))
-  .handler(async ({ data }) => mintDesktopSessionFromEmail(data.email));
+export const createDesktopSession = createServerFn({ method: "POST" }).handler(
+  async () => {
+    const supabase = getSupabaseServerClient();
+    return mintDesktopSessionForAuthenticatedUser({
+      getUser: () => supabase.auth.getUser(),
+      mintSession: mintDesktopSessionFromEmail,
+    });
+  },
+);
 
 export const doPasswordResetRequest = createServerFn({ method: "POST" })
   .inputValidator(

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -45,9 +45,7 @@ export const Route = createFileRoute("/auth")({
       }
 
       if (search.flow === "desktop") {
-        const result = await createDesktopSession({
-          data: { email: user.email },
-        });
+        const result = await createDesktopSession();
 
         if (result) {
           throw redirect({
@@ -226,7 +224,7 @@ function DesktopReauthView({
   scheme: DesktopScheme;
 }) {
   const retryMutation = useMutation({
-    mutationFn: () => createDesktopSession({ data: { email } }),
+    mutationFn: () => createDesktopSession(),
     onSuccess: (result) => {
       if (result) {
         const params = new URLSearchParams();


### PR DESCRIPTION
Bind desktop session minting to the request-scoped Supabase user and remove caller-controlled email input. Add focused coverage for unauthenticated rejection and authenticated subject binding.

Checks:
- `pnpm -F @hypr/web test`
- `pnpm -F @hypr/web typecheck`
- `CI=true pnpm -F @hypr/web build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and desktop token handoff; the change tightens binding but regressions could break the desktop sign-in flow if session resolution diverges from UI state.
> 
> **Overview**
> **Desktop session handoff no longer accepts a client-supplied email.** `createDesktopSession` now derives the subject from the request-scoped Supabase user via `getUser()` and returns `null` when there is no authenticated user or email.
> 
> A small helper, `mintDesktopSessionForAuthenticatedUser`, centralizes that guard and is wired from `createDesktopSession`; the auth route and desktop reauth retry call the endpoint with no body. **Tests** cover unauthenticated rejection and minting for the signed-in user’s email only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3c39910f7e26c183a93434459b8e759a2344727e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->