### PR TITLE
Fix Netlify web deployment

### DIFF
--- a/.github/workflows/web_cd.yaml
+++ b/.github/workflows/web_cd.yaml
@@ -28,16 +28,27 @@ jobs:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/pnpm_install
       - uses: denoland/setup-deno@v2
-      - run: pnpm -F ui build
-      - run: pnpm -F web build
-        env:
-          VITE_APP_URL: "https://anarlog.so"
-          VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
-      - run: npm install -g netlify-cli
-      - run: netlify deploy --prod --dir=apps/web/dist/client
+      - name: Check Netlify deployment credentials
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+        run: |
+          : "${NETLIFY_AUTH_TOKEN:?Missing NETLIFY_AUTH_TOKEN repository secret}"
+          : "${NETLIFY_SITE_ID:?Missing NETLIFY_SITE_ID repository secret}"
+      - run: pnpm -F ui build
+      - run: npm install -g netlify-cli@26.2.0
+      - name: Build and deploy web to Netlify
+        run: |
+          netlify deploy \
+            --prod \
+            --context production \
+            --site "$NETLIFY_SITE_ID" \
+            --filter @hypr/web \
+            --message "web v${{ needs.compute-version.outputs.version }} ($GITHUB_SHA)"
+        env:
+          NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+          NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}
+          VITE_APP_VERSION: ${{ needs.compute-version.outputs.version }}
 
   tag:
     needs: [compute-version, deploy]

--- a/apps/web/netlify.toml
+++ b/apps/web/netlify.toml
@@ -1,7 +1,7 @@
 # https://docs.netlify.com/build/configure-builds/overview/#definitions
 # We must set package="apps/web" in the UI
 [build]
-command = "VITE_APP_VERSION=$COMMIT_REF pnpm -F @hypr/web build"
+command = "VITE_APP_VERSION=${VITE_APP_VERSION:-$COMMIT_REF} pnpm -F @hypr/web build"
 publish = "apps/web/dist/client"
 ignore = "git diff --quiet $CACHED_COMMIT_REF $COMMIT_REF apps/web packages/api-client packages/changelog packages/ui packages/utils package.json pnpm-lock.yaml"
 


### PR DESCRIPTION
## Summary
- fail fast when Netlify deployment credentials are missing
- let Netlify build and deploy the complete production-context web artifact, including the TanStack SSR function
- preserve explicit release versions while retaining commit-SHA versions for Git-triggered builds

## Verification
- `pnpm exec dprint check .github/workflows/web_cd.yaml apps/web/netlify.toml`
- `pnpm -F @hypr/web test`
- `pnpm -F @hypr/web typecheck`
- Netlify CLI production-context dry run resolves `@hypr/web` and `apps/web/netlify.toml`
- `CI=true VITE_APP_VERSION=0.0.0-test pnpm -F @hypr/web build` emits `.netlify/v1/functions/server.mjs`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production deployment mechanics and how app version is baked into builds; misconfiguration could break deploys or ship wrong version labels, but scope is limited to CI/Netlify config.
> 
> **Overview**
> **Reworks the web CD pipeline** so production deploys go through Netlify’s build instead of uploading a prebuilt `dist` folder.
> 
> The workflow now **validates** `NETLIFY_AUTH_TOKEN` and `NETLIFY_SITE_ID` before doing work, still builds `@hypr/ui`, pins **Netlify CLI 26.2.0**, and runs `netlify deploy --prod --context production` with `--filter @hypr/web` and an explicit `--site`, so Netlify applies `apps/web/netlify.toml` (including the SSR/server function output). Release **`VITE_APP_VERSION`** is set from the computed version for that deploy; the old in-workflow `pnpm -F web build`, `VITE_APP_URL` on deploy, and `--dir=apps/web/dist/client` path are removed.
> 
> **`netlify.toml`** build command now prefers `VITE_APP_VERSION` when set and falls back to `$COMMIT_REF` for Git-triggered builds.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4249522be28f90e5d8619b51c29e1de88971b00. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->