### PR TITLE
Style destructive toast actions

### DIFF
--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
@@ -74,8 +74,12 @@ describe("UndoDeleteToast", () => {
       expect.objectContaining({
         id: "undo-delete:session-1",
         duration: Infinity,
-        action: expect.objectContaining({ label: "Undo" }),
-        cancel: expect.objectContaining({ label: "Delete" }),
+        actionButtonStyle: {
+          background: "hsl(var(--destructive))",
+          color: "hsl(var(--destructive-foreground))",
+        },
+        action: expect.objectContaining({ label: "Delete" }),
+        cancel: expect.objectContaining({ label: "Undo" }),
       }),
     );
 
@@ -128,7 +132,7 @@ describe("UndoDeleteToast", () => {
     const options =
       mocks.message.mock.calls[mocks.message.mock.calls.length - 1][1];
     await act(async () => {
-      options.action.onClick();
+      options.cancel.onClick();
       await Promise.resolve();
     });
 

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -138,13 +138,17 @@ function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
     sonnerToast.message(label, {
       id: toastId,
       duration: Infinity,
-      action: {
-        label: "Undo",
-        onClick: () => restoreGroup(group),
+      actionButtonStyle: {
+        background: "hsl(var(--destructive))",
+        color: "hsl(var(--destructive-foreground))",
       },
-      cancel: {
+      action: {
         label: "Delete",
         onClick: () => confirmGroup(group),
+      },
+      cancel: {
+        label: "Undo",
+        onClick: () => restoreGroup(group),
       },
     });
 

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -22,7 +22,7 @@ const Toaster = ({
         actionButton:
           "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",
         cancelButton:
-          "group-[.toast]:bg-muted group-[.toast]:text-muted-foreground",
+          "group-[.toast]:bg-transparent group-[.toast]:text-muted-foreground",
       },
     }}
     {...props}


### PR DESCRIPTION
Make the undo-delete confirmation button use the destructive color tokens and cover the styling in its focused test.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Presentation and button-slot mapping only; delete and undo behavior is unchanged aside from which Sonner button triggers each handler.
> 
> **Overview**
> The undo-delete Sonner toast now treats **Delete** as the primary **action** and **Undo** as **cancel**, so Sonner’s action slot can carry destructive styling. **Delete** uses `actionButtonStyle` with `--destructive` / `--destructive-foreground` tokens; handlers are unchanged (`confirmGroup` vs `restoreGroup`).
> 
> Shared `Toaster` styling updates **cancel** buttons from muted fill to **transparent** background so the secondary Undo control reads as a text-style action next to the red Delete button.
> 
> Tests assert the new labels, destructive `actionButtonStyle`, and batch restore via `cancel.onClick`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 81967d70fa521183ba8e0635e51aff2235f8bfde. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->