### PR TITLE
Keep unconfigured summaries visually neutral

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced-actions.test.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.test.ts
@@ -1,0 +1,65 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  model: null as unknown,
+  start: vi.fn(),
+  toastError: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: { event: vi.fn() },
+}));
+
+vi.mock("@hypr/ui/components/ui/toast", () => ({
+  sonnerToast: { error: mocks.toastError },
+}));
+
+vi.mock("~/ai/hooks", () => ({
+  useAITaskTask: () => ({
+    isGenerating: false,
+    isError: false,
+    error: null,
+    start: mocks.start,
+    cancel: vi.fn(),
+  }),
+  useLanguageModel: () => mocks.model,
+}));
+
+vi.mock("~/ai/task-window-sync", () => ({
+  isMainAITaskHostWindow: () => true,
+  requestMainAITaskCancel: vi.fn(),
+  requestMainEnhance: vi.fn(),
+}));
+
+vi.mock("~/session/queries", () => ({
+  useEnhancedNote: () => ({ templateId: "template-1" }),
+}));
+
+import { useEnhancedNoteActions } from "./enhanced-actions";
+
+describe("useEnhancedNoteActions", () => {
+  beforeEach(() => {
+    mocks.model = null;
+    mocks.start.mockReset();
+    mocks.toastError.mockReset();
+  });
+
+  it("shows a toast without entering an error state when Intelligence is not configured", async () => {
+    const { result } = renderHook(() =>
+      useEnhancedNoteActions({
+        enhancedNoteId: "summary-1",
+        sessionId: "session-1",
+      }),
+    );
+
+    await act(() => result.current.onRegenerate(null));
+
+    expect(mocks.toastError).toHaveBeenCalledWith(
+      "Set up Intelligence in Settings before regenerating this summary.",
+    );
+    expect(mocks.start).not.toHaveBeenCalled();
+    expect(result.current.isError).toBe(false);
+    expect(result.current.error).toBeNull();
+  });
+});

--- a/apps/desktop/src/session/components/note-input/enhanced-actions.ts
+++ b/apps/desktop/src/session/components/note-input/enhanced-actions.ts
@@ -1,15 +1,15 @@
-import { useCallback, useState } from "react";
+import { useCallback } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
+import { sonnerToast } from "@hypr/ui/components/ui/toast";
 
 import { useAITaskTask } from "~/ai/hooks";
-import { useLanguageModel, useLLMConnectionStatus } from "~/ai/hooks";
+import { useLanguageModel } from "~/ai/hooks";
 import {
   isMainAITaskHostWindow,
   requestMainAITaskCancel,
   requestMainEnhance,
 } from "~/ai/task-window-sync";
-import { shouldShowEmptySummaryConfigError } from "~/session/enhance-config";
 import { useEnhancedNote } from "~/session/queries";
 import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 
@@ -21,13 +21,9 @@ export function useEnhancedNoteActions({
   sessionId: string;
 }) {
   const model = useLanguageModel("enhance");
-  const llmStatus = useLLMConnectionStatus();
   const taskId = enhancedNoteId
     ? createTaskId(enhancedNoteId, "enhance")
     : null;
-  const [missingModelError, setMissingModelError] = useState<Error | null>(
-    null,
-  );
 
   const noteTemplateId =
     useEnhancedNote(enhancedNoteId ?? "")?.templateId || undefined;
@@ -41,13 +37,11 @@ export function useEnhancedNoteActions({
       }
 
       if (!model) {
-        setMissingModelError(
-          new Error("Intelligence provider not configured."),
+        sonnerToast.error(
+          "Set up Intelligence in Settings before regenerating this summary.",
         );
         return;
       }
-
-      setMissingModelError(null);
 
       if (!isMainAITaskHostWindow()) {
         void requestMainEnhance(sessionId, {
@@ -74,10 +68,6 @@ export function useEnhancedNoteActions({
     [enhancedNoteId, model, enhanceTask.start, sessionId, noteTemplateId],
   );
 
-  const isConfigError = shouldShowEmptySummaryConfigError(llmStatus);
-  const isIdleWithConfigError = enhanceTask.isIdle && isConfigError;
-  const error = model ? enhanceTask.error : missingModelError;
-  const isError = !!error || enhanceTask.isError || isIdleWithConfigError;
   const onCancel = useCallback(() => {
     if (!taskId) {
       return;
@@ -93,8 +83,8 @@ export function useEnhancedNoteActions({
 
   return {
     isGenerating: enhanceTask.isGenerating,
-    isError,
-    error,
+    isError: enhanceTask.isError,
+    error: enhanceTask.error,
     onRegenerate,
     onCancel,
   };


### PR DESCRIPTION
Show a transient setup toast when regeneration lacks an Intelligence model, and reserve the Summary tab error state for failed generation tasks.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized UX change in note regenerate handling with a focused test; no auth, data, or generation pipeline changes beyond error surfacing.
> 
> **Overview**
> **Summary regeneration** no longer surfaces missing Intelligence setup as a persistent tab error from `useEnhancedNoteActions`.
> 
> When **regenerate** runs without an enhance model, the hook now shows a **sonner error toast** (“Set up Intelligence in Settings…”) and returns early instead of setting local missing-model error state or folding in LLM connection / empty-summary config checks. **`isError` and `error`** from the hook now reflect only the enhance AI task, so unconfigured Intelligence stays visually neutral in the Summary UI until a generation actually fails.
> 
> Adds a **unit test** asserting toast + no `start` + `isError` stays false when the model is null.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82d383fefa6a97b6eff7556805de7ddcf511f1f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->