### PR TITLE
Restore note creation after CloudSync activation

### DIFF
--- a/crates/cloudsync/src/api.rs
+++ b/crates/cloudsync/src/api.rs
@@ -1,6 +1,47 @@
-use sqlx::{Executor, Sqlite};
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+use sqlx::{Executor, Sqlite, SqliteConnection};
 
 use crate::error::Error;
+
+#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
+pub struct CloudsyncTableSpec {
+    pub table_name: String,
+    pub crdt_algo: Option<String>,
+    pub init_flags: Option<i64>,
+    pub enabled: bool,
+}
+
+#[derive(Clone, Debug, Default)]
+pub struct CloudsyncConnectionInitializer {
+    tables: Arc<RwLock<Vec<CloudsyncTableSpec>>>,
+}
+
+impl CloudsyncConnectionInitializer {
+    pub fn replace_tables(&self, tables: Vec<CloudsyncTableSpec>) {
+        *self.tables.write().unwrap() = tables;
+    }
+
+    pub fn clear(&self) {
+        self.tables.write().unwrap().clear();
+    }
+
+    pub async fn initialize(&self, connection: &mut SqliteConnection) -> Result<(), Error> {
+        let tables = self.tables.read().unwrap().clone();
+        for table in tables.iter().filter(|table| table.enabled) {
+            init(
+                &mut *connection,
+                &table.table_name,
+                table.crdt_algo.as_deref(),
+                table.init_flags,
+            )
+            .await?;
+        }
+
+        Ok(())
+    }
+}
 
 /// https://docs.sqlitecloud.io/docs/sqlite-sync-api-cloudsync-version
 pub async fn version<'e, E>(executor: E) -> Result<String, Error>

--- a/crates/cloudsync/src/lib.rs
+++ b/crates/cloudsync/src/lib.rs
@@ -11,8 +11,8 @@ use std::path::PathBuf;
 use sqlx::sqlite::SqliteConnectOptions;
 
 pub use api::{
-    begin_alter, cleanup, commit_alter, db_version, disable, enable, init, is_enabled, siteid,
-    terminate, uuid, version,
+    CloudsyncConnectionInitializer, CloudsyncTableSpec, begin_alter, cleanup, commit_alter,
+    db_version, disable, enable, init, is_enabled, siteid, terminate, uuid, version,
 };
 pub use bundle::bundled_extension_path;
 pub use close::install_transaction_observer;

--- a/crates/db-change/src/notifier.rs
+++ b/crates/db-change/src/notifier.rs
@@ -16,18 +16,23 @@ pub struct ChangeNotifier {
 
 impl ChangeNotifier {
     pub fn new() -> (Self, SqlitePoolOptions) {
-        Self::build(Some(false))
+        Self::build(Some(false), None)
     }
 
-    pub fn new_with_cloudsync() -> (Self, SqlitePoolOptions) {
-        Self::build(Some(true))
+    pub fn new_with_cloudsync(
+        initializer: hypr_cloudsync::CloudsyncConnectionInitializer,
+    ) -> (Self, SqlitePoolOptions) {
+        Self::build(Some(true), Some(initializer))
     }
 
     pub fn disabled() -> (Self, SqlitePoolOptions) {
-        Self::build(None)
+        Self::build(None, None)
     }
 
-    fn build(cloudsync_enabled: Option<bool>) -> (Self, SqlitePoolOptions) {
+    fn build(
+        cloudsync_enabled: Option<bool>,
+        cloudsync_initializer: Option<hypr_cloudsync::CloudsyncConnectionInitializer>,
+    ) -> (Self, SqlitePoolOptions) {
         let (table_change_tx, _) = broadcast::channel(256);
         let change_tracker = Arc::new(ChangeTracker::default());
 
@@ -46,6 +51,7 @@ impl ChangeNotifier {
         let pool_options = SqlitePoolOptions::new().after_connect(move |conn, _| {
             let callback_tx = callback_tx.clone();
             let callback_tracker = Arc::clone(&callback_tracker);
+            let cloudsync_initializer = cloudsync_initializer.clone();
 
             Box::pin(async move {
                 let mut handle = conn.lock_handle().await?;
@@ -82,6 +88,14 @@ impl ChangeNotifier {
                     handle.set_rollback_hook(move || {
                         hook_state.clear();
                     });
+                }
+                drop(handle);
+
+                if let Some(initializer) = cloudsync_initializer {
+                    initializer
+                        .initialize(conn)
+                        .await
+                        .map_err(|error| sqlx::Error::Configuration(Box::new(error)))?;
                 }
 
                 Ok(())

--- a/crates/db-core/src/cloudsync/ops.rs
+++ b/crates/db-core/src/cloudsync/ops.rs
@@ -1,8 +1,8 @@
 use sqlx::pool::PoolConnection;
-use sqlx::{Executor, Sqlite};
+use sqlx::{Executor, Sqlite, SqliteConnection};
 use tokio::sync::MutexGuard;
 
-use super::CloudsyncAuth;
+use super::{CloudsyncAuth, CloudsyncTableSpec};
 use crate::Db;
 
 impl Db {
@@ -59,6 +59,58 @@ impl Db {
         )
         .await;
         self.release_single_pool_connection(&mut connection);
+        result
+    }
+
+    pub(crate) async fn cloudsync_init_enabled_tables(
+        &self,
+        tables: &[CloudsyncTableSpec],
+    ) -> Result<(), hypr_cloudsync::Error> {
+        if !tables.iter().any(|table| table.enabled) {
+            return Ok(());
+        }
+
+        let mut pinned = self.lock_cloudsync_connection().await?;
+        let mut connections = Vec::new();
+        for _ in 1..self.pool.options().get_max_connections() {
+            match self.pool.acquire().await {
+                Ok(connection) => connections.push(connection),
+                Err(error) => {
+                    for connection in connections {
+                        let _ = connection.close().await;
+                    }
+                    self.release_single_pool_connection(&mut pinned);
+                    return Err(error.into());
+                }
+            }
+        }
+
+        let result = async {
+            init_enabled_tables(pinned.as_mut().unwrap(), tables).await?;
+            for connection in &mut connections {
+                init_enabled_tables(connection, tables).await?;
+            }
+            Ok(())
+        }
+        .await;
+
+        if result.is_ok() {
+            self.cloudsync_initializer.replace_tables(
+                tables
+                    .iter()
+                    .filter(|table| table.enabled)
+                    .cloned()
+                    .collect(),
+            );
+        }
+
+        self.release_single_pool_connection(&mut pinned);
+        if result.is_err() {
+            for connection in connections {
+                let _ = connection.close().await;
+            }
+        }
+
         result
     }
 
@@ -130,6 +182,57 @@ impl Db {
         let result = hypr_cloudsync::terminate(&mut **connection.as_mut().unwrap()).await;
         self.release_single_pool_connection(&mut connection);
         result
+    }
+
+    pub(crate) async fn cloudsync_terminate_and_close(&self) -> Result<(), hypr_cloudsync::Error> {
+        self.cloudsync_initializer.clear();
+        let mut pinned = self.lock_cloudsync_connection().await?;
+        let mut connections = Vec::new();
+        for _ in 1..self.pool.options().get_max_connections() {
+            match self.pool.acquire().await {
+                Ok(connection) => connections.push(connection),
+                Err(error) => {
+                    connections.push(pinned.take().unwrap());
+                    drop(pinned);
+                    if let Err(close_error) = close_pool_connections(connections).await {
+                        tracing::warn!(%close_error, "failed to close cloudsync connections after pool acquisition failure");
+                    }
+                    return Err(error.into());
+                }
+            }
+        }
+
+        let mut terminate_error = None;
+        if let Err(error) = hypr_cloudsync::terminate(&mut **pinned.as_mut().unwrap()).await {
+            terminate_error = Some(error);
+        }
+        for connection in &mut connections {
+            if let Err(error) = hypr_cloudsync::terminate(&mut **connection).await
+                && terminate_error.is_none()
+            {
+                terminate_error = Some(error);
+            }
+        }
+
+        connections.push(pinned.take().unwrap());
+        drop(pinned);
+        let close_result = close_pool_connections(connections).await;
+
+        if let Some(error) = terminate_error {
+            return Err(error);
+        }
+        close_result
+    }
+
+    pub(crate) async fn cloudsync_close_connection(&self) -> Result<(), hypr_cloudsync::Error> {
+        let connection = self.cloudsync_connection.lock().await.take();
+        match connection {
+            Some(connection) => connection
+                .close()
+                .await
+                .map_err(hypr_cloudsync::Error::from),
+            None => Ok(()),
+        }
     }
 
     pub async fn cloudsync_network_cleanup(&self) -> Result<(), hypr_cloudsync::Error> {
@@ -220,6 +323,23 @@ impl Db {
     }
 }
 
+async fn init_enabled_tables(
+    connection: &mut SqliteConnection,
+    tables: &[CloudsyncTableSpec],
+) -> Result<(), hypr_cloudsync::Error> {
+    for table in tables.iter().filter(|table| table.enabled) {
+        hypr_cloudsync::init(
+            &mut *connection,
+            &table.table_name,
+            table.crdt_algo.as_deref(),
+            table.init_flags,
+        )
+        .await?;
+    }
+
+    Ok(())
+}
+
 pub async fn cloudsync_begin_alter_on<'e, E>(
     executor: E,
     table_name: &str,
@@ -248,6 +368,21 @@ where
     E: Executor<'e, Database = Sqlite>,
 {
     hypr_cloudsync::commit_alter(executor, table_name).await
+}
+
+async fn close_pool_connections(
+    connections: Vec<PoolConnection<Sqlite>>,
+) -> Result<(), hypr_cloudsync::Error> {
+    let mut first_error = None;
+    for connection in connections {
+        if let Err(error) = connection.close().await
+            && first_error.is_none()
+        {
+            first_error = Some(error.into());
+        }
+    }
+
+    first_error.map_or(Ok(()), Err)
 }
 
 #[cfg(test)]
@@ -301,5 +436,256 @@ mod tests {
                 .unwrap()
                 .is_err()
         );
+    }
+
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+    ))]
+    #[tokio::test]
+    async fn initializing_tables_updates_every_pool_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(crate::DbOpenOptions {
+            storage: crate::DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(4),
+        })
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                title TEXT NOT NULL DEFAULT ''
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let mut preexisting_connections = Vec::new();
+        for _ in 0..4 {
+            preexisting_connections.push(db.pool().acquire().await.unwrap());
+        }
+        drop(preexisting_connections);
+
+        db.cloudsync_init_enabled_tables(&[CloudsyncTableSpec {
+            table_name: "sessions".to_string(),
+            crdt_algo: None,
+            init_flags: None,
+            enabled: true,
+        }])
+        .await
+        .unwrap();
+
+        let mut write_connections = Vec::new();
+        for _ in 0..3 {
+            write_connections.push(db.pool().acquire().await.unwrap());
+        }
+        for (index, connection) in write_connections.iter_mut().enumerate() {
+            sqlx::query("INSERT INTO sessions (id, title) VALUES (?, 'Note')")
+                .bind(format!("session-{index}"))
+                .execute(&mut **connection)
+                .await
+                .unwrap();
+        }
+    }
+
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+    ))]
+    #[tokio::test]
+    async fn terminating_cloudsync_closes_a_single_pool_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(crate::DbOpenOptions {
+            storage: crate::DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(1),
+        })
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                title TEXT NOT NULL DEFAULT ''
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        db.cloudsync_init("sessions", None, None).await.unwrap();
+        {
+            let mut connection = db.lock_cloudsync_connection().await.unwrap();
+            sqlx::query("CREATE TEMP TABLE connection_marker (id INTEGER)")
+                .execute(&mut **connection.as_mut().unwrap())
+                .await
+                .unwrap();
+        }
+
+        db.cloudsync_terminate_and_close().await.unwrap();
+
+        let marker_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM sqlite_temp_master WHERE name = 'connection_marker'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(marker_count, 0);
+        sqlx::query("INSERT INTO sessions (id, title) VALUES ('session', 'Note')")
+            .execute(db.pool())
+            .await
+            .unwrap();
+    }
+
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+    ))]
+    #[tokio::test]
+    async fn terminating_cloudsync_closes_every_pool_connection() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(crate::DbOpenOptions {
+            storage: crate::DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(3),
+        })
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                title TEXT NOT NULL DEFAULT ''
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        db.cloudsync_init_enabled_tables(&[CloudsyncTableSpec {
+            table_name: "sessions".to_string(),
+            crdt_algo: None,
+            init_flags: None,
+            enabled: true,
+        }])
+        .await
+        .unwrap();
+
+        let mut connections = Vec::new();
+        for _ in 0..2 {
+            let mut connection = db.pool().acquire().await.unwrap();
+            sqlx::query("CREATE TEMP TABLE connection_marker (id INTEGER)")
+                .execute(&mut *connection)
+                .await
+                .unwrap();
+            connections.push(connection);
+        }
+        drop(connections);
+
+        db.cloudsync_terminate_and_close().await.unwrap();
+
+        let mut replacements = Vec::new();
+        for index in 0..3 {
+            let mut connection = db.pool().acquire().await.unwrap();
+            let marker_count: i64 = sqlx::query_scalar(
+                "SELECT COUNT(*) FROM sqlite_temp_master WHERE name = 'connection_marker'",
+            )
+            .fetch_one(&mut *connection)
+            .await
+            .unwrap();
+            assert_eq!(marker_count, 0);
+            sqlx::query("INSERT INTO sessions (id, title) VALUES (?, 'Note')")
+                .bind(format!("session-{index}"))
+                .execute(&mut *connection)
+                .await
+                .unwrap();
+            replacements.push(connection);
+        }
+    }
+
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+    ))]
+    #[tokio::test]
+    async fn initializes_replacement_pool_connections() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("cloudsync.db");
+        let db = Db::open(crate::DbOpenOptions {
+            storage: crate::DbStorage::Local(&db_path),
+            cloudsync_enabled: true,
+            journal_mode_wal: true,
+            foreign_keys: true,
+            max_connections: Some(2),
+        })
+        .await
+        .unwrap();
+        sqlx::query(
+            "CREATE TABLE sessions (
+                id TEXT PRIMARY KEY NOT NULL,
+                title TEXT NOT NULL DEFAULT ''
+            )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        db.cloudsync_init_enabled_tables(&[CloudsyncTableSpec {
+            table_name: "sessions".to_string(),
+            crdt_algo: None,
+            init_flags: None,
+            enabled: true,
+        }])
+        .await
+        .unwrap();
+
+        let connection = db.pool().acquire().await.unwrap();
+        connection.close().await.unwrap();
+        let mut replacement = db.pool().acquire().await.unwrap();
+
+        sqlx::query("INSERT INTO sessions (id, title) VALUES ('replacement', 'Note')")
+            .execute(&mut *replacement)
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn closes_pinned_connection_without_cloudsync_extension() {
+        let db = Db::connect_local_plain(tempfile::NamedTempFile::new().unwrap().path())
+            .await
+            .unwrap();
+        drop(db.lock_cloudsync_connection().await.unwrap());
+        assert!(db.cloudsync_connection.lock().await.is_some());
+
+        db.cloudsync_close_connection().await.unwrap();
+
+        assert!(db.cloudsync_connection.lock().await.is_none());
     }
 }

--- a/crates/db-core/src/cloudsync/runtime.rs
+++ b/crates/db-core/src/cloudsync/runtime.rs
@@ -88,18 +88,9 @@ impl Db {
                 .ok_or(CloudsyncRuntimeError::NotConfigured)?
         };
 
-        for table in config.enabled_tables() {
-            if let Err(error) = self
-                .cloudsync_init(
-                    &table.table_name,
-                    table.crdt_algo.as_deref(),
-                    table.init_flags,
-                )
-                .await
-            {
-                self.cleanup_failed_cloudsync_start(false).await;
-                return Err(error.into());
-            }
+        if let Err(error) = self.cloudsync_init_enabled_tables(&config.tables).await {
+            self.cleanup_failed_cloudsync_start(false).await;
+            return Err(error.into());
         }
 
         if let Err(error) = self.cloudsync_network_init(&config.connection_string).await {
@@ -167,20 +158,16 @@ impl Db {
 
         if self.cloudsync_enabled
             && self.has_cloudsync()
-            && let Err(error) = self.cloudsync_terminate().await
+            && let Err(error) = self.cloudsync_terminate_and_close().await
             && first_error.is_none()
         {
             first_error = Some(CloudsyncRuntimeError::from(error));
         }
 
-        let pinned_connection = self.cloudsync_connection.lock().await.take();
-        if let Some(connection) = pinned_connection
-            && let Err(error) = connection.close().await
+        if let Err(error) = self.cloudsync_close_connection().await
             && first_error.is_none()
         {
-            first_error = Some(CloudsyncRuntimeError::from(hypr_cloudsync::Error::from(
-                error,
-            )));
+            first_error = Some(CloudsyncRuntimeError::from(error));
         }
 
         let mut runtime = self.cloudsync_runtime.lock().unwrap();
@@ -229,11 +216,11 @@ impl Db {
         };
         let cleanup_result = self.cloudsync_network_cleanup().await;
         let terminate_result = if self.has_cloudsync() {
-            self.cloudsync_terminate().await
+            self.cloudsync_terminate_and_close().await
         } else {
             Ok(())
         };
-        self.cloudsync_connection.lock().await.take();
+        let close_result = self.cloudsync_close_connection().await;
 
         let logout_error = logout_result
             .as_ref()
@@ -262,6 +249,7 @@ impl Db {
             tracing::warn!(%error, "cloudsync cleanup after partial startup failed");
         }
         terminate_result?;
+        close_result?;
         Ok(())
     }
 
@@ -368,11 +356,13 @@ impl Db {
             tracing::warn!(%error, "cloudsync cleanup after failed startup failed");
         }
         if self.has_cloudsync()
-            && let Err(error) = self.cloudsync_terminate().await
+            && let Err(error) = self.cloudsync_terminate_and_close().await
         {
-            tracing::warn!(%error, "cloudsync termination after failed startup failed");
+            tracing::warn!(%error, "cloudsync teardown after failed startup failed");
         }
-        self.cloudsync_connection.lock().await.take();
+        if let Err(error) = self.cloudsync_close_connection().await {
+            tracing::warn!(%error, "cloudsync connection close after failed startup failed");
+        }
 
         let mut runtime = self.cloudsync_runtime.lock().unwrap();
         runtime.running = false;

--- a/crates/db-core/src/cloudsync/types.rs
+++ b/crates/db-core/src/cloudsync/types.rs
@@ -1,5 +1,6 @@
 use serde::{Deserialize, Serialize};
 
+pub use hypr_cloudsync::CloudsyncTableSpec;
 pub use hypr_cloudsync::NetworkResult as CloudsyncNetworkResult;
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -24,14 +25,6 @@ impl std::fmt::Debug for CloudsyncAuth {
                 .finish(),
         }
     }
-}
-
-#[derive(Clone, Debug, Eq, PartialEq, Serialize, Deserialize)]
-pub struct CloudsyncTableSpec {
-    pub table_name: String,
-    pub crdt_algo: Option<String>,
-    pub init_flags: Option<i64>,
-    pub enabled: bool,
 }
 
 #[derive(Clone, Eq, PartialEq, Serialize, Deserialize)]
@@ -115,10 +108,6 @@ impl CloudsyncRuntimeConfig {
         }
         self.connection_string = self.connection_string.trim().to_string();
         Ok(self)
-    }
-
-    pub(crate) fn enabled_tables(&self) -> impl Iterator<Item = &CloudsyncTableSpec> {
-        self.tables.iter().filter(|table| table.enabled)
     }
 }
 

--- a/crates/db-core/src/lib.rs
+++ b/crates/db-core/src/lib.rs
@@ -48,6 +48,7 @@ const SQLITE_BUSY_TIMEOUT: Duration = Duration::from_secs(5);
 pub struct Db {
     pub(crate) cloudsync_enabled: bool,
     pub(crate) cloudsync_path: Option<PathBuf>,
+    pub(crate) cloudsync_initializer: hypr_cloudsync::CloudsyncConnectionInitializer,
     pub(crate) cloudsync_connection: Arc<tokio::sync::Mutex<Option<PoolConnection<Sqlite>>>>,
     pub(crate) cloudsync_lifecycle: Arc<tokio::sync::Mutex<()>>,
     pub(crate) cloudsync_runtime: Arc<Mutex<CloudsyncRuntimeState>>,
@@ -93,12 +94,21 @@ impl Db {
             return Err(hypr_cloudsync::Error::WalRequired.into());
         }
 
+        let cloudsync_initializer = hypr_cloudsync::CloudsyncConnectionInitializer::default();
         let (change_notifier, pool_options) = match (options.cloudsync_enabled, options.storage) {
-            (true, DbStorage::Local(_)) => hypr_db_change::ChangeNotifier::new_with_cloudsync(),
+            (true, DbStorage::Local(_)) => {
+                hypr_db_change::ChangeNotifier::new_with_cloudsync(cloudsync_initializer.clone())
+            }
             (true, DbStorage::Memory) => hypr_db_change::ChangeNotifier::disabled(),
             (false, _) => hypr_db_change::ChangeNotifier::new(),
         };
-        connect_with_options(&options, pool_options, change_notifier).await
+        connect_with_options(
+            &options,
+            pool_options,
+            change_notifier,
+            cloudsync_initializer,
+        )
+        .await
     }
 
     pub fn change_notifier(&self) -> &hypr_db_change::ChangeNotifier {
@@ -114,7 +124,9 @@ impl Db {
             .create_if_missing(true)
             .pragma("journal_mode", "WAL");
         let (options, cloudsync_path) = hypr_cloudsync::apply(options)?;
-        let (change_notifier, pool_options) = hypr_db_change::ChangeNotifier::new_with_cloudsync();
+        let cloudsync_initializer = hypr_cloudsync::CloudsyncConnectionInitializer::default();
+        let (change_notifier, pool_options) =
+            hypr_db_change::ChangeNotifier::new_with_cloudsync(cloudsync_initializer.clone());
         let pool = pool_options
             .connect_with(options)
             .await
@@ -124,6 +136,7 @@ impl Db {
         Ok(Self {
             cloudsync_enabled: true,
             cloudsync_path: Some(cloudsync_path),
+            cloudsync_initializer,
             cloudsync_connection: Arc::new(tokio::sync::Mutex::new(None)),
             cloudsync_lifecycle: Arc::new(tokio::sync::Mutex::new(())),
             cloudsync_runtime: Arc::new(Mutex::new(CloudsyncRuntimeState::default())),
@@ -146,6 +159,7 @@ impl Db {
         Ok(Self {
             cloudsync_enabled: true,
             cloudsync_path: Some(cloudsync_path),
+            cloudsync_initializer: hypr_cloudsync::CloudsyncConnectionInitializer::default(),
             cloudsync_connection: Arc::new(tokio::sync::Mutex::new(None)),
             cloudsync_lifecycle: Arc::new(tokio::sync::Mutex::new(())),
             cloudsync_runtime: Arc::new(Mutex::new(CloudsyncRuntimeState::default())),
@@ -168,6 +182,7 @@ impl Db {
         Ok(Self {
             cloudsync_enabled: false,
             cloudsync_path: None,
+            cloudsync_initializer: hypr_cloudsync::CloudsyncConnectionInitializer::default(),
             cloudsync_connection: Arc::new(tokio::sync::Mutex::new(None)),
             cloudsync_lifecycle: Arc::new(tokio::sync::Mutex::new(())),
             cloudsync_runtime: Arc::new(Mutex::new(CloudsyncRuntimeState::default())),
@@ -188,6 +203,7 @@ impl Db {
         Ok(Self {
             cloudsync_enabled: false,
             cloudsync_path: None,
+            cloudsync_initializer: hypr_cloudsync::CloudsyncConnectionInitializer::default(),
             cloudsync_connection: Arc::new(tokio::sync::Mutex::new(None)),
             cloudsync_lifecycle: Arc::new(tokio::sync::Mutex::new(())),
             cloudsync_runtime: Arc::new(Mutex::new(CloudsyncRuntimeState::default())),
@@ -209,6 +225,7 @@ impl Db {
         Ok(Self {
             cloudsync_enabled: false,
             cloudsync_path: None,
+            cloudsync_initializer: hypr_cloudsync::CloudsyncConnectionInitializer::default(),
             cloudsync_connection: Arc::new(tokio::sync::Mutex::new(None)),
             cloudsync_lifecycle: Arc::new(tokio::sync::Mutex::new(())),
             cloudsync_runtime: Arc::new(Mutex::new(CloudsyncRuntimeState::default())),
@@ -226,6 +243,7 @@ async fn connect_with_options(
     options: &DbOpenOptions<'_>,
     pool_options: SqlitePoolOptions,
     change_notifier: hypr_db_change::ChangeNotifier,
+    cloudsync_initializer: hypr_cloudsync::CloudsyncConnectionInitializer,
 ) -> Result<Db, DbOpenError> {
     let mut connect_options = match options.storage {
         DbStorage::Local(path) => {
@@ -274,6 +292,7 @@ async fn connect_with_options(
     Ok(Db {
         cloudsync_enabled: options.cloudsync_enabled,
         cloudsync_path,
+        cloudsync_initializer,
         cloudsync_connection: Arc::new(tokio::sync::Mutex::new(None)),
         cloudsync_lifecycle: Arc::new(tokio::sync::Mutex::new(())),
         cloudsync_runtime: Arc::new(Mutex::new(CloudsyncRuntimeState::default())),

--- a/packages/changelog/content/1.2.1.md
+++ b/packages/changelog/content/1.2.1.md
@@ -1,0 +1,8 @@
+---
+date: "2026-07-16"
+summary: "Anarlog restores creating new notes and recordings after updating to 1.2.0."
+---
+
+## Fixes
+
+- Restored creating new notes and starting new recordings after updating to 1.2.0.


### PR DESCRIPTION
Summary:
- initialize enabled CloudSync tables across every pooled SQLite connection
- close failed-start connections instead of returning terminated contexts to the pool
- add the 1.2.1 hotfix changelog

Tests:
- cargo test -p db-core --lib
- cargo test -p db-migrate
- cargo check
- pnpm -F @hypr/changelog typecheck
- pnpm exec dprint fmt

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core local DB pooling and CloudSync lifecycle on the write path; behavior is well-covered by new integration tests but mistakes could still affect sync or local writes.
> 
> **Overview**
> Fixes **broken note/recording creation after CloudSync starts** by ensuring every SQLite pool connection is CloudSync-initialized, not just the pinned runtime connection.
> 
> Adds **`CloudsyncConnectionInitializer`** (shared table specs + `after_connect` hook) so **new** pool connections run `cloudsync_init` for enabled tables. **`cloudsync_init_enabled_tables`** applies init across **all** current pool connections and updates the initializer on success. **Stop/logout/failed-start teardown** now uses **`cloudsync_terminate_and_close`** to terminate and **close** pool connections instead of returning terminated contexts to the pool.
> 
> **`CloudsyncTableSpec`** moves to `hypr_cloudsync` and is re-exported from db-core. Includes **1.2.1 changelog** for the hotfix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b4d0eaeece3a111c0571fb445b4dd61c1358530d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->