### PR TITLE
Keep sidebar timeline mounted when collapsed

### DIFF
--- a/apps/desktop/src/main/body.test.tsx
+++ b/apps/desktop/src/main/body.test.tsx
@@ -325,7 +325,7 @@ describe("ClassicMainBody", () => {
     expect(panels[0]?.dataset.flexGrow).toBe("var(--left-sidebar-panel-size)");
     expect(panels[0]?.dataset.minWidth).toBe("200");
     expect(panels[0]?.dataset.maxWidth).toBe("360");
-    expect(panels[0]?.dataset.transition).toContain("flex-grow");
+    expect(panels[0]?.dataset.transition).toBeUndefined();
     expect(panels[1]?.dataset.panelId).toBe("classic-main-content");
     expect(panels[1]?.dataset.order).toBe("2");
 
@@ -340,6 +340,9 @@ describe("ClassicMainBody", () => {
     );
 
     expect(sidebarContent?.className).toContain("translate-x-0");
+    expect(sidebarContent?.className).toContain(
+      "transition-[opacity,transform]",
+    );
     expect(sidebarContent?.getAttribute("aria-hidden")).toBe("false");
     expect(sidebarChrome).toBeNull();
     expect(sidebarTimelineHeader).toBeTruthy();
@@ -698,7 +701,7 @@ describe("ClassicMainBody", () => {
     expect(panels[1]?.dataset.minWidth).toBe("500");
   });
 
-  it("collapses the sidebar panel and unmounts hidden timeline content", () => {
+  it("collapses the sidebar panel while keeping hidden timeline content mounted", () => {
     mocks.leftsidebar.expanded = false;
 
     render(<ClassicMainBody />);
@@ -707,7 +710,7 @@ describe("ClassicMainBody", () => {
 
     expect(resizeHandle.dataset.className).toContain("pointer-events-none");
     expect(resizeHandle.dataset.className).toContain("w-0");
-    expect(screen.queryByTestId("classic-main-sidebar")).toBeNull();
+    expect(screen.getByTestId("classic-main-sidebar")).toBeTruthy();
 
     const panels = screen.getAllByTestId("panel");
     expect(panels).toHaveLength(2);
@@ -715,13 +718,16 @@ describe("ClassicMainBody", () => {
     expect(panels[0]?.dataset.flexGrow).toBe("0");
     expect(panels[0]?.dataset.minWidth).toBe("0");
     expect(panels[0]?.dataset.maxWidth).toBe("0");
-    expect(panels[0]?.dataset.transition).toContain("flex-grow");
+    expect(panels[0]?.dataset.transition).toBeUndefined();
 
     const sidebarContent = document.querySelector<HTMLElement>(
       "[data-left-sidebar-panel-content]",
     );
     expect(sidebarContent?.className).toContain("-translate-x-3");
     expect(sidebarContent?.className).toContain("opacity-0");
+    expect(
+      document.querySelector("[data-sidebar-timeline-header]"),
+    ).toBeTruthy();
     expect(sidebarContent?.getAttribute("aria-hidden")).toBe("true");
     expect(sidebarContent?.hasAttribute("inert")).toBe(true);
   });
@@ -729,16 +735,22 @@ describe("ClassicMainBody", () => {
   it("resizes the collapsed sidebar panel before reopening it", () => {
     mocks.leftsidebar.expanded = false;
 
-    render(<ClassicMainBody />);
+    const { rerender } = render(<ClassicMainBody />);
+    const mountedSidebar = screen.getByTestId("classic-main-sidebar");
 
     fireEvent.click(screen.getByRole("button", { name: "Show sidebar" }));
 
     expect(mocks.leftSidebarPanelHandle.resize).toHaveBeenCalledWith(12.5);
     expect(mocks.leftSidebarPanelHandle.expand).not.toHaveBeenCalled();
     expect(mocks.leftsidebar.toggleExpanded).toHaveBeenCalledTimes(1);
+
+    mocks.leftsidebar.expanded = true;
+    rerender(<ClassicMainBody />);
+
+    expect(screen.getByTestId("classic-main-sidebar")).toBe(mountedSidebar);
   });
 
-  it("restores sidebar transitions when a resize is interrupted by collapse", () => {
+  it("keeps layout transitions disabled when resize is interrupted by collapse", () => {
     const { rerender } = render(<ClassicMainBody />);
 
     act(() => {
@@ -753,9 +765,9 @@ describe("ClassicMainBody", () => {
     mocks.leftsidebar.expanded = false;
     rerender(<ClassicMainBody />);
 
-    expect(screen.getAllByTestId("panel")[0]?.dataset.transition).toContain(
-      "flex-grow",
-    );
+    expect(
+      screen.getAllByTestId("panel")[0]?.dataset.transition,
+    ).toBeUndefined();
     expect(mocks.leftsidebar.toggleExpanded).toHaveBeenCalledTimes(1);
   });
 

--- a/apps/desktop/src/main/body.tsx
+++ b/apps/desktop/src/main/body.tsx
@@ -10,6 +10,7 @@ import {
 } from "lucide-react";
 import {
   type CSSProperties,
+  memo,
   type MouseEvent,
   type PointerEvent,
   type WheelEvent as ReactWheelEvent,
@@ -165,7 +166,6 @@ export function ClassicMainBody() {
     showSidebarTimelineChrome || hasLeftSurfaceCustomSidebar;
   const mainAreaTopDrag = useMainAreaTopWindowDrag(enableMainAreaTopDrag);
   const update = useDesktopUpdateControl();
-  const [leftSidebarResizing, setLeftSidebarResizing] = useState(false);
   const currentSessionId =
     currentTab?.type === "sessions" ? currentTab.id : undefined;
   const createNewNote = useNewNote();
@@ -200,7 +200,6 @@ export function ClassicMainBody() {
 
       if (!canResizeLeftSidebarPanel) {
         leftSidebarResizeDraggingRef.current = false;
-        setLeftSidebarResizing(false);
         pendingLeftSidebarDefaultSizeRef.current = null;
         return;
       }
@@ -255,7 +254,6 @@ export function ClassicMainBody() {
   const handleLeftSidebarResizeDragging = useCallback(
     (isDragging: boolean) => {
       leftSidebarResizeDraggingRef.current = isDragging;
-      setLeftSidebarResizing(isDragging);
 
       if (isDragging) {
         leftSidebarDefaultSizeTrackingRef.current = false;
@@ -290,13 +288,11 @@ export function ClassicMainBody() {
   ]);
   const handleLeftSidebarPanelCollapse = useCallback(() => {
     leftSidebarResizeDraggingRef.current = false;
-    setLeftSidebarResizing(false);
     restoreLeftSidebarPanelSize();
     leftsidebar.setExpanded(false);
   }, [leftsidebar.setExpanded, restoreLeftSidebarPanelSize]);
   const handleToggleLeftSidebar = useCallback(() => {
     leftSidebarResizeDraggingRef.current = false;
-    setLeftSidebarResizing(false);
 
     if (!leftsidebar.expanded) {
       restoreLeftSidebarPanelSize();
@@ -333,7 +329,6 @@ export function ClassicMainBody() {
 
     if (!canResizeLeftSidebarPanel) {
       leftSidebarResizeDraggingRef.current = false;
-      setLeftSidebarResizing(false);
       pendingLeftSidebarDefaultSizeRef.current = null;
     } else if (!leftSidebarDefaultSizeTrackingRef.current) {
       return;
@@ -442,14 +437,6 @@ export function ClassicMainBody() {
         flexGrow: 0,
         maxWidth: 0,
         minWidth: 0,
-        transition:
-          leftSidebarResizing && leftsidebar.expanded
-            ? undefined
-            : [
-                "flex-grow 180ms ease-out",
-                "max-width 180ms ease-out",
-                "min-width 180ms ease-out",
-              ].join(", "),
       } satisfies CSSProperties;
     }
 
@@ -459,14 +446,6 @@ export function ClassicMainBody() {
         flexGrow: 0,
         maxWidth: LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
         minWidth: LEFT_SIDEBAR_DEFAULT_WIDTH_PX,
-        transition:
-          leftSidebarResizing && leftsidebar.expanded
-            ? undefined
-            : [
-                "flex-grow 180ms ease-out",
-                "max-width 180ms ease-out",
-                "min-width 180ms ease-out",
-              ].join(", "),
       } satisfies CSSProperties;
     }
 
@@ -474,16 +453,8 @@ export function ClassicMainBody() {
       flexGrow: "var(--left-sidebar-panel-size)",
       maxWidth: LEFT_SIDEBAR_MAX_WIDTH_PX,
       minWidth: LEFT_SIDEBAR_MIN_WIDTH_PX,
-      transition:
-        leftSidebarResizing && leftsidebar.expanded
-          ? undefined
-          : [
-              "flex-grow 180ms ease-out",
-              "max-width 180ms ease-out",
-              "min-width 180ms ease-out",
-            ].join(", "),
     } satisfies CSSProperties;
-  }, [canResizeLeftSidebarPanel, leftSidebarResizing, leftsidebar.expanded]);
+  }, [canResizeLeftSidebarPanel, leftsidebar.expanded]);
   const leftSidebarPanelRenderConstraints = canResizeLeftSidebarPanel
     ? leftSidebarPanelConstraints
     : createFixedLeftSidebarPanelConstraints(
@@ -496,25 +467,27 @@ export function ClassicMainBody() {
     "--left-sidebar-panel-size": `${renderedLeftSidebarPanelSize}`,
     "--left-sidebar-panel-width": `${renderedLeftSidebarPanelSize}%`,
   } as LeftSidebarSizeStyle;
-  const timelineHeader = showSidebarTimeline ? (
+  const timelineHeader = showSidebarTimelineChrome ? (
     <div
       data-tauri-drag-region
       data-sidebar-timeline-header
       className="flex h-9 shrink-0 items-start pt-[9px] pr-1 pl-[76px]"
       onWheelCapture={handleSidebarTimelineHeaderWheel}
     >
-      <SidebarTimelineChromeWithUpcomingMeeting
-        currentSessionId={currentSessionId}
-        sidebarExpanded
-        showDevtoolsPanelButton={showDevtoolsPanelButton}
-        showIgnoredTimelineEvents={showIgnoredTimelineEvents}
-        devtoolsPanelOpen={devtoolsPanelOpen}
-        onNewNote={createNewNote}
-        onSearch={handleOpenNoteDialog}
-        onOpenDevtools={handleOpenDevtoolsPanel}
-        onToggleSidebar={handleToggleLeftSidebar}
-        update={update}
-      />
+      {showSidebarTimeline ? (
+        <SidebarTimelineChromeWithUpcomingMeeting
+          currentSessionId={currentSessionId}
+          sidebarExpanded
+          showDevtoolsPanelButton={showDevtoolsPanelButton}
+          showIgnoredTimelineEvents={showIgnoredTimelineEvents}
+          devtoolsPanelOpen={devtoolsPanelOpen}
+          onNewNote={createNewNote}
+          onSearch={handleOpenNoteDialog}
+          onOpenDevtools={handleOpenDevtoolsPanel}
+          onToggleSidebar={handleToggleLeftSidebar}
+          update={update}
+        />
+      ) : null}
     </div>
   ) : null;
 
@@ -629,6 +602,7 @@ export function ClassicMainBody() {
                 ])}
               >
                 <ClassicMainSidebar
+                  forceMount
                   timelineHeader={timelineHeader}
                   showIgnoredTimelineEvents={showIgnoredTimelineEvents}
                   onShowIgnoredTimelineEventsChange={
@@ -893,51 +867,53 @@ function isMainAreaWindowDrag(
   );
 }
 
-function SidebarTimelineChromeWithUpcomingMeeting({
-  currentSessionId,
-  devtoolsPanelOpen,
-  onNewNote,
-  onOpenDevtools,
-  onSearch,
-  onToggleSidebar,
-  sidebarExpanded,
-  showDevtoolsPanelButton,
-  showIgnoredTimelineEvents,
-  update,
-}: {
-  currentSessionId?: string;
-  devtoolsPanelOpen: boolean;
-  onNewNote: () => void;
-  onOpenDevtools: () => void;
-  onSearch: () => void;
-  onToggleSidebar: () => void;
-  sidebarExpanded: boolean;
-  showDevtoolsPanelButton: boolean;
-  showIgnoredTimelineEvents: boolean;
-  update: DesktopUpdateControl;
-}) {
-  const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus({
-    showIgnored: showIgnoredTimelineEvents,
-  });
-  const hasUpcomingMeeting = upcomingMeetingStatus
-    ? !currentSessionId ||
-      upcomingMeetingStatus.itemKey !== `session-${currentSessionId}`
-    : false;
+const SidebarTimelineChromeWithUpcomingMeeting = memo(
+  function SidebarTimelineChromeWithUpcomingMeeting({
+    currentSessionId,
+    devtoolsPanelOpen,
+    onNewNote,
+    onOpenDevtools,
+    onSearch,
+    onToggleSidebar,
+    sidebarExpanded,
+    showDevtoolsPanelButton,
+    showIgnoredTimelineEvents,
+    update,
+  }: {
+    currentSessionId?: string;
+    devtoolsPanelOpen: boolean;
+    onNewNote: () => void;
+    onOpenDevtools: () => void;
+    onSearch: () => void;
+    onToggleSidebar: () => void;
+    sidebarExpanded: boolean;
+    showDevtoolsPanelButton: boolean;
+    showIgnoredTimelineEvents: boolean;
+    update: DesktopUpdateControl;
+  }) {
+    const upcomingMeetingStatus = useSidebarUpcomingMeetingStatus({
+      showIgnored: showIgnoredTimelineEvents,
+    });
+    const hasUpcomingMeeting = upcomingMeetingStatus
+      ? !currentSessionId ||
+        upcomingMeetingStatus.itemKey !== `session-${currentSessionId}`
+      : false;
 
-  return (
-    <SidebarTimelineChrome
-      devtoolsPanelOpen={devtoolsPanelOpen}
-      hasUpcomingMeeting={hasUpcomingMeeting}
-      onNewNote={onNewNote}
-      onOpenDevtools={onOpenDevtools}
-      onSearch={onSearch}
-      onToggleSidebar={onToggleSidebar}
-      sidebarExpanded={sidebarExpanded}
-      showDevtoolsPanelButton={showDevtoolsPanelButton}
-      update={update}
-    />
-  );
-}
+    return (
+      <SidebarTimelineChrome
+        devtoolsPanelOpen={devtoolsPanelOpen}
+        hasUpcomingMeeting={hasUpcomingMeeting}
+        onNewNote={onNewNote}
+        onOpenDevtools={onOpenDevtools}
+        onSearch={onSearch}
+        onToggleSidebar={onToggleSidebar}
+        sidebarExpanded={sidebarExpanded}
+        showDevtoolsPanelButton={showDevtoolsPanelButton}
+        update={update}
+      />
+    );
+  },
+);
 
 function SidebarTimelineChrome({
   devtoolsPanelOpen,

--- a/apps/desktop/src/sidebar/timeline/index.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.test.tsx
@@ -516,6 +516,34 @@ describe("TimelineView", () => {
     ]);
   });
 
+  it("does not select sidebar notes while the mounted timeline is hidden", () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-01-15T09:00:00.000Z"));
+    mocks.currentTimeMs = Date.now();
+    mocks.currentTab = { type: "sessions", id: "selected-note" };
+    mocks.timelineSelectionAnchorId = "session-selected-note";
+    mocks.timelineSessionsTable = {
+      "selected-note": {
+        title: "Selected note",
+        created_at: "2024-01-15T12:00:00.000Z",
+      },
+      "other-note": {
+        title: "Other note",
+        created_at: "2024-01-15T11:00:00.000Z",
+      },
+    };
+
+    render(
+      <div aria-hidden inert>
+        <TimelineView />
+      </div>,
+    );
+
+    fireEvent.keyDown(window, { key: "a", metaKey: true });
+
+    expect(mocks.selectAll).not.toHaveBeenCalled();
+  });
+
   it("does not select sidebar notes when Cmd+A starts in the editor", () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date("2024-01-15T09:00:00.000Z"));

--- a/apps/desktop/src/sidebar/timeline/index.tsx
+++ b/apps/desktop/src/sidebar/timeline/index.tsx
@@ -280,7 +280,11 @@ export const TimelineView = memo(function TimelineView({
 
   useMountEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
+      const container = containerRef.current;
+
       if (
+        !container ||
+        container.closest("[inert], [aria-hidden='true']") ||
         event.defaultPrevented ||
         !isSelectAllShortcut(event) ||
         isTextEditingShortcutTarget(event.target) ||

--- a/apps/desktop/src/sidebar/timeline/item.test.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.test.tsx
@@ -233,6 +233,8 @@ describe("TimelineItemComponent", () => {
     expect(row?.getAttribute("data-sidebar-timeline-session-id")).toBe(
       "session-live",
     );
+    expect(row?.className).toContain("[content-visibility:auto]");
+    expect(row?.className).toContain("[contain-intrinsic-size:auto_56px]");
     expect(selectedNodeRef.mock.calls.some(([node]) => node === row)).toBe(
       true,
     );

--- a/apps/desktop/src/sidebar/timeline/item.tsx
+++ b/apps/desktop/src/sidebar/timeline/item.tsx
@@ -175,7 +175,7 @@ const ItemBase = memo(function ItemBase({
     <div
       ref={setItemRef}
       data-sidebar-timeline-session-id={timelineSessionId}
-      className="group/sidebar-live-item relative"
+      className="group/sidebar-live-item relative [contain-intrinsic-size:auto_56px] [content-visibility:auto]"
     >
       <InteractiveButton
         onClick={ignored ? undefined : onClick}


### PR DESCRIPTION
Preserve the timeline instance across sidebar toggles to avoid remounting every item and reconnecting its hooks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes collapse semantics (inert/aria-hidden), global keyboard handling, and sidebar layout transitions; core note editing is unchanged but sidebar interaction edge cases deserve a quick manual pass.
> 
> **Overview**
> **Keeps the left sidebar timeline mounted** when the panel is collapsed instead of unmounting it, so toggling the sidebar no longer tears down timeline items and their hooks on every open/close.
> 
> Collapsed sidebar content is **hidden in place** with `aria-hidden`, `inert`, and opacity/transform transitions on the panel wrapper; `ClassicMainSidebar` is rendered with **`forceMount`**. The resizable panel no longer animates `flex-grow`/`min-width`/`max-width` (the `leftSidebarResizing`-driven transitions were removed). The timeline header container can remain in the tree while collapsed; full timeline chrome still renders only when expanded.
> 
> **Timeline behavior while hidden:** Cmd/Ctrl+A select-all ignores shortcuts when the timeline sits under `inert` or `aria-hidden`. Timeline rows get **`content-visibility`** / intrinsic size hints to reduce work when the sidebar is off-screen. `SidebarTimelineChromeWithUpcomingMeeting` is wrapped in **`memo`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d98d1e7c000b13a534a3e23acc0fdc1ff440a332. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->