### PR TITLE
Redesign auth pages to match the homepage

### DIFF
--- a/apps/web/src/components/auth-shell.tsx
+++ b/apps/web/src/components/auth-shell.tsx
@@ -1,0 +1,99 @@
+import { cn } from "@hypr/utils";
+
+export const authInputClassName = cn([
+  "h-12 w-full rounded-xl border border-[#d9d1c5] bg-white px-4",
+  "text-[#181613] placeholder:text-[#9a9082]",
+  "transition-colors hover:border-[#b9ae9f]",
+  "focus:border-[#181613] focus:ring-2 focus:ring-[#181613]/10 focus:outline-hidden",
+]);
+
+export const authPrimaryButtonClassName = cn([
+  "flex h-12 w-full cursor-pointer items-center justify-center gap-3 rounded-full px-5",
+  "bg-[#181613] text-sm font-medium text-white",
+  "transition-colors hover:bg-[#4f4940]",
+  "focus-visible:ring-2 focus-visible:ring-[#181613] focus-visible:ring-offset-2 focus-visible:outline-hidden",
+  "disabled:cursor-not-allowed disabled:opacity-50",
+]);
+
+export const authSecondaryButtonClassName = cn([
+  "flex h-12 w-full cursor-pointer items-center justify-center gap-3 rounded-full border border-[#d9d1c5] bg-white px-5",
+  "text-sm font-medium text-[#181613]",
+  "transition-colors hover:bg-[#f7f4ef]",
+  "focus-visible:ring-2 focus-visible:ring-[#181613] focus-visible:ring-offset-2 focus-visible:outline-hidden",
+  "disabled:cursor-not-allowed disabled:opacity-50",
+]);
+
+export const authNoticeClassName =
+  "rounded-xl border border-[#e5ddcf] bg-[#f7f4ef] p-4 text-center";
+
+const authPromises = [
+  "Bot-free meeting capture",
+  "Fully offline notes",
+  "On-device or bring-your-own-key AI",
+];
+
+export function AuthShell({
+  title,
+  description,
+  children,
+}: {
+  title: string;
+  description: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <main className="min-h-screen bg-white text-[#181613]">
+      <div className="mx-auto flex min-h-screen w-full max-w-[1180px] flex-col px-5 sm:px-8">
+        <div className="grid flex-1 items-center gap-12 py-10 md:grid-cols-[minmax(0,1fr)_minmax(360px,440px)] lg:gap-20 lg:py-16">
+          <section className="hidden md:block">
+            <p className="font-hand text-2xl leading-none font-semibold text-[#756b5d]">
+              Stay present. Keep the notes.
+            </p>
+            <h2 className="font-hand mt-5 max-w-[620px] text-6xl leading-[0.95] font-semibold tracking-normal text-balance lg:text-7xl">
+              AI notepad for{" "}
+              <mark className="bg-[#fff0b3] px-1 text-[#181613]">
+                private meetings.
+              </mark>
+            </h2>
+            <p className="mt-7 max-w-xl text-lg leading-8 text-[#4f4940]">
+              Jot notes during the call. Anarlog turns them into an editable
+              summary while your work stays in your hands.
+            </p>
+
+            <ul className="mt-9 grid gap-3 text-sm text-[#4f4940]">
+              {authPromises.map((promise) => (
+                <li key={promise} className="flex items-center gap-3">
+                  <span className="size-1.5 rounded-full bg-[#d1a321]" />
+                  {promise}
+                </li>
+              ))}
+            </ul>
+          </section>
+
+          <section className="mx-auto w-full max-w-[440px] overflow-hidden rounded-[24px] border border-[#e5ddcf] bg-white shadow-[0_24px_80px_rgba(24,22,19,0.10)]">
+            <header className="border-b border-[#ede7dc] px-6 py-7 sm:px-8 sm:py-8">
+              <p className="font-hand text-xl leading-none font-semibold text-[#756b5d]">
+                Private by default
+              </p>
+              <h1 className="font-hand mt-3 text-4xl leading-none font-semibold text-[#181613]">
+                {title}
+              </h1>
+              <p className="mt-3 text-sm leading-6 text-[#756b5d]">
+                {description}
+              </p>
+            </header>
+
+            <div className="p-6 sm:p-8">{children}</div>
+          </section>
+        </div>
+
+        <footer className="flex min-h-16 items-center justify-between gap-4 border-t border-[#ede7dc] py-5 text-xs text-[#8b8174]">
+          <span>Open source. Local-first. Yours.</span>
+          <span className="hidden sm:inline">
+            Your notes should survive us.
+          </span>
+        </footer>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/src/routes/_view/callback/auth.tsx
+++ b/apps/web/src/routes/_view/callback/auth.tsx
@@ -1,14 +1,17 @@
 import { createFileRoute, redirect, useNavigate } from "@tanstack/react-router";
 import { jwtDecode } from "jwt-decode";
 import { CheckIcon, CopyIcon } from "lucide-react";
-import { motion } from "motion/react";
-import { useEffect, useRef, useState } from "react";
+import { useEffect, useState } from "react";
 import { z } from "zod";
 
 import { deriveBillingInfo, type SupabaseJwtPayload } from "@hypr/supabase";
-import { cn } from "@hypr/utils";
 
-import { AnarlogLogo } from "@/components/anarlog-logo";
+import {
+  AuthShell,
+  authNoticeClassName,
+  authPrimaryButtonClassName,
+  authSecondaryButtonClassName,
+} from "@/components/auth-shell";
 import { exchangeOAuthCode, exchangeOtpToken } from "@/functions/auth";
 import { desktopSchemeSchema } from "@/functions/desktop-flow";
 import { useAnalytics } from "@/hooks/use-posthog";
@@ -132,57 +135,6 @@ export const Route = createFileRoute("/_view/callback/auth")({
   },
 });
 
-function Container({ children }: { children: React.ReactNode }) {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState<number | "auto">("auto");
-
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(([entry]) => {
-      setHeight(entry.contentRect.height);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <div
-      className={cn([
-        "flex min-h-screen items-center justify-center",
-        "bg-page",
-        "bg-dotted-dark",
-      ])}
-    >
-      <div className="border-color-brand surface mx-auto w-md min-w-[320px] overflow-hidden rounded-xl border shadow-md">
-        <motion.div
-          animate={{ height }}
-          transition={{ duration: 0.3, ease: "easeInOut" }}
-        >
-          <div ref={contentRef}>{children}</div>
-        </motion.div>
-      </div>
-    </div>
-  );
-}
-
-function Header({ title }: { title: string }) {
-  return (
-    <div className="mb-8 text-center">
-      <div
-        className={cn([
-          "mx-auto mb-8 p-8",
-          "flex items-center justify-between",
-          "border-color-brand border-b",
-        ])}
-      >
-        <AnarlogLogo compact className="text-fg h-10 w-auto" />
-        <h1 className="text-fg py-4 font-mono text-xl">{title}</h1>
-      </div>
-    </div>
-  );
-}
-
 function Component() {
   const search = Route.useSearch();
   const navigate = useNavigate();
@@ -253,10 +205,12 @@ function Component() {
 
   if (search.error) {
     return (
-      <Container>
-        <Header title="Sign-in failed" />
-        <div className="flex flex-col gap-4 px-8 pb-8">
-          <p className="text-fg-muted text-center">
+      <AuthShell
+        title="Sign-in didn’t work"
+        description="Your notes are safe. Try the sign-in flow again."
+      >
+        <div className="flex flex-col gap-4">
+          <p className="text-center text-sm leading-6 text-[#756b5d]">
             {search.error_description
               ? search.error_description.replaceAll("+", " ")
               : "Something went wrong during sign-in"}
@@ -264,18 +218,12 @@ function Component() {
 
           <a
             href={`/auth?flow=${search.flow}&scheme=${search.scheme}`}
-            className={cn([
-              "w-full cursor-pointer px-4 py-2",
-              "bg-fg hover:bg-fg/80 rounded-full font-sans text-white",
-              "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-              "transition-colors",
-              "flex items-center justify-center",
-            ])}
+            className={authPrimaryButtonClassName}
           >
             Try again
           </a>
         </div>
-      </Container>
+      </AuthShell>
     );
   }
 
@@ -283,47 +231,31 @@ function Component() {
     const hasTokens = search.access_token && search.refresh_token;
 
     return (
-      <Container>
-        <Header title={hasTokens ? "Sign-in successful" : "Signing in..."} />
-        <div className="flex flex-col gap-4 px-8 pb-8">
-          <p className="text-fg-muted text-center">
-            {hasTokens
-              ? "Click the button below to return to the app"
-              : "Please wait while we complete the sign-in"}
-          </p>
-
+      <AuthShell
+        title={hasTokens ? "You’re signed in" : "Finishing sign-in"}
+        description={
+          hasTokens
+            ? "Return to the desktop app to keep going."
+            : "Please wait while we complete the secure handoff."
+        }
+      >
+        <div className="flex flex-col gap-4">
           {hasTokens && (
             <div className="flex flex-col gap-3">
               <button
                 onClick={handleDeeplink}
-                className={cn([
-                  "w-full cursor-pointer px-4 py-2",
-                  "bg-fg hover:bg-fg/80 rounded-full font-sans text-white",
-                  "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-                  "transition-colors",
-                  "flex items-center justify-center",
-                ])}
+                className={authPrimaryButtonClassName}
               >
                 Open Anarlog
               </button>
 
-              <button
-                onClick={handleCopy}
-                className={cn([
-                  "flex w-full cursor-pointer flex-col items-center gap-3 p-4 text-left",
-                  "border-color-brand rounded-lg border",
-                  "hover:bg-brand-dark/10 transition-colors",
-                ])}
-              >
-                <p className="text-fg-muted text-sm">
+              <div className="rounded-xl border border-[#e5ddcf] bg-[#fbfaf7] p-4 text-center">
+                <p className="mb-3 text-sm leading-6 text-[#756b5d]">
                   Button not working? Copy the link instead
                 </p>
-                <span
-                  className={cn([
-                    "flex w-full items-center justify-center gap-2 px-4 py-2 font-sans text-sm",
-                    "border-color-brand text-fg rounded-full border",
-                    "hover:bg-brand-dark/10 transition-colors",
-                  ])}
+                <button
+                  onClick={handleCopy}
+                  className={authSecondaryButtonClassName}
                 >
                   {copied ? (
                     <>
@@ -336,23 +268,35 @@ function Component() {
                       Copy URL
                     </>
                   )}
-                </span>
-              </button>
+                </button>
+              </div>
+            </div>
+          )}
+
+          {!hasTokens && (
+            <div className={authNoticeClassName}>
+              <p className="text-sm font-medium text-[#4f4940]">
+                Connecting your account...
+              </p>
             </div>
           )}
         </div>
-      </Container>
+      </AuthShell>
     );
   }
 
   if (search.flow === "web") {
     return (
-      <Container>
-        <Header title="Redirecting..." />
-        <div className="px-8 pb-8 text-center">
-          <p className="text-fg-muted">Taking you to your account...</p>
+      <AuthShell
+        title="Taking you back"
+        description="Your sign-in is complete."
+      >
+        <div className={authNoticeClassName}>
+          <p className="text-sm font-medium text-[#4f4940]">
+            Opening your account...
+          </p>
         </div>
-      </Container>
+      </AuthShell>
     );
   }
 }

--- a/apps/web/src/routes/auth.tsx
+++ b/apps/web/src/routes/auth.tsx
@@ -2,13 +2,18 @@ import { Icon } from "@iconify-icon/react";
 import { useMutation } from "@tanstack/react-query";
 import { createFileRoute, Link, redirect } from "@tanstack/react-router";
 import { ArrowLeftIcon, MailIcon } from "lucide-react";
-import { motion } from "motion/react";
 import { useEffect, useRef, useState } from "react";
 import { z } from "zod";
 
 import { cn } from "@hypr/utils";
 
-import { AnarlogLogo } from "@/components/anarlog-logo";
+import {
+  AuthShell,
+  authInputClassName,
+  authNoticeClassName,
+  authPrimaryButtonClassName,
+  authSecondaryButtonClassName,
+} from "@/components/auth-shell";
 import {
   createDesktopSession,
   doAuth,
@@ -74,24 +79,25 @@ function Component() {
 
   if (existingUser && flow === "desktop") {
     return (
-      <Container>
-        <Header />
+      <AuthShell
+        title="Welcome back"
+        description="Finishing your secure handoff to the desktop app."
+      >
         <DesktopReauthView
           email={existingUser.email}
           scheme={scheme ?? "hyprnote"}
         />
-      </Container>
+      </AuthShell>
     );
   }
 
   if (existingUser && flow === "web" && provider) {
     return (
-      <Container>
-        <Header />
-        <div className="flex flex-col gap-4 p-8">
-          <p className="text-fg-muted text-center text-sm">
-            Refreshing your {provider} access for admin actions.
-          </p>
+      <AuthShell
+        title={`Reconnect ${provider.charAt(0).toUpperCase() + provider.slice(1)}`}
+        description={`Refresh your ${provider} access to continue with admin actions.`}
+      >
+        <div className="flex flex-col gap-4">
           <OAuthButton
             flow={flow}
             scheme={scheme}
@@ -101,7 +107,7 @@ function Component() {
             autoStart
           />
         </div>
-      </Container>
+      </AuthShell>
     );
   }
 
@@ -110,11 +116,13 @@ function Component() {
   const showEmail = !provider;
 
   return (
-    <Container>
-      <Header />
+    <AuthShell
+      title="Welcome to Anarlog"
+      description="Choose how you’d like to continue."
+    >
       {view === "main" && (
         <>
-          <div className="flex flex-col gap-2 px-8">
+          <div className="flex flex-col gap-3">
             {showGoogle && (
               <OAuthButton
                 flow={flow}
@@ -135,15 +143,7 @@ function Component() {
             {showEmail && (
               <button
                 onClick={() => setView("email")}
-                className={cn([
-                  "w-full cursor-pointer px-4 py-2",
-                  "border-color-brand border",
-                  "text-fg rounded-full font-sans",
-                  "hover:bg-brand-dark/10",
-                  "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-                  "transition-colors",
-                  "flex items-center justify-center gap-3",
-                ])}
+                className={authSecondaryButtonClassName}
               >
                 <MailIcon className="size-4" />
                 Sign in with Email
@@ -161,58 +161,7 @@ function Component() {
           onBack={() => setView("main")}
         />
       )}
-    </Container>
-  );
-}
-
-function Container({ children }: { children: React.ReactNode }) {
-  const contentRef = useRef<HTMLDivElement>(null);
-  const [height, setHeight] = useState<number | "auto">("auto");
-
-  useEffect(() => {
-    const el = contentRef.current;
-    if (!el) return;
-    const observer = new ResizeObserver(([entry]) => {
-      setHeight(entry.contentRect.height);
-    });
-    observer.observe(el);
-    return () => observer.disconnect();
-  }, []);
-
-  return (
-    <div
-      className={cn([
-        "flex min-h-screen items-center justify-center",
-        "bg-page",
-        "bg-dotted-dark",
-      ])}
-    >
-      <div className="border-color-brand surface mx-auto w-md min-w-[320px] overflow-hidden rounded-xl border shadow-md">
-        <motion.div
-          animate={{ height }}
-          transition={{ duration: 0.3, ease: "easeInOut" }}
-        >
-          <div ref={contentRef}>{children}</div>
-        </motion.div>
-      </div>
-    </div>
-  );
-}
-
-function Header() {
-  return (
-    <div className="mb-8 text-center">
-      <div
-        className={cn([
-          "mx-auto mb-8 p-8",
-          "flex items-center justify-between",
-          "border-color-brand border-b",
-        ])}
-      >
-        <AnarlogLogo compact className="text-fg h-10 w-auto" />
-        <h1 className="text-fg py-4 font-mono text-xl">Welcome to Anarlog</h1>
-      </div>
-    </div>
+    </AuthShell>
   );
 }
 
@@ -245,21 +194,25 @@ function DesktopReauthView({
     retryMutation.isError || (retryMutation.isSuccess && !retryMutation.data);
 
   return (
-    <div className="flex flex-col gap-4 p-8">
+    <div className="flex flex-col gap-4">
       {!hasRetryFailed && (
-        <div className="text-center">
-          <p className="text-neutral-600">Signing in as {email}...</p>
+        <div className={authNoticeClassName}>
+          <p className="text-sm font-medium text-[#4f4940]">
+            Signing in as {email}...
+          </p>
         </div>
       )}
       {hasRetryFailed && (
         <>
           <div className="text-center">
-            <p className="mb-1 text-neutral-600">Signed in as {email}</p>
-            <p className="text-sm text-neutral-400">
+            <p className="mb-1 text-sm font-medium text-[#4f4940]">
+              Signed in as {email}
+            </p>
+            <p className="text-sm text-[#8b8174]">
               Sign in with your provider to continue to the app
             </p>
           </div>
-          <div className="flex flex-col gap-2">
+          <div className="flex flex-col gap-3">
             <OAuthButton flow="desktop" scheme={scheme} provider="google" />
             <OAuthButton flow="desktop" scheme={scheme} provider="github" />
           </div>
@@ -271,18 +224,18 @@ function DesktopReauthView({
 
 function LegalText() {
   return (
-    <p className="mt-4 px-8 pb-8 text-center text-xs text-neutral-500">
+    <p className="mt-6 text-center text-xs leading-5 text-[#8b8174]">
       By signing up, you agree to our{" "}
       <a
         href="https://anarlog.so/terms"
-        className="underline hover:text-neutral-700"
+        className="underline decoration-[#b9ae9f] underline-offset-2 hover:text-[#181613]"
       >
         Terms of Service
       </a>{" "}
       and{" "}
       <a
         href="https://anarlog.so/privacy"
-        className="underline hover:text-neutral-700"
+        className="underline decoration-[#b9ae9f] underline-offset-2 hover:text-[#181613]"
       >
         Privacy Policy
       </a>
@@ -307,23 +260,23 @@ function EmailAuthView({
   const [mode, setMode] = useState<EmailMode>("password");
 
   return (
-    <div className="flex flex-col gap-4 px-8">
+    <div className="flex flex-col gap-5">
       <button
         onClick={onBack}
-        className="-mt-2 mb-1 flex items-center gap-1 self-start text-sm text-neutral-500 transition-colors hover:text-neutral-700"
+        className="flex cursor-pointer items-center gap-1 self-start text-sm text-[#756b5d] transition-colors hover:text-[#181613]"
       >
         <ArrowLeftIcon className="size-3.5" />
         Back
       </button>
 
-      <div className="flex gap-1 rounded-full bg-neutral-100 p-1">
+      <div className="flex gap-1 rounded-full bg-[#f4efe6] p-1">
         <button
           onClick={() => setMode("password")}
           className={cn([
-            "flex-1 rounded-full py-1.5 font-sans text-sm font-medium transition-colors",
+            "flex-1 cursor-pointer rounded-full py-2 text-sm font-medium transition-colors",
             mode === "password"
-              ? "bg-white text-neutral-900 shadow-sm"
-              : "text-neutral-500 hover:text-neutral-700",
+              ? "bg-white text-[#181613] shadow-sm"
+              : "text-[#756b5d] hover:text-[#181613]",
           ])}
         >
           Password
@@ -331,13 +284,13 @@ function EmailAuthView({
         <button
           onClick={() => setMode("magic-link")}
           className={cn([
-            "flex-1 rounded-full py-1.5 font-sans text-sm font-medium transition-colors",
+            "flex-1 cursor-pointer rounded-full py-2 text-sm font-medium transition-colors",
             mode === "magic-link"
-              ? "bg-white text-neutral-900 shadow-sm"
-              : "text-neutral-500 hover:text-neutral-700",
+              ? "bg-white text-[#181613] shadow-sm"
+              : "text-[#756b5d] hover:text-[#181613]",
           ])}
         >
-          Magic Link
+          Magic link
         </button>
       </div>
 
@@ -451,9 +404,9 @@ function PasswordForm({
 
   if (submitted) {
     return (
-      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-center">
-        <p className="font-medium text-stone-700">Check your email</p>
-        <p className="mt-1 text-sm text-stone-500">
+      <div className={authNoticeClassName}>
+        <p className="font-medium text-[#4f4940]">Check your email</p>
+        <p className="mt-1 text-sm text-[#756b5d]">
           We sent a confirmation link to {email}
         </p>
       </div>
@@ -468,12 +421,7 @@ function PasswordForm({
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Email"
         required
-        className={cn([
-          "w-full px-4 py-2",
-          "rounded-lg border border-neutral-300",
-          "text-fg placeholder:text-fg-muted",
-          "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-        ])}
+        className={authInputClassName}
       />
       <input
         type="password"
@@ -481,12 +429,7 @@ function PasswordForm({
         onChange={(e) => setPassword(e.target.value)}
         placeholder="Password"
         required
-        className={cn([
-          "w-full px-4 py-2",
-          "rounded-lg border border-neutral-300",
-          "text-fg placeholder:text-fg-muted",
-          "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-        ])}
+        className={authInputClassName}
       />
       {isSignUp && (
         <input
@@ -495,33 +438,18 @@ function PasswordForm({
           onChange={(e) => setConfirmPassword(e.target.value)}
           placeholder="Confirm password"
           required
-          className={cn([
-            "w-full px-4 py-2",
-            "rounded-lg border border-neutral-300",
-            "text-fg placeholder:text-fg-muted",
-            "focus:ring-2 focus:ring-stone-800 focus:ring-offset-2 focus:outline-hidden",
-          ])}
+          className={authInputClassName}
         />
       )}
       {errorMessage && (
-        <p className="text-center text-sm text-red-500">{errorMessage}</p>
+        <p className="text-center text-sm text-red-700">{errorMessage}</p>
       )}
       <button
         type="submit"
         disabled={
           isPending || !email || !password || (isSignUp && !confirmPassword)
         }
-        className={cn([
-          "w-full cursor-pointer px-4 py-2",
-          "font rounded-full font-sans",
-          "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "transition-colors",
-          "flex items-center justify-center gap-3",
-          isSignUp
-            ? "border-color-border text-fg hover:bg-brand-dark/10 rounded-full border"
-            : "bg-fg hover:bg-fg/80 text-white",
-        ])}
+        className={authPrimaryButtonClassName}
       >
         {isPending ? "Loading..." : isSignUp ? "Create account" : "Sign in"}
       </button>
@@ -533,7 +461,7 @@ function PasswordForm({
             setErrorMessage("");
             setConfirmPassword("");
           }}
-          className="text-fg-muted hover:text-fg font-sans text-sm transition-colors hover:underline"
+          className="cursor-pointer text-sm text-[#756b5d] transition-colors hover:text-[#181613] hover:underline"
         >
           {isSignUp
             ? "Already have an account? Sign in"
@@ -542,7 +470,7 @@ function PasswordForm({
         {!isSignUp && (
           <Link
             to="/reset-password/"
-            className="text-fg-muted hover:text-fg text-sm transition-colors hover:underline"
+            className="text-sm text-[#756b5d] transition-colors hover:text-[#181613] hover:underline"
           >
             Forgot password?
           </Link>
@@ -602,9 +530,9 @@ function MagicLinkForm({
 
   if (submitted) {
     return (
-      <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-center">
-        <p className="font-medium text-stone-700">Check your email</p>
-        <p className="mt-1 text-sm text-stone-500">
+      <div className={authNoticeClassName}>
+        <p className="font-medium text-[#4f4940]">Check your email</p>
+        <p className="mt-1 text-sm text-[#756b5d]">
           We sent a magic link to {email}
         </p>
       </div>
@@ -627,31 +555,17 @@ function MagicLinkForm({
         onChange={(e) => setEmail(e.target.value)}
         placeholder="Enter your email"
         required
-        className={cn([
-          "w-full px-4 py-2",
-          "rounded-lg border border-neutral-300",
-          "text-neutral-700 placeholder:text-neutral-400",
-          "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-        ])}
+        className={authInputClassName}
       />
       <button
         type="submit"
         disabled={magicLinkMutation.isPending || !email}
-        className={cn([
-          "w-full cursor-pointer px-4 py-2",
-          "border border-neutral-300",
-          "rounded-lg font-medium text-neutral-700",
-          "hover:bg-neutral-50",
-          "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-          "disabled:cursor-not-allowed disabled:opacity-50",
-          "transition-colors",
-          "flex items-center justify-center gap-2",
-        ])}
+        className={authPrimaryButtonClassName}
       >
         {magicLinkMutation.isPending ? "Sending..." : "Send magic link"}
       </button>
       {magicLinkMutation.isError && (
-        <p className="text-center text-sm text-red-500">
+        <p className="text-center text-sm text-red-700">
           Failed to send magic link. Please try again.
         </p>
       )}
@@ -705,19 +619,14 @@ function OAuthButton({
     <button
       onClick={() => mutate(provider)}
       disabled={isPending}
-      className={cn([
-        "w-full cursor-pointer px-4 py-2",
-        "border-color-brand border",
-        "text-fg rounded-full font-sans",
-        "hover:bg-brand-dark/10",
-        "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-        "disabled:cursor-not-allowed disabled:opacity-50",
-        "transition-colors",
-        "flex items-center justify-center gap-3",
-      ])}
+      className={authSecondaryButtonClassName}
     >
-      {provider === "google" && <Icon icon="logos:google-icon" />}
-      {provider === "github" && <Icon icon="logos:github-icon" />}
+      {provider === "google" && (
+        <Icon icon="logos:google-icon" width="18" height="18" />
+      )}
+      {provider === "github" && (
+        <Icon icon="logos:github-icon" width="18" height="18" />
+      )}
       Sign in with {provider.charAt(0).toUpperCase() + provider.slice(1)}
     </button>
   );

--- a/apps/web/src/routes/reset-password.tsx
+++ b/apps/web/src/routes/reset-password.tsx
@@ -3,9 +3,12 @@ import { createFileRoute, Link } from "@tanstack/react-router";
 import { ArrowLeftIcon } from "lucide-react";
 import { useState } from "react";
 
-import { cn } from "@hypr/utils";
-
-import { Image } from "@/components/image";
+import {
+  AuthShell,
+  authInputClassName,
+  authNoticeClassName,
+  authPrimaryButtonClassName,
+} from "@/components/auth-shell";
 import { doPasswordResetRequest } from "@/functions/auth";
 
 export const Route = createFileRoute("/reset-password")({
@@ -40,94 +43,48 @@ function Component() {
   };
 
   return (
-    <div
-      className={cn([
-        "flex min-h-screen items-center justify-center p-4",
-        "bg-linear-to-b from-stone-50 via-stone-100/50 to-stone-50",
-      ])}
+    <AuthShell
+      title="Reset your password"
+      description="We’ll send a reset link to the email on your account."
     >
-      <div className="mx-auto max-w-md rounded-xs border border-neutral-200 bg-white p-8">
-        <div className="mb-8 text-center">
-          <div
-            className={cn([
-              "mx-auto mb-6 size-28",
-              "border border-neutral-200 shadow-xl",
-              "flex items-center justify-center",
-              "rounded-4xl bg-transparent",
-            ])}
-          >
-            <Image
-              src="/logo.svg"
-              alt="Anarlog"
-              width={96}
-              height={96}
-              className={cn([
-                "size-24",
-                "rounded-3xl border border-neutral-200",
-              ])}
-            />
-          </div>
-          <h1 className="mb-2 font-sans text-3xl text-stone-800">
-            Reset your password
-          </h1>
-          <p className="text-sm text-neutral-500">
-            Enter your email and we'll send you a link to reset your password.
+      {submitted ? (
+        <div className={authNoticeClassName}>
+          <p className="font-medium text-[#4f4940]">Check your email</p>
+          <p className="mt-1 text-sm leading-6 text-[#756b5d]">
+            We sent a password reset link to {email}
           </p>
         </div>
+      ) : (
+        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            placeholder="Email"
+            required
+            className={authInputClassName}
+          />
+          {errorMessage && (
+            <p className="text-center text-sm text-red-700">{errorMessage}</p>
+          )}
+          <button
+            type="submit"
+            disabled={resetMutation.isPending || !email}
+            className={authPrimaryButtonClassName}
+          >
+            {resetMutation.isPending ? "Sending..." : "Send reset link"}
+          </button>
+        </form>
+      )}
 
-        {submitted ? (
-          <div className="rounded-lg border border-stone-200 bg-stone-50 p-4 text-center">
-            <p className="font-medium text-stone-700">Check your email</p>
-            <p className="mt-1 text-sm text-stone-500">
-              We sent a password reset link to {email}
-            </p>
-          </div>
-        ) : (
-          <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              placeholder="Email"
-              required
-              className={cn([
-                "w-full px-4 py-2",
-                "rounded-lg border border-neutral-300",
-                "text-neutral-700 placeholder:text-neutral-400",
-                "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-              ])}
-            />
-            {errorMessage && (
-              <p className="text-center text-sm text-red-500">{errorMessage}</p>
-            )}
-            <button
-              type="submit"
-              disabled={resetMutation.isPending || !email}
-              className={cn([
-                "w-full cursor-pointer px-4 py-2",
-                "border border-neutral-300",
-                "rounded-lg font-medium text-neutral-700",
-                "hover:bg-neutral-50",
-                "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-                "disabled:cursor-not-allowed disabled:opacity-50",
-                "transition-colors",
-                "flex items-center justify-center gap-2",
-              ])}
-            >
-              {resetMutation.isPending ? "Sending..." : "Send reset link"}
-            </button>
-          </form>
-        )}
-
-        <Link
-          to="/auth/"
-          search={{ flow: "web" }}
-          className="mt-4 flex items-center justify-center gap-1 text-sm text-neutral-500 transition-colors hover:text-neutral-700"
-        >
-          <ArrowLeftIcon className="size-3.5" />
-          Back to sign in
-        </Link>
-      </div>
-    </div>
+      <Link
+        to="/auth/"
+        search={{ flow: "web" }}
+        className="mt-5 flex items-center justify-center gap-1 text-sm text-[#756b5d] transition-colors hover:text-[#181613]"
+      >
+        <ArrowLeftIcon className="size-3.5" />
+        Back to sign in
+      </Link>
+    </AuthShell>
   );
 }

--- a/apps/web/src/routes/update-password.tsx
+++ b/apps/web/src/routes/update-password.tsx
@@ -7,9 +7,11 @@ import {
 } from "@tanstack/react-router";
 import { useState } from "react";
 
-import { cn } from "@hypr/utils";
-
-import { Image } from "@/components/image";
+import {
+  AuthShell,
+  authInputClassName,
+  authPrimaryButtonClassName,
+} from "@/components/auth-shell";
 import { doUpdatePassword, fetchUser } from "@/functions/auth";
 
 export const Route = createFileRoute("/update-password")({
@@ -63,97 +65,46 @@ function Component() {
   };
 
   return (
-    <div
-      className={cn([
-        "flex min-h-screen items-center justify-center p-4",
-        "bg-linear-to-b from-stone-50 via-stone-100/50 to-stone-50",
-      ])}
+    <AuthShell
+      title="Choose a new password"
+      description="Use at least six characters, then you’ll be ready to sign in."
     >
-      <div className="mx-auto max-w-md rounded-xs border border-neutral-200 bg-white p-8">
-        <div className="mb-8 text-center">
-          <div
-            className={cn([
-              "mx-auto mb-6 size-28",
-              "border border-neutral-200 shadow-xl",
-              "flex items-center justify-center",
-              "rounded-4xl bg-transparent",
-            ])}
-          >
-            <Image
-              src="/logo.svg"
-              alt="Anarlog"
-              width={96}
-              height={96}
-              className={cn([
-                "size-24",
-                "rounded-3xl border border-neutral-200",
-              ])}
-            />
-          </div>
-          <h1 className="mb-2 font-sans text-3xl text-stone-800">
-            Set new password
-          </h1>
-          <p className="text-sm text-neutral-500">
-            Enter your new password below.
-          </p>
-        </div>
-
-        <form onSubmit={handleSubmit} className="flex flex-col gap-3">
-          <input
-            type="password"
-            value={password}
-            onChange={(e) => setPassword(e.target.value)}
-            placeholder="New password"
-            required
-            className={cn([
-              "w-full px-4 py-2",
-              "rounded-lg border border-neutral-300",
-              "text-neutral-700 placeholder:text-neutral-400",
-              "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-            ])}
-          />
-          <input
-            type="password"
-            value={confirmPassword}
-            onChange={(e) => setConfirmPassword(e.target.value)}
-            placeholder="Confirm new password"
-            required
-            className={cn([
-              "w-full px-4 py-2",
-              "rounded-lg border border-neutral-300",
-              "text-neutral-700 placeholder:text-neutral-400",
-              "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-            ])}
-          />
-          {errorMessage && (
-            <p className="text-center text-sm text-red-500">{errorMessage}</p>
-          )}
-          <button
-            type="submit"
-            disabled={updateMutation.isPending || !password || !confirmPassword}
-            className={cn([
-              "w-full cursor-pointer px-4 py-2",
-              "border border-neutral-300",
-              "rounded-lg font-medium text-neutral-700",
-              "hover:bg-neutral-50",
-              "focus:ring-2 focus:ring-stone-500 focus:ring-offset-2 focus:outline-hidden",
-              "disabled:cursor-not-allowed disabled:opacity-50",
-              "transition-colors",
-              "flex items-center justify-center gap-2",
-            ])}
-          >
-            {updateMutation.isPending ? "Updating..." : "Update password"}
-          </button>
-        </form>
-
-        <Link
-          to="/auth/"
-          search={{ flow: "web" }}
-          className="mt-4 flex items-center justify-center gap-1 text-sm text-neutral-500 transition-colors hover:text-neutral-700"
+      <form onSubmit={handleSubmit} className="flex flex-col gap-3">
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="New password"
+          required
+          className={authInputClassName}
+        />
+        <input
+          type="password"
+          value={confirmPassword}
+          onChange={(e) => setConfirmPassword(e.target.value)}
+          placeholder="Confirm new password"
+          required
+          className={authInputClassName}
+        />
+        {errorMessage && (
+          <p className="text-center text-sm text-red-700">{errorMessage}</p>
+        )}
+        <button
+          type="submit"
+          disabled={updateMutation.isPending || !password || !confirmPassword}
+          className={authPrimaryButtonClassName}
         >
-          Back to sign in
-        </Link>
-      </div>
-    </div>
+          {updateMutation.isPending ? "Updating..." : "Update password"}
+        </button>
+      </form>
+
+      <Link
+        to="/auth/"
+        search={{ flow: "web" }}
+        className="mt-5 flex items-center justify-center gap-1 text-sm text-[#756b5d] transition-colors hover:text-[#181613]"
+      >
+        Back to sign in
+      </Link>
+    </AuthShell>
   );
 }


### PR DESCRIPTION
Unify sign-in, callback, and password flows with the homepage visual language while preserving existing auth behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation-only refactor across auth routes; no changes to auth APIs, redirects, or token handling.
> 
> **Overview**
> Introduces a shared **`AuthShell`** layout and exported input/button/notice styles so sign-in, OAuth callback, password reset, and password update pages match the homepage look (two-column marketing panel on desktop, card with per-flow title/description, footer tagline).
> 
> **`/auth`**, **`/callback/auth`**, **`/reset-password`**, and **`/update-password`** drop their local centered card wrappers (dotted background, logo header, `motion` height animation) and render through **`AuthShell`** with the new palette and typography. Callback states get refreshed copy and a clearer desktop “copy URL” fallback; OAuth buttons use fixed icon sizes.
> 
> Auth logic, redirects, token exchange, and desktop deeplink behavior are unchanged—this is presentation and consolidation only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dea53c09487b9c8166ca1825be4a8830144bb94. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->