### PR TITLE
Prepare desktop 1.2.0 changelog

### DIFF
--- a/packages/changelog/content/1.2.0.md
+++ b/packages/changelog/content/1.2.0.md
@@ -1,5 +1,5 @@
 ---
-date: "2026-07-14"
+date: "2026-07-15"
 summary: "Anarlog makes large note libraries faster, adds flexible summary instructions, improves recording recovery, and strengthens CloudSync reliability."
 ---
 


### PR DESCRIPTION
Move the unreleased desktop 1.1.17 changelog to 1.2.0 and update the release date.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changelog metadata only; no application or runtime behavior changes.
> 
> **Overview**
> Updates the **desktop 1.2.0** changelog frontmatter so the published release date is **2026-07-15** instead of **2026-07-14**. No release-note bullets or summary text change in this diff—only the `date` field in `packages/changelog/content/1.2.0.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96d5ae885fae0af21b9c4d995d4bdb36f1813ee4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->