### PR TITLE
Require macOS 15 for desktop builds

### DIFF
--- a/apps/desktop/src-tauri/build.rs
+++ b/apps/desktop/src-tauri/build.rs
@@ -6,7 +6,7 @@ use std::{
 };
 
 #[cfg(target_os = "macos")]
-const MACOS_MINIMUM_SYSTEM_VERSION: &str = "14.2";
+const MACOS_MINIMUM_SYSTEM_VERSION: &str = "15.0";
 
 fn main() {
     #[cfg(target_os = "macos")]

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -43,7 +43,7 @@
       "resources/notification-icons": "notification-icons"
     },
     "macOS": {
-      "minimumSystemVersion": "14.2",
+      "minimumSystemVersion": "15.0",
       "frameworks": [
         "../../../crates/cloudsync/vendor/cloudsync/macos/aarch64/cloudsync.dylib"
       ],


### PR DESCRIPTION
Raise the desktop bundle and bundled permissions helper deployment target to macOS 15.0 so the app matches SQLite Sync 1.1.2.

Verification: `cargo check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Deployment-target-only change with no auth or data-path logic; main effect is dropping macOS 14.x support.
> 
> **Overview**
> Raises the desktop app’s **macOS minimum version from 14.2 to 15.0** so packaging and native helpers match **SQLite Sync 1.1.2**.
> 
> `tauri.conf.json` now sets `bundle.macOS.minimumSystemVersion` to **15.0**, which controls what macOS versions can install/run the bundled app. In `build.rs`, `MACOS_MINIMUM_SYSTEM_VERSION` is updated to **15.0**, so the permissions `check-permissions` Swift helper is compiled with an `*-apple-macosx15.0` deployment target instead of 14.2.
> 
> There is no application logic change—only the supported OS floor moves up, so users on macOS 14.x will no longer be supported.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 416fa80760647b780b0e652a4d9963946981ed02. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->