### PR TITLE
Show placeholder for empty document titles

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -139,6 +139,7 @@ describe("EnhancedEditor", () => {
 
     expect(props?.className).toContain("session-note-editor");
     expect(props?.className).toContain("enhanced-summary-editor");
+    expect(props?.placeholderComponent).toEqual(expect.any(Function));
     expect(props?.syncContentWhenFocused).toBe(false);
     expect(props?.handleChange).not.toBe(hoisted.persistContent);
     expect(props?.taskSource).toEqual({ type: "enhanced_note", id: "note-1" });

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -22,6 +22,7 @@ import { useUpdateEnhancedNoteContent } from "~/session/queries";
 import {
   ensureFirstLineTitle,
   extractFirstLineTitle,
+  documentTitlePlaceholder,
 } from "~/session/title-content";
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
@@ -102,6 +103,7 @@ const EnhancedEditorInner = forwardRef<
           key={editorKey}
           initialContent={initialContent}
           handleChange={persistChanges ? handleChange : undefined}
+          placeholderComponent={documentTitlePlaceholder}
           mentionConfig={mentionConfig}
           sessionMentionDropConfig={sessionMentionDropConfig}
           onNavigateToTitle={onNavigateToTitle}

--- a/apps/desktop/src/session/components/note-input/raw.test.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.test.tsx
@@ -138,6 +138,7 @@ describe("RawEditor", () => {
 
     expect(props?.className).toContain("session-note-editor");
     expect(props?.className).toContain("custom-editor-class");
+    expect(props?.placeholderComponent).toEqual(expect.any(Function));
     expect(props?.initialContent).toMatchObject({
       type: "doc",
       content: [

--- a/apps/desktop/src/session/components/note-input/raw.tsx
+++ b/apps/desktop/src/session/components/note-input/raw.tsx
@@ -23,6 +23,7 @@ import { useUpdateSession } from "~/session/queries";
 import {
   ensureFirstLineTitle,
   extractFirstLineTitle,
+  documentTitlePlaceholder,
 } from "~/session/title-content";
 
 const extraNodeViews = { appLink: AppLinkView, session: SessionNodeView };
@@ -120,6 +121,7 @@ export const RawEditor = forwardRef<
           key={`session-${sessionId}-raw`}
           initialContent={initialContent}
           handleChange={handleChange}
+          placeholderComponent={documentTitlePlaceholder}
           mentionConfig={mentionConfig}
           sessionMentionDropConfig={sessionMentionDropConfig}
           onNavigateToTitle={onNavigateToTitle}

--- a/apps/desktop/src/session/title-content.test.ts
+++ b/apps/desktop/src/session/title-content.test.ts
@@ -1,10 +1,32 @@
 import { describe, expect, it } from "vitest";
 
+import { schema } from "@hypr/editor/note";
+
 import {
+  documentTitlePlaceholder,
   ensureFirstLineTitle,
   ensureMarkdownFirstLineTitle,
   extractFirstLineTitle,
 } from "./title-content";
+
+describe("documentTitlePlaceholder", () => {
+  it("shows Untitled only for the document title block", () => {
+    expect(
+      documentTitlePlaceholder({
+        node: schema.node("heading", { level: 1 }),
+        pos: 0,
+        hasAnchor: true,
+      }),
+    ).toBe("Untitled");
+    expect(
+      documentTitlePlaceholder({
+        node: schema.node("paragraph"),
+        pos: 2,
+        hasAnchor: true,
+      }),
+    ).toBe("");
+  });
+});
 
 describe("extractFirstLineTitle", () => {
   it("returns the first block text", () => {

--- a/apps/desktop/src/session/title-content.ts
+++ b/apps/desktop/src/session/title-content.ts
@@ -1,4 +1,9 @@
-import type { JSONContent } from "@hypr/editor/note";
+import type { JSONContent, PlaceholderFunction } from "@hypr/editor/note";
+
+export const documentTitlePlaceholder: PlaceholderFunction = ({ node, pos }) =>
+  pos === 0 && node.type.name === "heading" && node.attrs.level === 1
+    ? "Untitled"
+    : "";
 
 export function extractFirstLineTitle(content: JSONContent) {
   const firstBlock = content.content?.[0];


### PR DESCRIPTION
Render Untitled in empty title headings without persisting placeholder text.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only placeholder wiring with unit tests; no changes to save or title-extraction behavior.
> 
> **Overview**
> Session **raw** and **enhanced** note editors now pass a shared `documentTitlePlaceholder` into `NoteEditor` so an empty first-line **H1** shows **Untitled** in the UI only.
> 
> The placeholder is scoped to `pos === 0` and level-1 headings; other blocks get no placeholder. Persistence is unchanged—`extractFirstLineTitle` still treats a blank title as empty or `null` for an empty doc, so **Untitled** is not written to stored content.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9a6bcf8ed6f21e0436a74921c1753f3295fc84f6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->