### PR TITLE
Hide border for standalone Memos tab

### DIFF
--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -461,7 +461,8 @@ describe("Header", () => {
     expect(memoTab.textContent).toBe("Memos");
     expect(memoTab.className).toContain("h-7");
     expect(memoTab.className).toContain("bg-white");
-    expect(memoTab.className).toContain("border");
+    expect(memoTab.className).toContain("border-0");
+    expect(memoTab.className).not.toContain("border-border");
     expect(memoTab.className).toContain("shadow-none");
     expect(memoTab.className).not.toContain("shadow-xs");
     expect(memoTab.className).not.toContain("bg-foreground/10");

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -293,7 +293,7 @@ function HeaderViewRawButton({
       onClick={onClick}
       onContextMenu={onContextMenu}
       size={standalone ? "standalone" : "tray"}
-      className={standalone ? "border-border/70 border shadow-none" : undefined}
+      className={standalone ? "border-0 shadow-none" : undefined}
     />
   );
 }


### PR DESCRIPTION
Remove the tab outline when Memos is the only available note view.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Cosmetic Tailwind class change on the session note header with a matching unit test update only.
> 
> **Overview**
> When a session only exposes the **Memos** note view (no summary/transcript tabs), the Memos control no longer draws a visible tab outline.
> 
> `HeaderViewRawButton` now applies **`border-0`** instead of **`border-border/70 border`** in standalone mode, while keeping **`shadow-none`**. The raw-only header test was updated to expect **`border-0`** and to reject **`border-border`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12128767e2fe7db5024fdb61fb463d44b2fa5639. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->