### PR TITLE
Show CloudSync initial sync progress

### DIFF
--- a/apps/desktop/src/auth/cloudsync-progress.test.tsx
+++ b/apps/desktop/src/auth/cloudsync-progress.test.tsx
@@ -1,0 +1,106 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getCloudsyncStatus: vi.fn(),
+  showNotification: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-db", () => ({
+  getCloudsyncStatus: mocks.getCloudsyncStatus,
+}));
+
+vi.mock("@hypr/plugin-notification", () => ({
+  commands: {
+    showNotification: mocks.showNotification,
+  },
+}));
+
+import {
+  startCloudsyncInitialSyncProgress,
+  stopCloudsyncInitialSyncProgress,
+  useCloudsyncInitialSyncProgress,
+} from "./cloudsync-progress";
+
+function cloudsyncStatus(lastSyncAtMs: number | null) {
+  return {
+    cloudsync_enabled: true,
+    extension_loaded: true,
+    configured: true,
+    running: true,
+    network_initialized: true,
+    last_sync: lastSyncAtMs === null ? null : {},
+    last_sync_at_ms: lastSyncAtMs,
+    has_unsent_changes: false,
+    last_error: null,
+    last_error_kind: null,
+    consecutive_failures: 0,
+  };
+}
+
+describe("CloudSync initial sync progress", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    const storage = new Map<string, string>();
+    vi.stubGlobal("localStorage", {
+      clear: () => storage.clear(),
+      getItem: (key: string) => storage.get(key) ?? null,
+      removeItem: (key: string) => storage.delete(key),
+      setItem: (key: string, value: string) => storage.set(key, value),
+    });
+    localStorage.clear();
+    stopCloudsyncInitialSyncProgress();
+    mocks.getCloudsyncStatus.mockReset();
+    mocks.showNotification.mockReset();
+    mocks.showNotification.mockResolvedValue({ status: "ok", data: null });
+  });
+
+  afterEach(() => {
+    stopCloudsyncInitialSyncProgress();
+    cleanup();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  it("shows progress and sends a notification when initial sync completes", async () => {
+    mocks.getCloudsyncStatus
+      .mockResolvedValueOnce(cloudsyncStatus(null))
+      .mockResolvedValueOnce(cloudsyncStatus(123));
+    const progress = renderHook(() => useCloudsyncInitialSyncProgress());
+
+    act(() => startCloudsyncInitialSyncProgress("user-1"));
+
+    expect(progress.result.current).toEqual({
+      state: "syncing",
+      toastId: "cloudsync-initial-sync-user-1",
+      userId: "user-1",
+    });
+
+    await act(() => vi.advanceTimersByTimeAsync(2_000));
+
+    expect(progress.result.current).toEqual({ state: "idle" });
+    expect(
+      localStorage.getItem("anarlog:cloudsync_initial_sync_completed:user-1"),
+    ).toBe("1");
+    expect(mocks.showNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        key: "cloudsync-initial-sync-complete-user-1",
+        title: "Cloud sync complete",
+        message: "Your Anarlog data is ready on this device.",
+      }),
+    );
+  });
+
+  it("does not restart progress after completion was persisted", () => {
+    localStorage.setItem(
+      "anarlog:cloudsync_initial_sync_completed:user-1",
+      "1",
+    );
+    const progress = renderHook(() => useCloudsyncInitialSyncProgress());
+
+    act(() => startCloudsyncInitialSyncProgress("user-1"));
+
+    expect(progress.result.current).toEqual({ state: "idle" });
+    expect(mocks.getCloudsyncStatus).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/auth/cloudsync-progress.ts
+++ b/apps/desktop/src/auth/cloudsync-progress.ts
@@ -1,0 +1,142 @@
+import { useSyncExternalStore } from "react";
+
+import { getCloudsyncStatus } from "@hypr/plugin-db";
+import { commands as notificationCommands } from "@hypr/plugin-notification";
+
+const POLL_INTERVAL_MS = 2_000;
+const COMPLETED_KEY_PREFIX = "anarlog:cloudsync_initial_sync_completed:";
+
+type CloudsyncInitialSyncProgress =
+  | { state: "idle" }
+  | { state: "syncing"; toastId: string; userId: string };
+
+let monitorGeneration = 0;
+let snapshot: CloudsyncInitialSyncProgress = { state: "idle" };
+const listeners = new Set<() => void>();
+
+function completionKey(userId: string) {
+  return `${COMPLETED_KEY_PREFIX}${userId}`;
+}
+
+function readCompleted(userId: string) {
+  try {
+    return localStorage.getItem(completionKey(userId)) === "1";
+  } catch {
+    return false;
+  }
+}
+
+function markCompleted(userId: string) {
+  try {
+    localStorage.setItem(completionKey(userId), "1");
+  } catch {
+    // The completion notification may repeat after restart if storage is unavailable.
+  }
+}
+
+function setSnapshot(next: CloudsyncInitialSyncProgress) {
+  snapshot = next;
+  listeners.forEach((listener) => listener());
+}
+
+function subscribe(listener: () => void) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+function sleep(ms: number) {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms));
+}
+
+async function showCompletionNotification(userId: string) {
+  try {
+    const result = await notificationCommands.showNotification({
+      key: `cloudsync-initial-sync-complete-${userId}`,
+      title: "Cloud sync complete",
+      message: "Your Anarlog data is ready on this device.",
+      timeout: null,
+      source: null,
+      start_time: null,
+      participants: null,
+      event_details: null,
+      action_label: "Open Anarlog",
+      action_variant: null,
+      options: null,
+      footer: null,
+      icon: null,
+    });
+
+    if (result.status === "error") {
+      console.error(
+        "[cloudsync] failed to show completion notification",
+        result.error,
+      );
+    }
+  } catch (error) {
+    console.error("[cloudsync] failed to show completion notification", error);
+  }
+}
+
+async function monitorInitialSync(userId: string, activeGeneration: number) {
+  while (activeGeneration === monitorGeneration) {
+    try {
+      const status = await getCloudsyncStatus();
+      if (activeGeneration !== monitorGeneration) {
+        return;
+      }
+
+      if (status.last_sync_at_ms !== null) {
+        markCompleted(userId);
+        setSnapshot({ state: "idle" });
+        await showCompletionNotification(userId);
+        return;
+      }
+
+      if (
+        status.configured &&
+        !status.running &&
+        status.last_error_kind !== null
+      ) {
+        setSnapshot({ state: "idle" });
+        return;
+      }
+    } catch {
+      // Credential exchange and startup can briefly make status unavailable.
+    }
+
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+export function startCloudsyncInitialSyncProgress(userId: string) {
+  if (readCompleted(userId)) {
+    return;
+  }
+
+  if (snapshot.state === "syncing" && snapshot.userId === userId) {
+    return;
+  }
+
+  const activeGeneration = ++monitorGeneration;
+  setSnapshot({
+    state: "syncing",
+    toastId: `cloudsync-initial-sync-${userId}`,
+    userId,
+  });
+  void monitorInitialSync(userId, activeGeneration);
+}
+
+export function stopCloudsyncInitialSyncProgress() {
+  monitorGeneration += 1;
+  if (snapshot.state !== "idle") {
+    setSnapshot({ state: "idle" });
+  }
+}
+
+export function useCloudsyncInitialSyncProgress() {
+  return useSyncExternalStore(
+    subscribe,
+    () => snapshot,
+    () => snapshot,
+  );
+}

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -13,6 +13,15 @@ import {
   handleCloudsyncAuthChange,
   prepareCloudsyncSignOut,
 } from "./cloudsync";
+import {
+  startCloudsyncInitialSyncProgress,
+  stopCloudsyncInitialSyncProgress,
+} from "./cloudsync-progress";
+
+vi.mock("./cloudsync-progress", () => ({
+  startCloudsyncInitialSyncProgress: vi.fn(),
+  stopCloudsyncInitialSyncProgress: vi.fn(),
+}));
 
 vi.mock("~/env", () => ({
   env: {
@@ -102,7 +111,9 @@ describe("CloudSync auth lifecycle", () => {
       "sqlite-token",
       "user-id",
     );
+    expect(startCloudsyncInitialSyncProgress).toHaveBeenCalledWith("user-id");
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
+    expect(stopCloudsyncInitialSyncProgress).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(13 * 60 * 1000 - 1);
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -7,6 +7,11 @@ import {
   suspendCloudsync,
 } from "@hypr/plugin-db";
 
+import {
+  startCloudsyncInitialSyncProgress,
+  stopCloudsyncInitialSyncProgress,
+} from "./cloudsync-progress";
+
 import { env } from "~/env";
 
 const REFRESH_LEAD_MS = 2 * 60 * 1000;
@@ -69,6 +74,7 @@ async function suspendCloudsyncForGeneration(activeGeneration: number) {
         return;
       }
       await suspendCloudsync();
+      stopCloudsyncInitialSyncProgress();
     });
   } catch {
     if (activeGeneration === generation) {
@@ -356,6 +362,8 @@ async function activateCloudsync(
       console.warn("[cloudsync] local database belongs to another account");
       return "account_mismatch";
     }
+
+    startCloudsyncInitialSyncProgress(session.user.id);
   } catch (error) {
     if (activeGeneration !== generation) {
       return "ok";
@@ -393,6 +401,7 @@ async function activateCloudsync(
 
 async function suspendCloudsyncSession(): Promise<void> {
   beginTransition();
+  stopCloudsyncInitialSyncProgress();
 
   try {
     await enqueuePluginOperation(suspendCloudsync);
@@ -406,6 +415,7 @@ export async function prepareCloudsyncSignOut(
   onAccountMismatch?: CloudsyncAccountMismatchHandler,
 ): Promise<void> {
   const activeGeneration = beginTransition();
+  stopCloudsyncInitialSyncProgress();
 
   try {
     await enqueuePluginOperation(suspendCloudsync);

--- a/apps/desktop/src/sidebar/toast/index.test.tsx
+++ b/apps/desktop/src/sidebar/toast/index.test.tsx
@@ -54,6 +54,10 @@ vi.mock("~/auth", () => ({
   useAuth: () => ({ session: null, signIn: mocks.signIn }),
 }));
 
+vi.mock("~/auth/cloudsync-progress", () => ({
+  useCloudsyncInitialSyncProgress: () => ({ state: "idle" }),
+}));
+
 vi.mock("~/contexts/notifications", () => ({
   useNotifications: () => mocks.notifications,
 }));

--- a/apps/desktop/src/sidebar/toast/index.tsx
+++ b/apps/desktop/src/sidebar/toast/index.tsx
@@ -11,6 +11,7 @@ import type { ToastType } from "./types";
 import { useDismissedToasts } from "./useDismissedToasts";
 
 import { useAuth } from "~/auth";
+import { useCloudsyncInitialSyncProgress } from "~/auth/cloudsync-progress";
 import { useNotifications } from "~/contexts/notifications";
 import { useConfigValues } from "~/shared/config";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
@@ -26,6 +27,7 @@ import { useListener } from "~/stt/contexts";
 
 export function ToastNotifications() {
   const auth = useAuth();
+  const cloudsyncProgress = useCloudsyncInitialSyncProgress();
   const { dismissToast, isDismissed } = useDismissedToasts();
   const shouldShowToast = useShouldShowToast();
   const {
@@ -123,6 +125,10 @@ export function ToastNotifications() {
         isAiTranscriptionTabActive,
         isAiIntelligenceTabActive,
         isBatchTranscribingInActiveTranscriptTab,
+        cloudsyncInitialSyncToastId:
+          cloudsyncProgress.state === "syncing"
+            ? cloudsyncProgress.toastId
+            : null,
         hasActiveDownload,
         downloadingModel,
         activeDownloads,
@@ -142,6 +148,7 @@ export function ToastNotifications() {
       isAiTranscriptionTabActive,
       isAiIntelligenceTabActive,
       isBatchTranscribingInActiveTranscriptTab,
+      cloudsyncProgress,
       hasActiveDownload,
       downloadingModel,
       activeDownloads,

--- a/apps/desktop/src/sidebar/toast/registry.test.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.test.tsx
@@ -16,6 +16,7 @@ const baseParams = {
   isAiTranscriptionTabActive: false,
   isAiIntelligenceTabActive: false,
   isBatchTranscribingInActiveTranscriptTab: false,
+  cloudsyncInitialSyncToastId: null,
   hasActiveDownload: false,
   downloadingModel: null,
   activeDownloads: [],
@@ -81,6 +82,21 @@ describe("sidebar toast registry", () => {
 
     expect(toast?.id).toBe("local-stt-loading");
     expect(toast?.description).toBe("Starting transcription...");
+  });
+
+  it("shows a dismissible loading toast during initial cloud sync", () => {
+    const toast = getToastToShow(
+      createToastRegistry({
+        ...baseParams,
+        cloudsyncInitialSyncToastId: "cloudsync-initial-sync-user-1",
+      }),
+      () => false,
+    );
+
+    expect(toast?.id).toBe("cloudsync-initial-sync-user-1");
+    expect(toast?.description).toBe("Syncing your data in the background...");
+    expect(toast?.dismissible).toBe(true);
+    expect(toast?.loading).toBe(true);
   });
 
   it("renders the pro upgrade toast without an icon", () => {

--- a/apps/desktop/src/sidebar/toast/registry.tsx
+++ b/apps/desktop/src/sidebar/toast/registry.tsx
@@ -21,6 +21,7 @@ type ToastRegistryParams = {
   isAiTranscriptionTabActive: boolean;
   isAiIntelligenceTabActive: boolean;
   isBatchTranscribingInActiveTranscriptTab: boolean;
+  cloudsyncInitialSyncToastId: string | null;
   hasActiveDownload: boolean;
   downloadingModel: string | null;
   activeDownloads: DownloadProgress[];
@@ -48,6 +49,7 @@ export function createToastRegistry({
   isAiTranscriptionTabActive,
   isAiIntelligenceTabActive,
   isBatchTranscribingInActiveTranscriptTab,
+  cloudsyncInitialSyncToastId,
   hasActiveDownload,
   downloadingModel,
   activeDownloads,
@@ -72,6 +74,15 @@ export function createToastRegistry({
         loading: true,
       },
       condition: () => hasActiveDownload,
+    },
+    {
+      toast: {
+        id: cloudsyncInitialSyncToastId ?? "cloudsync-initial-sync",
+        description: "Syncing your data in the background...",
+        dismissible: true,
+        loading: true,
+      },
+      condition: () => cloudsyncInitialSyncToastId !== null,
     },
     {
       toast: {


### PR DESCRIPTION
Show a per-user dismissible loading toast while the first device sync runs, persist completion to avoid repeat prompts, and send a native completion notification.

Verification:
- `pnpm -F @hypr/desktop exec vitest run src/auth/cloudsync-progress.test.tsx src/auth/cloudsync.test.ts src/sidebar/toast/registry.test.tsx src/sidebar/toast/index.test.tsx`
- `pnpm -F @hypr/desktop typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Hooks into the CloudSync auth lifecycle and drives user-visible sync state; behavior is mostly additive (polling, localStorage, toasts) but mis-timed start/stop could show wrong UI around sign-out or suspension.
> 
> **Overview**
> Adds **first-device cloud sync feedback**: after credentials configure successfully, the app starts monitoring sync until `last_sync_at_ms` is set (or sync fails while configured).
> 
> A new **`cloudsync-progress`** module polls status every 2s, exposes **`useSyncExternalStore`** state for a per-user loading toast (`Syncing your data in the background...`), and writes **`anarlog:cloudsync_initial_sync_completed:{userId}`** so the flow does not repeat. On completion it fires a **native “Cloud sync complete”** notification with an Open Anarlog action.
> 
> **`cloudsync.ts`** calls **`startCloudsyncInitialSyncProgress`** after token configuration and **`stopCloudsyncInitialSyncProgress`** on suspend, sign-out prep, and related suspension paths. The **sidebar toast registry** gains a dismissible loading entry wired from **`ToastNotifications`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2bf8f3f34673c49b807ae21ad84829e0af6c549. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->