### PR TITLE
Expand Mintlify user guides

### DIFF
--- a/docs/ai-setup.mdx
+++ b/docs/ai-setup.mdx
@@ -29,6 +29,8 @@ Open **Settings → Transcription** or **Settings → Intelligence** to choose a
 
 Models labeled **Live** show text during the meeting. Models labeled **After recording** transcribe after you stop.
 
+To keep transcription, summaries, and chat on your computer, follow [Use Anarlog offline](/offline).
+
 ## LM Studio
 
 1. Install [LM Studio](https://lmstudio.ai/download) and download a model.
@@ -52,3 +54,5 @@ Models labeled **Live** show text during the meeting. Models labeled **After rec
 ## What leaves your computer
 
 Your app data remains local. Local transcription and local Intelligence providers process content on your computer. If you select Anarlog Cloud or another hosted provider, Anarlog sends the audio or text needed for that request to the selected provider.
+
+See [Data, privacy, and retention](/data-and-privacy) for a feature-by-feature explanation.

--- a/docs/automatic-capture.mdx
+++ b/docs/automatic-capture.mdx
@@ -1,0 +1,34 @@
+---
+title: "Automate meeting capture"
+description: "Use calendar timing, microphone detection, and automatic stopping without losing control."
+---
+
+Anarlog can start an event-backed note at its scheduled time, remind you when another meeting app uses your microphone, and stop listening when the call ends.
+
+## Start scheduled meetings automatically
+
+Open **Settings → App → Meetings** and enable **Start when meeting begins**.
+
+When a calendar-backed note reaches its scheduled start time, Anarlog starts listening. This setting does not apply to ordinary notes without a calendar event.
+
+Keep Anarlog running and make sure microphone and system-audio access are allowed. See [Connect a calendar](/calendar) if your events are not visible.
+
+## Detect unscheduled calls
+
+Open **Settings → Notifications** and enable **Microphone detection**. Anarlog watches for sustained microphone activity and notifies you that a meeting may have started.
+
+Microphone detection is a reminder; it does not start recording by itself. Choose a detection delay from 5 seconds to 2 minutes, and exclude apps that should not trigger a meeting prompt.
+
+Accessibility permission is required to detect meeting apps and synchronize mute state. You can manage it under **Settings → Permissions**.
+
+## Stop when the call ends
+
+Under **Settings → App → Meetings**, enable **Stop when meeting ends**. Anarlog stops listening when the meeting app releases the microphone.
+
+If you switch audio devices or use an app with unusual microphone behavior, check that the recording is still active before closing the meeting.
+
+## Keep controls nearby
+
+Enable **Show floating bar** under **Settings → App → Meetings** to keep compact recording controls visible while Anarlog listens.
+
+Event and microphone notifications can also respect your system's Do Not Disturb mode from **Settings → Notifications**.

--- a/docs/customize-summaries.mdx
+++ b/docs/customize-summaries.mdx
@@ -1,0 +1,36 @@
+---
+title: "Customize meeting summaries"
+description: "Choose a structure, add standing instructions, and teach Anarlog your terminology."
+---
+
+Use a template for the shape of one summary. Use summary instructions and the dictionary for preferences that should apply across meetings.
+
+## Choose a template
+
+Open a meeting and use the template picker beside **Summary**. Templates can emphasize decisions, action items, a one-on-one format, or another structure.
+
+Changing the selected template does not rewrite an existing summary automatically. Regenerate the summary to apply the new template.
+
+## Set instructions for every summary
+
+1. Open **Settings → Personalization**.
+2. Edit **Summary instructions**.
+3. Describe the result you want, then click **Save**.
+
+For example:
+
+> Start with a two-sentence overview. Then list decisions and action items with owners. Do not use headings.
+
+The **Template** chip inserts the selected meeting template into your instructions. Keep it when you want both your standing instructions and the selected template. Remove it when you want the instructions to replace templates entirely.
+
+Summary instructions take priority when they conflict with a template. Use **Reset to default** to return to Anarlog's standard behavior.
+
+## Improve names and specialized terms
+
+Under **Settings → Personalization → Dictionary**, add names, acronyms, product names, and other terms that transcription often gets wrong.
+
+The dictionary helps recognition, but it does not replace choosing the correct spoken languages or a model that supports them. See [Languages](/languages) for multilingual meetings.
+
+## Apply your changes
+
+New summaries use the latest template and instructions. Regenerate an older summary when you want it to use the new settings.

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -1,0 +1,52 @@
+---
+title: "Data, privacy, and retention"
+description: "Understand what stays on your computer, what can leave it, and how long audio is kept."
+---
+
+Anarlog stores its app data on your computer and captures meetings without adding a bot to the call. Data leaves your computer only when you use a connected or hosted feature that needs it.
+
+## What stays on your computer
+
+Your notes, local transcripts, settings, recordings you choose to keep, and downloaded local models are stored locally. You can write notes, record audio, and use configured local models without sending meeting content to Anarlog Cloud.
+
+Use Anarlog's export tools when you need a portable copy. Do not edit the app database directly.
+
+## When content is sent elsewhere
+
+The destination depends on the feature you choose:
+
+- A hosted **Transcription** provider receives the audio needed to create a transcript.
+- A hosted **Intelligence** provider receives the text and instructions needed to create a summary or chat response.
+- Connected calendars exchange the event data required to show and update your meetings.
+- Sync and sharing features send the content you choose to make available on another device or through a link.
+
+Anarlog Cloud, your own API-key providers, and local providers are separate choices. Review the provider's own retention and training policies before sending sensitive content.
+
+## Keep a meeting fully local
+
+1. Select an on-device model under **Settings → Transcription**.
+2. Select LM Studio or Ollama under **Settings → Intelligence**.
+3. Avoid cloud sync, share links, and hosted providers for that content.
+
+See [Use Anarlog offline](/offline) for the full setup.
+
+## Choose how long audio is kept
+
+Open **Settings → App → Storage → Audio file retention**. Choose:
+
+- **Don't save**
+- **1 day**
+- **3 days**
+- **1 week**
+- **1 month**
+- **Forever**
+
+Deleting retained audio does not remove the meeting note or transcript. If you need the recording later, open the meeting's **•••** menu, choose **Show in Finder**, and copy the audio before its retention period ends.
+
+## Turn off usage analytics
+
+Open **Settings → App** and disable **Share usage data**. This controls anonymous product analytics, not the meeting content sent to a provider you selected.
+
+<Warning>
+  Recording-consent rules depend on where you and the other participants are located. Make sure you have permission before recording.
+</Warning>

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -21,7 +21,19 @@
       },
       {
         "group": "Using Anarlog",
-        "pages": ["meetings", "notes", "calendar", "ai-setup"]
+        "pages": [
+          "meetings",
+          "automatic-capture",
+          "import-recordings",
+          "notes",
+          "customize-summaries",
+          "calendar",
+          "languages"
+        ]
+      },
+      {
+        "group": "AI and privacy",
+        "pages": ["ai-setup", "offline", "data-and-privacy"]
       },
       {
         "group": "CLI and agents",
@@ -47,7 +59,7 @@
       },
       {
         "group": "Help",
-        "pages": ["troubleshooting"]
+        "pages": ["help", "troubleshooting"]
       }
     ],
     "global": {

--- a/docs/help.mdx
+++ b/docs/help.mdx
@@ -1,0 +1,33 @@
+---
+title: "Common questions"
+description: "Find the right guide for the questions people ask most often about Anarlog."
+---
+
+<CardGroup cols={2}>
+  <Card title="Does Anarlog join the call?" icon="video-slash" href="/meetings">
+    No. Anarlog captures microphone and computer audio on your Mac without adding a meeting bot.
+  </Card>
+  <Card title="Can I use it offline?" icon="wifi-slash" href="/offline">
+    Yes. Prepare local transcription and Intelligence models before disconnecting.
+  </Card>
+  <Card title="Where is my data stored?" icon="hard-drive" href="/data-and-privacy">
+    App data is stored locally. Hosted and connected features receive only the data needed for the feature.
+  </Card>
+  <Card title="Can I import an old recording?" icon="file-arrow-up" href="/import-recordings">
+    Import common audio formats, or start from an SRT or VTT transcript.
+  </Card>
+  <Card title="Can recording start automatically?" icon="clock" href="/automatic-capture">
+    Start calendar-backed meetings on schedule and get prompts for unscheduled calls.
+  </Card>
+  <Card title="How do I improve summaries?" icon="wand-magic-sparkles" href="/customize-summaries">
+    Choose a template, set standing instructions, and add specialized terms.
+  </Card>
+  <Card title="Can a meeting use multiple languages?" icon="language" href="/languages">
+    Choose the output language and add every language you expect people to speak.
+  </Card>
+  <Card title="How do I export my notes?" icon="file-export" href="/notes#export-a-meeting">
+    Export any combination of the memo, summary, and transcript.
+  </Card>
+</CardGroup>
+
+If something is not working, go to [Troubleshooting](/troubleshooting). For a question not covered here, email [hello@anarlog.so](mailto:hello@anarlog.so) or [join Discord](https://anarlog.so/discord).

--- a/docs/import-recordings.mdx
+++ b/docs/import-recordings.mdx
@@ -1,0 +1,33 @@
+---
+title: "Import audio or a transcript"
+description: "Turn an existing recording or subtitle file into an Anarlog meeting note."
+---
+
+You can use Anarlog with a conversation that was recorded elsewhere. Import audio to create a new transcript, or import an existing transcript to create a summary.
+
+## Import audio
+
+1. Create a **New Note** or open an empty note.
+2. Open the **•••** menu and choose **Upload audio**.
+3. Select a supported audio file.
+4. Leave Anarlog open while it imports and transcribes the recording.
+
+You can also drag one audio file onto an open note.
+
+Anarlog accepts WAV, MP3, OGG, MP4, M4A, FLAC, WebM, and AAC files. It uses your selected **Transcription** model, so configure that model before importing.
+
+When transcription finishes, Anarlog creates a summary if an **Intelligence** model is configured.
+
+## Import a transcript
+
+1. Create a **New Note** or open an empty note.
+2. Open the **•••** menu and choose **Upload transcript**.
+3. Select a WebVTT (`.vtt`) or SubRip (`.srt`) file.
+
+Anarlog adds the timed text to the note and generates a summary when an Intelligence model is available. Importing a transcript does not create an audio recording.
+
+## If an import does not start
+
+Confirm that the file uses one of the supported formats and that a Transcription model is selected for audio imports. For local or bring-your-own-key providers, make sure the provider is running and configured.
+
+See [Transcription and AI](/ai-setup) for model setup or [Troubleshooting](/troubleshooting) for common failures.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -20,6 +20,25 @@ Anarlog records your microphone and computer audio without joining the call as a
   </Card>
 </CardGroup>
 
+## Popular questions
+
+<CardGroup cols={2}>
+  <Card title="Can I use Anarlog offline?" icon="wifi-slash" href="/offline">
+    Record, transcribe, summarize, and chat with local models.
+  </Card>
+  <Card title="Where is my data stored?" icon="hard-drive" href="/data-and-privacy">
+    See what stays local and what hosted features receive.
+  </Card>
+  <Card title="Can I import a recording?" icon="file-arrow-up" href="/import-recordings">
+    Create a meeting note from audio, SRT, or VTT files.
+  </Card>
+  <Card title="How do I improve summaries?" icon="wand-magic-sparkles" href="/customize-summaries">
+    Use templates, instructions, languages, and your dictionary.
+  </Card>
+</CardGroup>
+
+[Browse all common questions →](/help)
+
 ## The short version
 
 1. Open a calendar event or create a note.

--- a/docs/languages.mdx
+++ b/docs/languages.mdx
@@ -1,0 +1,26 @@
+---
+title: "Use multiple languages"
+description: "Choose the language for AI output and tell transcription which languages to expect."
+---
+
+Anarlog separates the language used for summaries and chat from the languages it should expect in a conversation.
+
+## Choose the main language
+
+Open **Settings → App → Language & Region** and choose **Main language**.
+
+Anarlog uses the main language for summaries, chat, and other AI-generated responses. It is also always included as a transcription language.
+
+Changing the main language does not translate an existing transcript. Regenerate a summary to apply the new output language to an older meeting.
+
+## Add spoken languages
+
+Under **Additional spoken languages**, add other languages people may use in the same meeting. This gives transcription more context for multilingual conversations.
+
+The selected Transcription provider and model must support those languages. If a language is missing or performs poorly, try another model under **Settings → Transcription**.
+
+## Improve names and jargon
+
+Language selection does not teach the model company-specific terminology. Add names, acronyms, and product terms under **Settings → Personalization → Dictionary**.
+
+For summary structure and wording, use [Customize meeting summaries](/customize-summaries).

--- a/docs/meetings.mdx
+++ b/docs/meetings.mdx
@@ -35,4 +35,6 @@ You can resume a finished meeting from the same top-right control if the convers
 
 Create or open an empty note, click the **•••** menu, then choose **Upload audio** or **Upload transcript**.
 
-For automatic start and stop controls, open **Settings → App → Meetings**.
+See [Import audio or a transcript](/import-recordings) for supported formats and the complete flow.
+
+For automatic start, meeting detection, and stop controls, see [Automate meeting capture](/automatic-capture).

--- a/docs/notes.mdx
+++ b/docs/notes.mdx
@@ -13,9 +13,9 @@ You can edit memos and summaries like regular notes. In a transcript, select a s
 
 ## Shape the summary
 
-Use the template picker beside **Summary** to change its structure. To set rules for every summary, open **Settings → Personalization → Summary instructions**.
+Use the template picker beside **Summary** to change its structure. You can also set standing instructions, add names and specialized terms, and control how templates interact with your preferences.
 
-Add names, acronyms, and product terms under **Settings → Personalization → Dictionary** to help transcription recognize them.
+See [Customize meeting summaries](/customize-summaries) for the complete setup.
 
 ## Export a meeting
 

--- a/docs/offline.mdx
+++ b/docs/offline.mdx
@@ -1,0 +1,40 @@
+---
+title: "Use Anarlog offline"
+description: "Prepare local transcription and intelligence models before working without a network connection."
+---
+
+Anarlog can record meetings and manage notes without an internet connection. To transcribe, summarize, and chat offline, configure local models before you disconnect.
+
+## What works without the internet
+
+- Create and edit notes.
+- Record and play meeting audio.
+- Export memos, summaries, and transcripts already on your computer.
+- Transcribe with a downloaded on-device model on a supported Apple Silicon Mac.
+- Generate summaries and chat with a local LM Studio or Ollama server.
+
+Hosted models, Google and Outlook calendar sync, cloud sync, and share links need a network connection.
+
+## Prepare offline transcription
+
+1. Open **Settings → Transcription**.
+2. Download a supported on-device model.
+3. Select it under **Model being used**.
+4. Run a short test recording before going offline.
+
+The model's **Live** or **After recording** label tells you when text will appear. On-device model availability depends on your Mac and the current Anarlog release.
+
+## Prepare offline summaries and chat
+
+Use [LM Studio](https://lmstudio.ai/download) or [Ollama](https://ollama.com/download) as your local Intelligence provider. Download the model in advance, start the local server, and select that model in **Settings → Intelligence**.
+
+Anarlog must be able to reach the local server while you work. The server can run on the same computer without internet access.
+
+## Check that nothing uses a hosted provider
+
+Before a sensitive meeting, confirm both selections:
+
+- **Settings → Transcription → Model being used** points to an on-device model.
+- **Settings → Intelligence → Model being used** points to LM Studio or Ollama.
+
+Choosing a local model for only one setting does not make the other setting local. See [Data, privacy, and retention](/data-and-privacy) for what each provider receives.

--- a/docs/troubleshooting.mdx
+++ b/docs/troubleshooting.mdx
@@ -32,7 +32,15 @@ For Apple Calendar, also check **Settings → Permissions → Calendar**.
 
 ## A recording disappeared
 
-Open **Settings → Storage** and check **Audio file retention**. Anarlog can delete audio immediately or after a selected period while keeping the note and transcript.
+Open **Settings → App → Storage** and check **Audio file retention**. Anarlog can delete audio immediately or after a selected period while keeping the note and transcript.
+
+See [Data, privacy, and retention](/data-and-privacy#choose-how-long-audio-is-kept) for every retention option.
+
+## An imported file does nothing
+
+Audio imports accept WAV, MP3, OGG, MP4, M4A, FLAC, WebM, and AAC. Transcript imports accept SRT and VTT.
+
+For audio, confirm that a Transcription model is selected and that a local provider is running. See [Import audio or a transcript](/import-recordings).
 
 ## Get more help
 


### PR DESCRIPTION
Turn common FAQ topics into task-oriented pages and add navigation from the docs home and help sections.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and Mintlify navigation only; no application code or runtime behavior changes.
> 
> **Overview**
> Adds **task-oriented Mintlify pages** for topics that were previously scattered or only implied in FAQs: automatic capture, importing recordings, customizing summaries, multilingual setup, offline use, and data/privacy/retention. A new **Common questions** hub (`help.mdx`) links those guides from card shortcuts.
> 
> **Navigation** in `docs.json` is reorganized: **Using Anarlog** gains the new workflow pages; **AI and privacy** groups `ai-setup`, `offline`, and `data-and-privacy`; **Help** adds `help` ahead of troubleshooting.
> 
> The **docs home** gets a **Popular questions** card group and a link to browse all FAQs. Existing pages (`meetings`, `notes`, `ai-setup`, `troubleshooting`) are trimmed in favor of **cross-links** to the dedicated guides, with small path fixes (e.g. **Settings → App → Storage** for audio retention).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9053b396c63d25dbd4ead09590b7dbe22cf23e2b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->