### PR TITLE
Update desktop 1.2.0 changelog

### DIFF
--- a/packages/changelog/content/1.2.0.md
+++ b/packages/changelog/content/1.2.0.md
@@ -1,7 +1,11 @@
 ---
 date: "2026-07-15"
-summary: "Anarlog makes large note libraries faster, adds flexible summary instructions, improves recording recovery, and strengthens CloudSync reliability."
+summary: "Anarlog makes large note libraries faster, adds local agent access, improves recording recovery, and makes Pro CloudSync more reliable."
 ---
+
+<banner title="macOS 15 is now required" variant="warning">
+Anarlog 1.2.0 supports macOS 15 and later.
+</banner>
 
 ## Performance
 
@@ -26,12 +30,15 @@ summary: "Anarlog makes large note libraries faster, adds flexible summary instr
 ## Reliability
 
 - Pro CloudSync stays bound to the correct account and workspace
-- CloudSync now recovers more safely from failures and shuts down cleanly with the app database
+- Large note libraries sync in smaller batches for a more reliable first setup
+- Pro CloudSync now shows when an initial sync is running and notifies you when your data is ready
+- CloudSync recovers more safely from failures and shuts down cleanly with the app database
 - CloudSync and live note updates now coexist safely across database transactions
 - Secure API key storage keeps a consistent identity across app updates
 
 ## Polish
 
+- Sign-in and account setup now match the rest of Anarlog more closely
 - Transcript controls remain visible while expanding the floating bar
 - macOS window controls align consistently across development and release builds
 - Onboarding demo controls and support links are clearer and more reliable


### PR DESCRIPTION
Document the final user-facing CloudSync, compatibility, developer, and account experience changes for the stable release.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to release notes; no application code or runtime behavior.
> 
> **Overview**
> Updates the **1.2.0** changelog copy to match the stable release messaging.
> 
> The front-matter **summary** now highlights local agent access and Pro CloudSync reliability instead of flexible summary instructions. A **warning banner** states that **macOS 15+** is required.
> 
> Under **Reliability**, the notes add batched first-time sync for large libraries, in-app progress and completion notifications for Pro initial sync, and slightly clearer wording on failure recovery. **Polish** gains a bullet that sign-in and account setup align better with the rest of the app.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 249c3dface62f4da8085257639a431f1e2f2c036. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->