### PR TITLE
Restore startup with legacy import conflicts

### DIFF
--- a/crates/db-app/src/legacy_import.rs
+++ b/crates/db-app/src/legacy_import.rs
@@ -431,6 +431,7 @@ pub async fn apply_legacy_import_item(
     let mut imported_count = 0_i64;
     let mut matched_count = 0_i64;
     let mut conflict_count = 0_i64;
+    let mut missing_dependency_count = 0_usize;
 
     for row in &batch.rows {
         let outcome = if dry_run {
@@ -440,8 +441,11 @@ pub async fn apply_legacy_import_item(
         };
         match outcome {
             InsertOutcome::Inserted => imported_count += 1,
-            InsertOutcome::Matched | InsertOutcome::RetainedExisting => matched_count += 1,
+            InsertOutcome::Matched
+            | InsertOutcome::FilledFromLegacy
+            | InsertOutcome::RetainedExisting => matched_count += 1,
             InsertOutcome::Conflict => conflict_count += 1,
+            InsertOutcome::MissingDependency => missing_dependency_count += 1,
             InsertOutcome::DryRun => {}
         }
         record_import_target(&mut transaction, &item, row, outcome).await?;
@@ -449,7 +453,8 @@ pub async fn apply_legacy_import_item(
 
     let discovered_count = i64::try_from(batch.rows.len()).unwrap_or(i64::MAX)
         + i64::try_from(batch.skipped_count).unwrap_or(i64::MAX);
-    let skipped_count = i64::try_from(batch.skipped_count).unwrap_or(i64::MAX);
+    let skipped_count = i64::try_from(batch.skipped_count.saturating_add(missing_dependency_count))
+        .unwrap_or(i64::MAX);
     let status = if dry_run {
         "dry_run"
     } else if skipped_count > 0 || !batch.warning.is_empty() {
@@ -537,10 +542,12 @@ pub async fn finish_legacy_import_run(
     let skipped_count = aggregate.get::<i64, _>("skipped_count");
     let conflict_count = aggregate.get::<i64, _>("conflict_count");
     let error_count = aggregate.get::<i64, _>("error_count");
-    let status = if skipped_count == 0 && conflict_count == 0 && error_count == 0 {
-        "completed"
-    } else {
+    let status = if skipped_count > 0 || error_count > 0 {
         "completed_with_issues"
+    } else if conflict_count > 0 {
+        "completed_with_conflicts"
+    } else {
+        "completed"
     };
 
     sqlx::query(
@@ -626,8 +633,10 @@ pub async fn fail_legacy_import_run(
 enum InsertOutcome {
     Inserted,
     Matched,
+    FilledFromLegacy,
     RetainedExisting,
     Conflict,
+    MissingDependency,
     DryRun,
 }
 
@@ -636,8 +645,10 @@ impl InsertOutcome {
         match self {
             Self::Inserted => "inserted",
             Self::Matched => "matched",
+            Self::FilledFromLegacy => "filled_from_legacy",
             Self::RetainedExisting => "retained_existing",
             Self::Conflict => "conflict",
+            Self::MissingDependency => "missing_dependency",
             Self::DryRun => "dry_run",
         }
     }
@@ -974,10 +985,293 @@ async fn insert_row_if_missing(
         Ok(InsertOutcome::Inserted)
     } else if row_matches_existing(transaction, row).await? {
         Ok(InsertOutcome::Matched)
-    } else if row.existing_sqlite_is_authoritative() {
-        Ok(InsertOutcome::RetainedExisting)
+    } else if let Some(outcome) = reconcile_content_conflict(transaction, row).await? {
+        Ok(outcome)
+    } else if import_target_exists(transaction, row).await? {
+        Ok(if row.existing_sqlite_is_authoritative() {
+            InsertOutcome::RetainedExisting
+        } else {
+            InsertOutcome::Conflict
+        })
     } else {
-        Ok(InsertOutcome::Conflict)
+        Ok(InsertOutcome::MissingDependency)
+    }
+}
+
+async fn import_target_exists(
+    transaction: &mut Transaction<'_, Sqlite>,
+    row: &LegacyImportRow,
+) -> Result<bool, sqlx::Error> {
+    let query = format!(
+        "SELECT EXISTS(SELECT 1 FROM {} WHERE id = ?)",
+        row.table_name()
+    );
+    sqlx::query_scalar(sqlx::AssertSqlSafe(query.as_str()))
+        .bind(row.id())
+        .fetch_one(&mut **transaction)
+        .await
+}
+
+async fn reconcile_content_conflict(
+    transaction: &mut Transaction<'_, Sqlite>,
+    row: &LegacyImportRow,
+) -> Result<Option<InsertOutcome>, sqlx::Error> {
+    match row {
+        LegacyImportRow::Document(row) => {
+            let Some((session_id, title, body_format, body, deleted_at)) =
+                sqlx::query_as::<_, (String, String, String, String, Option<String>)>(
+                    "SELECT session_id, title, body_format, body, deleted_at
+                     FROM session_documents
+                     WHERE id = ?",
+                )
+                .bind(&row.id)
+                .fetch_optional(&mut **transaction)
+                .await?
+            else {
+                return Ok(None);
+            };
+
+            if deleted_at.is_some() || session_id != row.session_id {
+                return Ok(None);
+            }
+
+            let existing_empty = document_body_is_empty(&body_format, &body);
+            let incoming_empty = document_body_is_empty(&row.body_format, &row.body);
+            if !existing_empty && incoming_empty {
+                return Ok(Some(InsertOutcome::RetainedExisting));
+            }
+
+            let bodies_resolve =
+                document_bodies_are_equivalent(&body_format, &body, row) || existing_empty;
+            let existing_title_empty = title.trim().is_empty();
+            let incoming_title_empty = row.title.trim().is_empty();
+            let titles_resolve = existing_title_empty || incoming_title_empty || title == row.title;
+            if !bodies_resolve || !titles_resolve {
+                return Ok(None);
+            }
+
+            let fill_body = existing_empty && !incoming_empty;
+            let fill_title = existing_title_empty && !incoming_title_empty;
+            if !fill_body && !fill_title {
+                return Ok(Some(InsertOutcome::RetainedExisting));
+            }
+
+            if !fill_body {
+                let result = sqlx::query(
+                    "UPDATE session_documents
+                     SET title = ?
+                     WHERE id = ?
+                       AND session_id = ?
+                       AND title IS ?
+                       AND body_format IS ?
+                       AND body IS ?
+                       AND deleted_at IS NULL",
+                )
+                .bind(&row.title)
+                .bind(&row.id)
+                .bind(&row.session_id)
+                .bind(&title)
+                .bind(&body_format)
+                .bind(&body)
+                .execute(&mut **transaction)
+                .await?;
+
+                return Ok((result.rows_affected() == 1).then_some(InsertOutcome::FilledFromLegacy));
+            }
+
+            let result = sqlx::query(
+                "UPDATE session_documents
+                 SET kind = ?,
+                     template_id = ?,
+                     title = CASE WHEN ? THEN title ELSE ? END,
+                     body_format = ?,
+                     body = ?,
+                     source_hash = ?,
+                     sort_order = ?,
+                     created_by = CASE WHEN ? = '' THEN created_by ELSE ? END,
+                     updated_by = CASE WHEN ? = '' THEN updated_by ELSE ? END,
+                     created_at = CASE WHEN ? = '' THEN created_at ELSE ? END,
+                     updated_at = CASE WHEN ? = '' THEN updated_at ELSE ? END
+                 WHERE id = ?
+                   AND session_id = ?
+                   AND title IS ?
+                   AND body_format IS ?
+                   AND body IS ?
+                   AND deleted_at IS NULL",
+            )
+            .bind(&row.kind)
+            .bind(&row.template_id)
+            .bind(incoming_title_empty)
+            .bind(&row.title)
+            .bind(&row.body_format)
+            .bind(&row.body)
+            .bind(&row.source_hash)
+            .bind(row.sort_order)
+            .bind(&row.created_by)
+            .bind(&row.created_by)
+            .bind(&row.created_by)
+            .bind(&row.created_by)
+            .bind(&row.created_at)
+            .bind(&row.created_at)
+            .bind(&row.updated_at)
+            .bind(&row.updated_at)
+            .bind(&row.id)
+            .bind(&row.session_id)
+            .bind(&title)
+            .bind(&body_format)
+            .bind(&body)
+            .execute(&mut **transaction)
+            .await?;
+
+            Ok((result.rows_affected() == 1).then_some(InsertOutcome::FilledFromLegacy))
+        }
+        LegacyImportRow::Transcript(row) => {
+            let Some((session_id, memo, words_json, speaker_hints_json, deleted_at)) =
+                sqlx::query_as::<_, (String, String, String, String, Option<String>)>(
+                    "SELECT session_id, memo, words_json, speaker_hints_json, deleted_at
+                     FROM transcripts
+                     WHERE id = ?",
+                )
+                .bind(&row.id)
+                .fetch_optional(&mut **transaction)
+                .await?
+            else {
+                return Ok(None);
+            };
+
+            if deleted_at.is_some() || session_id != row.session_id {
+                return Ok(None);
+            }
+
+            let existing_empty =
+                transcript_payload_is_empty(&memo, &words_json, &speaker_hints_json);
+            let incoming_empty =
+                transcript_payload_is_empty(&row.memo, &row.words_json, &row.speaker_hints_json);
+            if transcript_payloads_are_equivalent(&memo, &words_json, &speaker_hints_json, row)
+                || incoming_empty
+            {
+                return Ok(Some(InsertOutcome::RetainedExisting));
+            }
+            if !existing_empty {
+                return Ok(None);
+            }
+
+            let result = sqlx::query(
+                "UPDATE transcripts
+                 SET owner_user_id = CASE WHEN owner_user_id = '' THEN ? ELSE owner_user_id END,
+                     started_at_ms = ?,
+                     ended_at_ms = ?,
+                     memo = ?,
+                     words_json = ?,
+                     speaker_hints_json = ?,
+                     created_at = CASE WHEN ? = '' THEN created_at ELSE ? END,
+                     updated_at = CASE WHEN ? = '' THEN updated_at ELSE ? END
+                 WHERE id = ?
+                   AND session_id = ?
+                   AND memo IS ?
+                   AND words_json IS ?
+                   AND speaker_hints_json IS ?
+                   AND deleted_at IS NULL",
+            )
+            .bind(&row.owner_user_id)
+            .bind(row.started_at_ms)
+            .bind(row.ended_at_ms)
+            .bind(&row.memo)
+            .bind(&row.words_json)
+            .bind(&row.speaker_hints_json)
+            .bind(&row.created_at)
+            .bind(&row.created_at)
+            .bind(&row.created_at)
+            .bind(&row.created_at)
+            .bind(&row.id)
+            .bind(&row.session_id)
+            .bind(&memo)
+            .bind(&words_json)
+            .bind(&speaker_hints_json)
+            .execute(&mut **transaction)
+            .await?;
+
+            Ok((result.rows_affected() == 1).then_some(InsertOutcome::FilledFromLegacy))
+        }
+        _ => Ok(None),
+    }
+}
+
+fn document_bodies_are_equivalent(
+    existing_format: &str,
+    existing_body: &str,
+    incoming: &LegacyDocument,
+) -> bool {
+    existing_format == incoming.body_format && existing_body == incoming.body
+}
+
+fn document_body_is_empty(body_format: &str, body: &str) -> bool {
+    let body = body.trim();
+    if body.is_empty() || body == "&nbsp;" {
+        return true;
+    }
+    if body_format != "prosemirror_json" {
+        return false;
+    }
+
+    let Ok(serde_json::Value::Object(document)) = serde_json::from_str(body) else {
+        return false;
+    };
+    if document.get("type").and_then(serde_json::Value::as_str) != Some("doc") {
+        return false;
+    }
+    let Some(content) = document.get("content") else {
+        return true;
+    };
+    let Some(content) = content.as_array() else {
+        return false;
+    };
+
+    content.is_empty()
+        || content.iter().all(|node| {
+            let Some(node) = node.as_object() else {
+                return false;
+            };
+            node.get("type").and_then(serde_json::Value::as_str) == Some("paragraph")
+                && node
+                    .get("content")
+                    .is_none_or(|content| content.as_array().is_some_and(Vec::is_empty))
+        })
+}
+
+fn transcript_payloads_are_equivalent(
+    existing_memo: &str,
+    existing_words_json: &str,
+    existing_speaker_hints_json: &str,
+    incoming: &LegacyTranscript,
+) -> bool {
+    existing_memo == incoming.memo
+        && json_payloads_are_equivalent(existing_words_json, &incoming.words_json)
+        && json_payloads_are_equivalent(existing_speaker_hints_json, &incoming.speaker_hints_json)
+}
+
+fn transcript_payload_is_empty(memo: &str, words_json: &str, speaker_hints_json: &str) -> bool {
+    memo.trim().is_empty()
+        && json_array_is_empty(words_json)
+        && json_array_is_empty(speaker_hints_json)
+}
+
+fn json_array_is_empty(value: &str) -> bool {
+    let value = value.trim();
+    value.is_empty()
+        || matches!(
+            serde_json::from_str::<serde_json::Value>(value),
+            Ok(serde_json::Value::Array(items)) if items.is_empty()
+        )
+}
+
+fn json_payloads_are_equivalent(left: &str, right: &str) -> bool {
+    match (
+        serde_json::from_str::<serde_json::Value>(left),
+        serde_json::from_str::<serde_json::Value>(right),
+    ) {
+        (Ok(left), Ok(right)) => left == right,
+        _ => left == right,
     }
 }
 
@@ -1442,6 +1736,57 @@ mod tests {
         }
     }
 
+    async fn begin_run_with_session(db: &Db, run_id: &str) {
+        begin_legacy_import_run(db.pool(), run_id, "/vault", false)
+            .await
+            .unwrap();
+        apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "session-item",
+                run_id,
+                source_path: "sessions/session-1/_meta.json",
+                source_kind: "session_meta",
+                source_sha256: "session-hash",
+            },
+            &session_batch(),
+            false,
+        )
+        .await
+        .unwrap();
+    }
+
+    fn document_row(id: &str, body_format: &str, body: &str) -> LegacyImportRow {
+        LegacyImportRow::Document(LegacyDocument {
+            id: id.to_string(),
+            session_id: "session-1".to_string(),
+            kind: "note".to_string(),
+            template_id: String::new(),
+            title: String::new(),
+            body_format: body_format.to_string(),
+            body: body.to_string(),
+            source_hash: format!("{id}-hash"),
+            sort_order: 0,
+            created_by: String::new(),
+            created_at: String::new(),
+            updated_at: String::new(),
+        })
+    }
+
+    fn transcript_row(id: &str, words_json: &str) -> LegacyImportRow {
+        LegacyImportRow::Transcript(LegacyTranscript {
+            id: id.to_string(),
+            owner_user_id: "user-1".to_string(),
+            session_id: "session-1".to_string(),
+            started_at_ms: 10,
+            ended_at_ms: Some(20),
+            memo: String::new(),
+            words_json: words_json.to_string(),
+            speaker_hints_json: "[]".to_string(),
+            created_at: "2026-07-10T12:00:00Z".to_string(),
+        })
+    }
+
     #[tokio::test]
     async fn import_fails_closed_without_a_workspace_binding() {
         let db = test_db().await;
@@ -1552,6 +1897,379 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(title, "Planning");
+    }
+
+    #[tokio::test]
+    async fn orphaned_session_document_is_a_blocking_missing_dependency() {
+        let db = test_db().await;
+        begin_legacy_import_run(db.pool(), "run-1", "/vault", false)
+            .await
+            .unwrap();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "document-item",
+                run_id: "run-1",
+                source_path: "sessions/missing/_memo.md",
+                source_kind: "session_document",
+                source_sha256: "document-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![document_row("document-1", "markdown", "Orphaned note")],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.imported_count, 0);
+        assert_eq!(result.matched_count, 0);
+        assert_eq!(result.conflict_count, 0);
+        assert_eq!(result.skipped_count, 1);
+        let target_status: String = sqlx::query_scalar(
+            "SELECT status FROM migration_import_targets
+             WHERE run_id = 'run-1' AND target_id = 'document-1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(target_status, "missing_dependency");
+        assert_eq!(
+            finish_legacy_import_run(db.pool(), "run-1").await.unwrap(),
+            "completed_with_issues"
+        );
+    }
+
+    #[tokio::test]
+    async fn nonempty_legacy_document_fills_an_empty_sqlite_document() {
+        let db = test_db().await;
+        begin_run_with_session(&db, "run-1").await;
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, title, body_format, body)
+             VALUES ('document-1', 'session-1', 'note', 'Keep this title',
+                     'prosemirror_json',
+                     '{\"type\":\"doc\",\"content\":[{\"type\":\"paragraph\"}]}')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let mut incoming = document_row("document-1", "markdown", "Legacy note");
+        let LegacyImportRow::Document(row) = &mut incoming else {
+            unreachable!();
+        };
+        row.title = "  \n".to_string();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "document-item",
+                run_id: "run-1",
+                source_path: "sessions/session-1/_memo.md",
+                source_kind: "session_document",
+                source_sha256: "document-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![incoming],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matched_count, 1);
+        assert_eq!(result.conflict_count, 0);
+        let document: (String, String, String) = sqlx::query_as(
+            "SELECT title, body_format, body FROM session_documents WHERE id = 'document-1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            document,
+            (
+                "Keep this title".to_string(),
+                "markdown".to_string(),
+                "Legacy note".to_string()
+            )
+        );
+        let target_status: String = sqlx::query_scalar(
+            "SELECT status FROM migration_import_targets
+             WHERE run_id = 'run-1' AND target_id = 'document-1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(target_status, "filled_from_legacy");
+        assert_eq!(
+            finish_legacy_import_run(db.pool(), "run-1").await.unwrap(),
+            "completed"
+        );
+    }
+
+    #[tokio::test]
+    async fn nonempty_sqlite_document_wins_over_an_empty_legacy_document() {
+        let db = test_db().await;
+        begin_run_with_session(&db, "run-1").await;
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, body_format, body)
+             VALUES ('document-1', 'session-1', 'note', 'markdown', 'SQLite note')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let mut incoming = document_row("document-1", "markdown", "  \n");
+        let LegacyImportRow::Document(row) = &mut incoming else {
+            unreachable!();
+        };
+        row.title = "Legacy title".to_string();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "document-item",
+                run_id: "run-1",
+                source_path: "sessions/session-1/_memo.md",
+                source_kind: "session_document",
+                source_sha256: "document-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![incoming],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matched_count, 1);
+        assert_eq!(result.conflict_count, 0);
+        let document: (String, String) =
+            sqlx::query_as("SELECT title, body FROM session_documents WHERE id = 'document-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(document, (String::new(), "SQLite note".to_string()));
+        assert_eq!(
+            finish_legacy_import_run(db.pool(), "run-1").await.unwrap(),
+            "completed"
+        );
+    }
+
+    #[tokio::test]
+    async fn document_title_is_filled_only_when_the_existing_title_is_empty() {
+        let db = test_db().await;
+        begin_run_with_session(&db, "run-1").await;
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, title, body_format, body)
+             VALUES ('document-1', 'session-1', 'note', '', 'markdown', 'Same note')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        let mut incoming = document_row("document-1", "markdown", "Same note");
+        let LegacyImportRow::Document(row) = &mut incoming else {
+            unreachable!();
+        };
+        row.title = "Legacy title".to_string();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "document-item",
+                run_id: "run-1",
+                source_path: "sessions/session-1/_memo.md",
+                source_kind: "session_document",
+                source_sha256: "document-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![incoming],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matched_count, 1);
+        assert_eq!(result.conflict_count, 0);
+        let title: String =
+            sqlx::query_scalar("SELECT title FROM session_documents WHERE id = 'document-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(title, "Legacy title");
+    }
+
+    #[tokio::test]
+    async fn divergent_nonempty_document_titles_remain_conflicted() {
+        let db = test_db().await;
+        begin_run_with_session(&db, "run-1").await;
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, title, body_format, body)
+             VALUES ('document-1', 'session-1', 'note', 'SQLite title',
+                     'markdown', 'Same note')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        let mut incoming = document_row("document-1", "markdown", "Same note");
+        let LegacyImportRow::Document(row) = &mut incoming else {
+            unreachable!();
+        };
+        row.title = "Legacy title".to_string();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "document-item",
+                run_id: "run-1",
+                source_path: "sessions/session-1/_memo.md",
+                source_kind: "session_document",
+                source_sha256: "document-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![incoming],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matched_count, 0);
+        assert_eq!(result.conflict_count, 1);
+        let title: String =
+            sqlx::query_scalar("SELECT title FROM session_documents WHERE id = 'document-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(title, "SQLite title");
+    }
+
+    #[tokio::test]
+    async fn divergent_nonempty_documents_remain_conflicted_and_unchanged() {
+        let db = test_db().await;
+        begin_run_with_session(&db, "run-1").await;
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, body_format, body)
+             VALUES ('document-1', 'session-1', 'note', 'markdown', 'SQLite note')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "document-item",
+                run_id: "run-1",
+                source_path: "sessions/session-1/_memo.md",
+                source_kind: "session_document",
+                source_sha256: "document-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![document_row("document-1", "markdown", "Legacy note")],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matched_count, 0);
+        assert_eq!(result.conflict_count, 1);
+        let body: String =
+            sqlx::query_scalar("SELECT body FROM session_documents WHERE id = 'document-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(body, "SQLite note");
+        assert_eq!(
+            finish_legacy_import_run(db.pool(), "run-1").await.unwrap(),
+            "completed_with_conflicts"
+        );
+        let parity_verified: bool = sqlx::query_scalar(
+            "SELECT parity_verified FROM storage_migration_state WHERE id = 'legacy_v1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert!(!parity_verified);
+    }
+
+    #[tokio::test]
+    async fn transcript_reconciliation_only_fills_an_empty_payload() {
+        let db = test_db().await;
+        begin_run_with_session(&db, "run-1").await;
+        sqlx::query(
+            "INSERT INTO transcripts
+             (id, session_id, words_json, speaker_hints_json)
+             VALUES
+             ('fill', 'session-1', '[]', '[]'),
+             ('retain', 'session-1', '[{\"id\":\"sqlite\"}]', '[]'),
+             ('equivalent', 'session-1', '[ { \"id\": \"same\" } ]', '[]'),
+             ('conflict', 'session-1', '[{\"id\":\"sqlite\"}]', '[]')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let result = apply_legacy_import_item(
+            db.pool(),
+            LegacyImportItem {
+                id: "transcript-item",
+                run_id: "run-1",
+                source_path: "sessions/session-1/transcript.json",
+                source_kind: "transcript",
+                source_sha256: "transcript-hash",
+            },
+            &LegacyImportBatch {
+                rows: vec![
+                    transcript_row("fill", "[{\"id\":\"legacy\"}]"),
+                    transcript_row("retain", "[]"),
+                    transcript_row("equivalent", "[{\"id\":\"same\"}]"),
+                    transcript_row("conflict", "[{\"id\":\"legacy\"}]"),
+                ],
+                ..Default::default()
+            },
+            false,
+        )
+        .await
+        .unwrap();
+
+        assert_eq!(result.matched_count, 3);
+        assert_eq!(result.conflict_count, 1);
+        let payloads: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, words_json FROM transcripts ORDER BY id")
+                .fetch_all(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            payloads,
+            vec![
+                ("conflict".to_string(), "[{\"id\":\"sqlite\"}]".to_string()),
+                (
+                    "equivalent".to_string(),
+                    "[ { \"id\": \"same\" } ]".to_string()
+                ),
+                ("fill".to_string(), "[{\"id\":\"legacy\"}]".to_string()),
+                ("retain".to_string(), "[{\"id\":\"sqlite\"}]".to_string()),
+            ]
+        );
+        assert_eq!(
+            finish_legacy_import_run(db.pool(), "run-1").await.unwrap(),
+            "completed_with_conflicts"
+        );
     }
 
     #[tokio::test]

--- a/packages/changelog/content/1.2.2.md
+++ b/packages/changelog/content/1.2.2.md
@@ -1,0 +1,8 @@
+---
+date: "2026-07-16"
+summary: "Anarlog opens reliably when older note or transcript files differ from their SQLite copies."
+---
+
+## Fixes
+
+- Restored startup when older note or transcript files differ from their SQLite copies, while keeping those files available for recovery.

--- a/plugins/db/src/import/legacy_vault.rs
+++ b/plugins/db/src/import/legacy_vault.rs
@@ -72,7 +72,11 @@ impl SourceFile {
                 .map_or(self.relative_path.as_str(), |(directory, _)| directory),
             _ => self.relative_path.as_str(),
         };
-        let dependency_order = u8::from(self.kind != SourceKind::SessionMeta);
+        let dependency_order = match self.kind {
+            SourceKind::SessionMeta => 0,
+            SourceKind::SessionDocument if self.relative_path.ends_with("/.md") => 2,
+            _ => 1,
+        };
 
         (group, dependency_order, self.relative_path.as_str())
     }
@@ -81,14 +85,15 @@ impl SourceFile {
 #[derive(Debug)]
 struct SourceDiscovery {
     files: Vec<SourceFile>,
-    shadowed_summaries: Vec<ShadowedSummary>,
+    summary_pairs: Vec<SummaryPair>,
 }
 
 #[derive(Debug)]
-struct ShadowedSummary {
+struct SummaryPair {
     hidden_relative_path: String,
     canonical_relative_path: String,
     hidden_document: LegacyDocument,
+    hide_hidden_source: bool,
 }
 
 pub async fn import_legacy_vault(
@@ -131,8 +136,14 @@ pub async fn import_legacy_vault(
         };
         let source_sha256 = sha256(&bytes);
         let item_id = stable_id(&format!("{run_id}:{}", source.relative_path));
+        let recheck_summary_pair = discovery.summary_pairs.iter().any(|summary| {
+            summary.canonical_relative_path == source.relative_path
+                || (!summary.hide_hidden_source
+                    && summary.hidden_relative_path == source.relative_path)
+        });
 
         if !dry_run
+            && !recheck_summary_pair
             && hypr_db_app::legacy_source_already_imported(
                 pool,
                 &source.relative_path,
@@ -165,13 +176,13 @@ pub async fn import_legacy_vault(
         match parse_source(vault_base, &source, &bytes, &source_sha256) {
             Ok(batch) => {
                 if !dry_run
-                    && let Some(shadowed) = discovery
-                        .shadowed_summaries
+                    && let Some(summary_pair) = discovery
+                        .summary_pairs
                         .iter()
                         .find(|summary| summary.canonical_relative_path == source.relative_path)
                     && let Some(LegacyImportRow::Document(document)) = batch.rows.first()
                 {
-                    promote_canonical_summary(pool, shadowed, document).await?;
+                    promote_canonical_summary(pool, summary_pair, document).await?;
                 }
                 hypr_db_app::apply_legacy_import_item(pool, item, &batch, dry_run).await?;
             }
@@ -189,19 +200,18 @@ fn discover_sources(vault_base: &Path) -> std::io::Result<SourceDiscovery> {
     if !vault_base.exists() {
         return Ok(SourceDiscovery {
             files: Vec::new(),
-            shadowed_summaries: Vec::new(),
+            summary_pairs: Vec::new(),
         });
     }
 
     let mut files = Vec::new();
-    let mut shadowed_summaries = Vec::new();
-    collect_files(vault_base, vault_base, &mut files, &mut shadowed_summaries)?;
+    let mut summary_pairs = Vec::new();
+    collect_files(vault_base, vault_base, &mut files, &mut summary_pairs)?;
     files.sort_by(|left, right| left.import_sort_key().cmp(&right.import_sort_key()));
-    shadowed_summaries
-        .sort_by(|left, right| left.hidden_relative_path.cmp(&right.hidden_relative_path));
+    summary_pairs.sort_by(|left, right| left.hidden_relative_path.cmp(&right.hidden_relative_path));
     Ok(SourceDiscovery {
         files,
-        shadowed_summaries,
+        summary_pairs,
     })
 }
 
@@ -209,7 +219,7 @@ fn collect_files(
     vault_base: &Path,
     directory: &Path,
     files: &mut Vec<SourceFile>,
-    shadowed_summaries: &mut Vec<ShadowedSummary>,
+    summary_pairs: &mut Vec<SummaryPair>,
 ) -> std::io::Result<()> {
     let mut entries = std::fs::read_dir(directory)?.collect::<Result<Vec<_>, _>>()?;
     entries.sort_by_key(std::fs::DirEntry::file_name);
@@ -217,14 +227,17 @@ fn collect_files(
     for entry in entries {
         let path = entry.path();
         if path.is_dir() {
-            collect_files(vault_base, &path, files, shadowed_summaries)?;
+            collect_files(vault_base, &path, files, summary_pairs)?;
             continue;
         }
 
         let relative_path = normalized_relative_path(vault_base, &path);
-        if let Some(shadowed) = shadowed_summary(vault_base, &path, &relative_path) {
-            shadowed_summaries.push(shadowed);
-            continue;
+        if let Some(summary_pair) = summary_pair(vault_base, &path, &relative_path) {
+            let hide_hidden_source = summary_pair.hide_hidden_source;
+            summary_pairs.push(summary_pair);
+            if hide_hidden_source {
+                continue;
+            }
         }
         if let Some(kind) = classify_source(&relative_path) {
             files.push(SourceFile {
@@ -238,11 +251,7 @@ fn collect_files(
     Ok(())
 }
 
-fn shadowed_summary(
-    vault_base: &Path,
-    path: &Path,
-    relative_path: &str,
-) -> Option<ShadowedSummary> {
+fn summary_pair(vault_base: &Path, path: &Path, relative_path: &str) -> Option<SummaryPair> {
     if path.file_name()?.to_str()? != ".md" {
         return None;
     }
@@ -275,23 +284,39 @@ fn shadowed_summary(
     {
         return None;
     }
+    let hidden_empty = legacy_document_body_is_empty(&hidden_document.body);
+    let canonical_empty = legacy_document_body_is_empty(&canonical_document.body);
+    let hidden_title_empty = hidden_document.title.trim().is_empty();
+    let canonical_title_empty = canonical_document.title.trim().is_empty();
+    let hide_hidden_source = !((!hidden_empty && canonical_empty)
+        || (!hidden_empty && !canonical_empty && hidden_document.body != canonical_document.body)
+        || (!hidden_title_empty && canonical_title_empty)
+        || (!hidden_title_empty
+            && !canonical_title_empty
+            && hidden_document.title != canonical_document.title));
 
-    Some(ShadowedSummary {
+    Some(SummaryPair {
         hidden_relative_path: relative_path.to_string(),
         canonical_relative_path: normalized_relative_path(vault_base, &canonical_path),
         hidden_document,
+        hide_hidden_source,
     })
 }
 
 async fn promote_canonical_summary(
     pool: &SqlitePool,
-    shadowed: &ShadowedSummary,
+    summary_pair: &SummaryPair,
     canonical: &LegacyDocument,
 ) -> Result<(), sqlx::Error> {
-    let hidden = &shadowed.hidden_document;
+    let hidden = &summary_pair.hidden_document;
+    if legacy_document_body_is_empty(&canonical.body) {
+        return Ok(());
+    }
     sqlx::query(
         "UPDATE session_documents
-         SET session_id = ?, kind = ?, template_id = ?, title = ?, body_format = ?, body = ?,
+         SET session_id = ?, kind = ?, template_id = ?,
+             title = CASE WHEN ? THEN title ELSE ? END,
+             body_format = ?, body = ?,
              source_hash = ?, sort_order = ?, created_by = ?, updated_by = ?, created_at = ?,
              updated_at = ?
          WHERE id = ?
@@ -327,6 +352,7 @@ async fn promote_canonical_summary(
     .bind(&canonical.session_id)
     .bind(&canonical.kind)
     .bind(&canonical.template_id)
+    .bind(canonical.title.trim().is_empty())
     .bind(&canonical.title)
     .bind(&canonical.body_format)
     .bind(&canonical.body)
@@ -348,12 +374,17 @@ async fn promote_canonical_summary(
     .bind(&hidden.created_by)
     .bind(&hidden.created_at)
     .bind(&hidden.updated_at)
-    .bind(&shadowed.hidden_relative_path)
+    .bind(&summary_pair.hidden_relative_path)
     .bind(&hidden.source_hash)
     .execute(pool)
     .await?;
 
     Ok(())
+}
+
+fn legacy_document_body_is_empty(body: &str) -> bool {
+    let body = body.trim();
+    body.is_empty() || body == "&nbsp;"
 }
 
 fn classify_source(relative_path: &str) -> Option<SourceKind> {
@@ -1126,7 +1157,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn canonical_summary_shadows_same_id_hidden_artifact() {
+    async fn nonempty_canonical_summary_shadows_empty_hidden_artifact() {
         let db = test_db().await;
         let dir = tempfile::tempdir().unwrap();
         let session_dir = dir.path().join("sessions/session-1");
@@ -1138,7 +1169,7 @@ mod tests {
         .unwrap();
         std::fs::write(
             session_dir.join(".md"),
-            "---\nid: summary-1\nsession_id: session-1\ntemplate_id: ''\ntitle: Summary\n---\n\nStale summary",
+            "---\nid: summary-1\nsession_id: session-1\ntemplate_id: ''\ntitle: Summary\n---\n\n",
         )
         .unwrap();
         std::fs::write(
@@ -1177,6 +1208,118 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn nonempty_hidden_summary_is_not_shadowed_by_empty_canonical_summary() {
+        let db = test_db().await;
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join("sessions/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("_meta.json"),
+            r#"{"id":"session-1","created_at":"2026-07-12T01:00:00Z","title":"Planning"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            session_dir.join(".md"),
+            "---\nid: summary-1\nsession_id: session-1\ntemplate_id: ''\ntitle: Summary\n---\n\nKeep this summary",
+        )
+        .unwrap();
+        std::fs::write(
+            session_dir.join("_summary.md"),
+            "---\nid: summary-1\nsession_id: session-1\ntitle: Summary\n---\n\n",
+        )
+        .unwrap();
+
+        let run_id = import_legacy_vault(db.pool(), dir.path(), false)
+            .await
+            .unwrap();
+
+        let run: (String, i64) =
+            sqlx::query_as("SELECT status, conflict_count FROM migration_import_runs WHERE id = ?")
+                .bind(&run_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let body: String =
+            sqlx::query_scalar("SELECT body FROM session_documents WHERE id = 'summary-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let hidden_item_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM migration_import_items
+             WHERE run_id = ? AND source_path = 'sessions/session-1/.md'",
+        )
+        .bind(&run_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(run, ("completed".to_string(), 0));
+        assert_eq!(body, "Keep this summary");
+        assert_eq!(hidden_item_count, 1);
+    }
+
+    #[tokio::test]
+    async fn divergent_summaries_import_canonical_content_and_preserve_the_hidden_conflict() {
+        let db = test_db().await;
+        let dir = tempfile::tempdir().unwrap();
+        let session_dir = dir.path().join("sessions/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("_meta.json"),
+            r#"{"id":"session-1","created_at":"2026-07-12T01:00:00Z","title":"Planning"}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            session_dir.join(".md"),
+            "---\nid: summary-1\nsession_id: session-1\ntitle: Summary\n---\n\nHidden recovery copy",
+        )
+        .unwrap();
+        std::fs::write(
+            session_dir.join("_summary.md"),
+            "---\nid: summary-1\nsession_id: session-1\ntitle: Summary\n---\n\nCanonical summary",
+        )
+        .unwrap();
+
+        let run_id = import_legacy_vault(db.pool(), dir.path(), false)
+            .await
+            .unwrap();
+
+        let run: (String, i64) =
+            sqlx::query_as("SELECT status, conflict_count FROM migration_import_runs WHERE id = ?")
+                .bind(&run_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let body: String =
+            sqlx::query_scalar("SELECT body FROM session_documents WHERE id = 'summary-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let targets: Vec<(String, String)> = sqlx::query_as(
+            "SELECT source_path, status FROM migration_import_targets
+             WHERE run_id = ? AND table_name = 'session_documents'
+             ORDER BY source_path",
+        )
+        .bind(&run_id)
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(run, ("completed_with_conflicts".to_string(), 1));
+        assert_eq!(body, "Canonical summary");
+        assert_eq!(
+            targets,
+            vec![
+                ("sessions/session-1/.md".to_string(), "conflict".to_string()),
+                (
+                    "sessions/session-1/_summary.md".to_string(),
+                    "inserted".to_string()
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
     async fn empty_session_title_is_recovered_from_summary_heading() {
         let db = test_db().await;
         let dir = tempfile::tempdir().unwrap();
@@ -1205,7 +1348,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn failed_hidden_summary_import_is_repaired_from_canonical_source() {
+    async fn divergent_nonempty_summaries_remain_conflicted_without_overwrite() {
         let db = test_db().await;
         let dir = tempfile::tempdir().unwrap();
         let session_dir = dir.path().join("sessions/session-1");
@@ -1281,8 +1424,17 @@ mod tests {
             hypr_db_app::finish_legacy_import_run(db.pool(), failed_run_id)
                 .await
                 .unwrap(),
-            "completed_with_issues"
+            "completed_with_conflicts"
         );
+        sqlx::query(
+            "UPDATE migration_import_runs
+             SET status = 'completed_with_issues'
+             WHERE id = ?",
+        )
+        .bind(failed_run_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
 
         let recovery_run_id = import_legacy_vault(db.pool(), dir.path(), false)
             .await
@@ -1306,8 +1458,8 @@ mod tests {
         .unwrap();
 
         assert_eq!(body, "Current summary");
-        assert_eq!(status, "completed");
-        assert!(parity_verified);
+        assert_eq!(status, "completed_with_conflicts");
+        assert!(!parity_verified);
     }
 
     #[tokio::test]

--- a/plugins/db/src/import/mod.rs
+++ b/plugins/db/src/import/mod.rs
@@ -18,10 +18,10 @@ pub async fn import_legacy_data<R: tauri::Runtime>(
 
     let vault_base = resolve_startup_vault_base(app)?;
     let run_id = legacy_vault::import_legacy_vault(pool, &vault_base, false).await?;
-    require_verified_import(pool, &run_id).await
+    require_startup_ready_import(pool, &run_id).await
 }
 
-async fn require_verified_import(pool: &SqlitePool, run_id: &str) -> crate::Result<()> {
+async fn require_startup_ready_import(pool: &SqlitePool, run_id: &str) -> crate::Result<()> {
     if legacy_import_required(pool).await? {
         return Err(std::io::Error::other(format!(
             "legacy import {run_id} did not pass parity verification; source files were left unchanged",
@@ -33,20 +33,31 @@ async fn require_verified_import(pool: &SqlitePool, run_id: &str) -> crate::Resu
 }
 
 async fn legacy_import_required(pool: &SqlitePool) -> Result<bool, sqlx::Error> {
-    let verified: bool = sqlx::query_scalar(
+    let startup_ready: bool = sqlx::query_scalar(
         "SELECT EXISTS(
            SELECT 1
-           FROM storage_migration_state
-           WHERE id = 'legacy_v1'
-             AND importer_version = ?
-             AND parity_verified = 1
+           FROM storage_migration_state AS state
+           LEFT JOIN migration_import_runs AS run ON run.id = state.latest_run_id
+           WHERE state.id = 'legacy_v1'
+             AND (
+               (state.importer_version = ? AND state.parity_verified = 1)
+               OR (
+                 run.importer_version = ?
+                 AND run.dry_run = 0
+                 AND run.status = 'completed_with_conflicts'
+                 AND run.conflict_count > 0
+                 AND run.skipped_count = 0
+                 AND run.error_count = 0
+               )
+             )
          )",
     )
+    .bind(hypr_db_app::LEGACY_IMPORTER_VERSION)
     .bind(hypr_db_app::LEGACY_IMPORTER_VERSION)
     .fetch_one(pool)
     .await?;
 
-    Ok(!verified)
+    Ok(!startup_ready)
 }
 
 pub async fn rerun_legacy_import(pool: &SqlitePool, dry_run: bool) -> crate::Result<String> {
@@ -155,6 +166,37 @@ fn resolve_startup_vault_base<R: tauri::Runtime>(
 mod tests {
     use super::*;
 
+    async fn finish_issue_run(
+        pool: &SqlitePool,
+        run_id: &str,
+        item_status: &str,
+        skipped_count: i64,
+        conflict_count: i64,
+    ) -> String {
+        hypr_db_app::begin_legacy_import_run(pool, run_id, "/vault", false)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO migration_import_items
+             (id, run_id, source_path, source_kind, source_sha256, status,
+              discovered_count, skipped_count, conflict_count, error, completed_at)
+             VALUES (?, ?, 'source.json', 'test', 'hash', ?, 1, ?, ?, '',
+                     strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))",
+        )
+        .bind(format!("item-{run_id}"))
+        .bind(run_id)
+        .bind(item_status)
+        .bind(skipped_count)
+        .bind(conflict_count)
+        .execute(pool)
+        .await
+        .unwrap();
+
+        hypr_db_app::finish_legacy_import_run(pool, run_id)
+            .await
+            .unwrap()
+    }
+
     #[tokio::test]
     async fn verified_current_import_is_not_repeated_at_startup() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
@@ -173,7 +215,7 @@ mod tests {
         .unwrap();
 
         assert!(!legacy_import_required(db.pool()).await.unwrap());
-        require_verified_import(db.pool(), "verified-run")
+        require_startup_ready_import(db.pool(), "verified-run")
             .await
             .unwrap();
 
@@ -190,11 +232,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn incomplete_import_prevents_cutover() {
+    async fn incomplete_import_still_blocks_startup() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
 
-        let error = require_verified_import(db.pool(), "run-with-errors")
+        let error = require_startup_ready_import(db.pool(), "run-with-errors")
             .await
             .unwrap_err();
 
@@ -208,6 +250,412 @@ mod tests {
                 .to_string()
                 .contains("source files were left unchanged")
         );
+    }
+
+    #[tokio::test]
+    async fn conflict_only_import_allows_startup_without_verifying_parity() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+
+        assert_eq!(
+            finish_issue_run(db.pool(), "conflict-run", "conflict", 0, 1).await,
+            "completed_with_conflicts"
+        );
+
+        let parity_verified: bool = sqlx::query_scalar(
+            "SELECT parity_verified FROM storage_migration_state WHERE id = 'legacy_v1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert!(!parity_verified);
+        assert!(!legacy_import_required(db.pool()).await.unwrap());
+        require_startup_ready_import(db.pool(), "conflict-run")
+            .await
+            .unwrap();
+
+        let cleanup_status = cleanup::get_status(db.pool()).await.unwrap();
+        assert!(!cleanup_status.migration_verified);
+        assert!(!cleanup_status.available);
+        assert!(cleanup_status.blocking_reason.is_some());
+    }
+
+    #[tokio::test]
+    async fn legacy_completed_with_issues_conflicts_remain_retryable() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+        finish_issue_run(db.pool(), "legacy-conflict-run", "conflict", 0, 1).await;
+        sqlx::query(
+            "UPDATE migration_import_runs SET status = 'completed_with_issues' WHERE id = ?",
+        )
+        .bind("legacy-conflict-run")
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        assert!(legacy_import_required(db.pool()).await.unwrap());
+        assert!(
+            require_startup_ready_import(db.pool(), "legacy-conflict-run")
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn legacy_conflict_only_run_is_retried_once_and_then_allows_startup() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+        let sqlite_document = r#"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"SQLite note"}]}]}"#;
+        let sqlite_words =
+            r#"[{"id":"sqlite-word","text":"SQLite words","start_ms":0,"end_ms":10,"channel":0}]"#;
+        sqlx::query(
+            "INSERT INTO sessions
+             (id, owner_user_id, title, created_at, started_at, ended_at, event_id,
+              external_event_id, external_provider, series_id, event_json, folder_path)
+             VALUES ('session-1', 'user-1', 'Planning', '2026-07-10T01:00:00Z',
+                     '', '', '', '', '', '', '', '')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, body_format, body, created_at, updated_at)
+             VALUES ('note-1', 'session-1', 'note', 'prosemirror_json', ?,
+                     '2026-07-10T01:00:00Z', '2026-07-10T02:00:00Z')",
+        )
+        .bind(sqlite_document)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO transcripts
+             (id, owner_user_id, session_id, started_at_ms, memo, words_json,
+              speaker_hints_json, created_at)
+             VALUES ('transcript-1', 'user-1', 'session-1', 0, 'SQLite memo', ?,
+                     '[]', '2026-07-10T01:00:00Z')",
+        )
+        .bind(sqlite_words)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let vault = tempfile::tempdir().unwrap();
+        let session_dir = vault.path().join("sessions/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let meta = br#"{"id":"session-1","user_id":"user-1","created_at":"2026-07-10T01:00:00Z","title":"Planning"}"#;
+        let note = b"---\nid: note-1\nsession_id: session-1\n---\n\nLegacy note";
+        let transcript = br#"{"transcripts":[{"id":"transcript-1","user_id":"user-1","session_id":"session-1","created_at":"2026-07-10T01:00:00Z","started_at":0,"memo_md":"Legacy memo","words":[{"text":"Legacy words","start_ms":0,"end_ms":10,"channel":0}],"speaker_hints":[]}] }"#;
+        std::fs::write(session_dir.join("_meta.json"), meta).unwrap();
+        std::fs::write(session_dir.join("_memo.md"), note).unwrap();
+        std::fs::write(session_dir.join("transcript.json"), transcript).unwrap();
+
+        let legacy_run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
+            .await
+            .unwrap();
+        let legacy_run: (String, i64, i64, i64) = sqlx::query_as(
+            "SELECT status, conflict_count, skipped_count, error_count
+             FROM migration_import_runs WHERE id = ?",
+        )
+        .bind(&legacy_run_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            legacy_run,
+            ("completed_with_conflicts".to_string(), 2, 0, 0)
+        );
+        sqlx::query(
+            "UPDATE migration_import_runs
+             SET status = 'completed_with_issues'
+             WHERE id = ?",
+        )
+        .bind(&legacy_run_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "UPDATE storage_migration_state
+             SET last_error = 'completed_with_issues'
+             WHERE id = 'legacy_v1' AND latest_run_id = ?",
+        )
+        .bind(&legacy_run_id)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        assert!(legacy_import_required(db.pool()).await.unwrap());
+        let recovery_run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
+            .await
+            .unwrap();
+        require_startup_ready_import(db.pool(), &recovery_run_id)
+            .await
+            .unwrap();
+
+        let recovery_run: (String, i64, i64, i64) = sqlx::query_as(
+            "SELECT status, conflict_count, skipped_count, error_count
+             FROM migration_import_runs WHERE id = ?",
+        )
+        .bind(&recovery_run_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            recovery_run,
+            ("completed_with_conflicts".to_string(), 2, 0, 0)
+        );
+        let recovery_run_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM migration_import_runs
+             WHERE status = 'completed_with_conflicts'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(recovery_run_count, 1);
+        let total_run_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(total_run_count, 2);
+
+        let document_body: String =
+            sqlx::query_scalar("SELECT body FROM session_documents WHERE id = 'note-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let transcript_data: (String, String) =
+            sqlx::query_as("SELECT memo, words_json FROM transcripts WHERE id = 'transcript-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(document_body, sqlite_document);
+        assert_eq!(
+            transcript_data,
+            ("SQLite memo".to_string(), sqlite_words.to_string())
+        );
+        assert_eq!(std::fs::read(session_dir.join("_meta.json")).unwrap(), meta);
+        assert_eq!(std::fs::read(session_dir.join("_memo.md")).unwrap(), note);
+        assert_eq!(
+            std::fs::read(session_dir.join("transcript.json")).unwrap(),
+            transcript
+        );
+
+        let cleanup_status = cleanup::get_status(db.pool()).await.unwrap();
+        assert!(!cleanup_status.migration_verified);
+        assert!(!cleanup_status.available);
+        assert!(cleanup_status.blocking_reason.is_some());
+
+        assert!(!legacy_import_required(db.pool()).await.unwrap());
+        let run_count_before_second_startup: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        if legacy_import_required(db.pool()).await.unwrap() {
+            let run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
+                .await
+                .unwrap();
+            require_startup_ready_import(db.pool(), &run_id)
+                .await
+                .unwrap();
+        }
+        let run_count_after_second_startup: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            run_count_after_second_startup,
+            run_count_before_second_startup
+        );
+    }
+
+    #[tokio::test]
+    async fn skipped_and_error_imports_remain_blocking_and_retryable() {
+        for (run_id, item_status, skipped_count) in
+            [("skipped-run", "partial", 1), ("error-run", "error", 0)]
+        {
+            let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+            hypr_db_app::prepare_schema(&db).await.unwrap();
+
+            assert_eq!(
+                finish_issue_run(db.pool(), run_id, item_status, skipped_count, 0).await,
+                "completed_with_issues"
+            );
+            assert!(legacy_import_required(db.pool()).await.unwrap());
+            assert!(
+                require_startup_ready_import(db.pool(), run_id)
+                    .await
+                    .is_err()
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn orphaned_session_children_remain_blocking_and_retryable() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+        let vault = tempfile::tempdir().unwrap();
+        let session_dir = vault.path().join("sessions/missing-session");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("_memo.md"),
+            "---\nid: orphan-note\nsession_id: missing-session\n---\n\nOrphaned note",
+        )
+        .unwrap();
+
+        let run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
+            .await
+            .unwrap();
+        let run: (String, i64, i64, i64) = sqlx::query_as(
+            "SELECT status, skipped_count, conflict_count, error_count
+             FROM migration_import_runs WHERE id = ?",
+        )
+        .bind(&run_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        let target_status: String = sqlx::query_scalar(
+            "SELECT status FROM migration_import_targets
+             WHERE run_id = ? AND target_id = 'orphan-note'",
+        )
+        .bind(&run_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(run, ("completed_with_issues".to_string(), 1, 0, 1));
+        assert_eq!(target_status, "missing_dependency");
+        assert!(legacy_import_required(db.pool()).await.unwrap());
+        assert!(
+            require_startup_ready_import(db.pool(), &run_id)
+                .await
+                .is_err()
+        );
+    }
+
+    #[tokio::test]
+    async fn document_and_transcript_conflicts_preserve_both_stores_and_allow_startup() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+        let sqlite_document = r#"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"SQLite note"}]}]}"#;
+        let sqlite_words =
+            r#"[{"id":"sqlite-word","text":"SQLite words","start_ms":0,"end_ms":10,"channel":0}]"#;
+        sqlx::query(
+            "INSERT INTO sessions
+             (id, owner_user_id, title, created_at, started_at, ended_at, event_id,
+              external_event_id, external_provider, series_id, event_json, folder_path)
+             VALUES ('session-1', 'user-1', 'Planning', '2026-07-10T01:00:00Z',
+                     '', '', '', '', '', '', '', '')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO session_documents
+             (id, session_id, kind, body_format, body, created_at, updated_at)
+             VALUES ('note-1', 'session-1', 'note', 'prosemirror_json',
+                     ?,
+                     '2026-07-10T01:00:00Z', '2026-07-10T02:00:00Z')",
+        )
+        .bind(sqlite_document)
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO transcripts
+             (id, owner_user_id, session_id, started_at_ms, memo, words_json,
+              speaker_hints_json, created_at)
+             VALUES ('transcript-1', 'user-1', 'session-1', 0, 'SQLite memo',
+                     ?,
+                     '[]', '2026-07-10T01:00:00Z')",
+        )
+        .bind(sqlite_words)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let vault = tempfile::tempdir().unwrap();
+        let session_dir = vault.path().join("sessions/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        let meta = br#"{"id":"session-1","user_id":"user-1","created_at":"2026-07-10T01:00:00Z","title":"Planning"}"#;
+        let note = b"---\nid: note-1\nsession_id: session-1\n---\n\nLegacy note";
+        let transcript = br#"{"transcripts":[{"id":"transcript-1","user_id":"user-1","session_id":"session-1","created_at":"2026-07-10T01:00:00Z","started_at":0,"memo_md":"Legacy memo","words":[{"text":"Legacy words","start_ms":0,"end_ms":10,"channel":0}],"speaker_hints":[]}]}"#;
+        std::fs::write(session_dir.join("_meta.json"), meta).unwrap();
+        std::fs::write(session_dir.join("_memo.md"), note).unwrap();
+        std::fs::write(session_dir.join("transcript.json"), transcript).unwrap();
+
+        let run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
+            .await
+            .unwrap();
+        let run: (String, i64, i64, i64) = sqlx::query_as(
+            "SELECT status, conflict_count, skipped_count, error_count
+             FROM migration_import_runs WHERE id = ?",
+        )
+        .bind(&run_id)
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(run, ("completed_with_conflicts".to_string(), 2, 0, 0));
+
+        let targets: Vec<(String, String)> = sqlx::query_as(
+            "SELECT table_name, status FROM migration_import_targets
+             WHERE run_id = ? ORDER BY table_name",
+        )
+        .bind(&run_id)
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            targets,
+            vec![
+                ("session_documents".to_string(), "conflict".to_string()),
+                ("sessions".to_string(), "matched".to_string()),
+                ("transcripts".to_string(), "conflict".to_string()),
+            ]
+        );
+
+        let document_body: String =
+            sqlx::query_scalar("SELECT body FROM session_documents WHERE id = 'note-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let transcript_memo: String =
+            sqlx::query_scalar("SELECT memo FROM transcripts WHERE id = 'transcript-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let transcript_words: String =
+            sqlx::query_scalar("SELECT words_json FROM transcripts WHERE id = 'transcript-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(document_body, sqlite_document);
+        assert_eq!(transcript_memo, "SQLite memo");
+        assert_eq!(transcript_words, sqlite_words);
+        assert_eq!(std::fs::read(session_dir.join("_meta.json")).unwrap(), meta);
+        assert_eq!(std::fs::read(session_dir.join("_memo.md")).unwrap(), note);
+        assert_eq!(
+            std::fs::read(session_dir.join("transcript.json")).unwrap(),
+            transcript
+        );
+
+        let parity_verified: bool = sqlx::query_scalar(
+            "SELECT parity_verified FROM storage_migration_state WHERE id = 'legacy_v1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert!(!parity_verified);
+        assert!(!legacy_import_required(db.pool()).await.unwrap());
+        require_startup_ready_import(db.pool(), &run_id)
+            .await
+            .unwrap();
+
+        let cleanup_status = cleanup::get_status(db.pool()).await.unwrap();
+        assert!(!cleanup_status.migration_verified);
+        assert!(!cleanup_status.available);
+        assert!(cleanup_status.blocking_reason.is_some());
     }
 
     #[tokio::test]
@@ -271,7 +719,9 @@ mod tests {
             .await
             .unwrap();
 
-        require_verified_import(db.pool(), &run_id).await.unwrap();
+        require_startup_ready_import(db.pool(), &run_id)
+            .await
+            .unwrap();
         let target_statuses: Vec<String> = sqlx::query_scalar(
             "SELECT status FROM migration_import_targets WHERE run_id = ? ORDER BY target_id",
         )
@@ -296,5 +746,94 @@ mod tests {
                 .unwrap();
         assert!(!calendar_enabled);
         assert_eq!(event_title, "Updated title");
+    }
+
+    #[tokio::test]
+    async fn verified_file_import_survives_cloudsync_reopen_without_rerun() {
+        let dir = tempfile::tempdir().unwrap();
+        let db_path = dir.path().join("app.db");
+        let vault = dir.path().join("vault");
+        let session_dir = vault.join("sessions/session-1");
+        std::fs::create_dir_all(&session_dir).unwrap();
+        std::fs::write(
+            session_dir.join("_meta.json"),
+            r#"{"id":"session-1","user_id":"user-1","created_at":"2026-07-10T01:00:00Z","title":"Imported before restart"}"#,
+        )
+        .unwrap();
+
+        let db = crate::runtime::open_app_db(Some(&db_path)).await.unwrap();
+        assert!(db.cloudsync_enabled());
+        assert!(legacy_import_required(db.pool()).await.unwrap());
+
+        let run_id = legacy_vault::import_legacy_vault(db.pool(), &vault, false)
+            .await
+            .unwrap();
+        let run_status: String =
+            sqlx::query_scalar("SELECT status FROM migration_import_runs WHERE id = ?")
+                .bind(&run_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let state_before: (String, bool, i64) = sqlx::query_as(
+            "SELECT latest_run_id, parity_verified, importer_version
+             FROM storage_migration_state WHERE id = 'legacy_v1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        let run_count_before: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(run_status, "completed");
+        assert_eq!(state_before.0, run_id);
+        assert!(state_before.1);
+        assert_eq!(state_before.2, hypr_db_app::LEGACY_IMPORTER_VERSION);
+        assert!(!legacy_import_required(db.pool()).await.unwrap());
+
+        db.pool().close().await;
+        drop(db);
+
+        std::fs::write(
+            session_dir.join("_meta.json"),
+            r#"{"id":"session-1","user_id":"user-1","created_at":"2026-07-10T01:00:00Z","title":"Changed after verified import"}"#,
+        )
+        .unwrap();
+
+        let reopened = crate::runtime::open_app_db(Some(&db_path)).await.unwrap();
+        assert!(reopened.cloudsync_enabled());
+
+        if legacy_import_required(reopened.pool()).await.unwrap() {
+            legacy_vault::import_legacy_vault(reopened.pool(), &vault, false)
+                .await
+                .unwrap();
+        }
+
+        let state_after: (String, bool, i64) = sqlx::query_as(
+            "SELECT latest_run_id, parity_verified, importer_version
+             FROM storage_migration_state WHERE id = 'legacy_v1'",
+        )
+        .fetch_one(reopened.pool())
+        .await
+        .unwrap();
+        let run_count_after: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
+            .fetch_one(reopened.pool())
+            .await
+            .unwrap();
+        let stored_title: String =
+            sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+                .fetch_one(reopened.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(state_after, state_before);
+        assert_eq!(run_count_after, run_count_before);
+        assert_eq!(stored_title, "Imported before restart");
+        assert!(!legacy_import_required(reopened.pool()).await.unwrap());
+        require_startup_ready_import(reopened.pool(), &run_id)
+            .await
+            .unwrap();
     }
 }


### PR DESCRIPTION
## Summary
- allow startup after conflict-only legacy migration runs while keeping destructive cleanup disabled
- reconcile safe empty-versus-populated note and transcript copies, prefer canonical summaries, and preserve divergent legacy files
- keep missing-parent imports blocking and add the 1.2.2 changelog

## Testing
- cargo test -p db-app legacy_import
- cargo test -p tauri-plugin-db import::
- cargo check -p db-app -p tauri-plugin-db
- pnpm -F @hypr/changelog typecheck
- isolated Computer Use smoke: open, click New note, quit, and reopen without rerunning migration

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup gating and SQLite merge logic for notes/transcripts; wrong reconciliation could lose data, though conflicts are preserved and missing-parent imports remain blocking.
> 
> **Overview**
> **Startup no longer hard-blocks** when the latest legacy migration finishes with **conflicts only** (no skips or errors): `legacy_import_required` treats `completed_with_conflicts` as startup-ready without setting `parity_verified`, so destructive vault cleanup stays disabled while the app can open.
> 
> **Legacy row handling** gains `filled_from_legacy`, `missing_dependency`, and run statuses `completed_with_conflicts` vs `completed_with_issues`. Documents and transcripts can **reconcile** empty SQLite rows from legacy, keep nonempty SQLite when legacy is empty, and record true conflicts without overwriting; orphans without a parent session count as blocking missing dependencies.
> 
> **Vault import** for session `.md` / `_summary.md` pairs is smarter: hidden `.md` is only skipped when canonical content should win; divergent pairs import both (canonical into SQLite, hidden marked conflict). Import order defers session `.md` after other session files.
> 
> Changelog **1.2.2** documents reliable open when note/transcript files differ from SQLite.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d211005e5fc7b7ea07df29a2f0f6834e3f0463e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->