### PR TITLE
Enlarge summary setup actions

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/config-error.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/config-error.tsx
@@ -1,5 +1,4 @@
 import { Trans } from "@lingui/react/macro";
-import { CircleAlertIcon } from "lucide-react";
 
 import { Button } from "@hypr/ui/components/ui/button";
 
@@ -13,10 +12,6 @@ export function ConfigError() {
       role="alert"
       className="flex h-full min-h-[400px] flex-col items-center justify-center px-6"
     >
-      <CircleAlertIcon
-        aria-hidden
-        className="text-muted-foreground mb-5 size-9 stroke-[1.5]"
-      />
       <div className="mb-6 flex max-w-md flex-col gap-2 text-center">
         <p className="text-base font-medium">
           <Trans>Set up AI summaries</Trans>
@@ -30,7 +25,7 @@ export function ConfigError() {
       </div>
       <div className="flex items-center gap-2">
         <Button
-          size="sm"
+          className="shadow-none"
           onClick={() =>
             openNew({ type: "settings", state: { tab: "account" } })
           }
@@ -39,7 +34,7 @@ export function ConfigError() {
         </Button>
         <Button
           variant="outline"
-          size="sm"
+          className="shadow-none"
           onClick={() =>
             openNew({ type: "settings", state: { tab: "intelligence" } })
           }


### PR DESCRIPTION
Remove the alert icon and use standard-size setup buttons.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only changes to a single empty-state component; no logic, routing, or data handling changes.
> 
> **Overview**
> Polishes the **empty summary / LLM not configured** state in `ConfigError` so setup actions read more prominently.
> 
> The alert icon is removed for a cleaner layout. **Get Pro** and **Add API key** drop `size="sm"` so they use the default button size, with `shadow-none` on both for a flatter look. Copy and navigation (`openNew` to account vs intelligence settings) are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd6cc126561d10760db374be135e4f7d8c2965e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->