### PR TITLE
Check local AI provider readiness

### DIFF
--- a/apps/desktop/src/settings/ai/llm/shared.tsx
+++ b/apps/desktop/src/settings/ai/llm/shared.tsx
@@ -14,6 +14,10 @@ import type { ReactNode } from "react";
 import { env } from "~/env";
 import { AnarlogProviderIcon } from "~/settings/ai/shared";
 import { type ProviderRequirement } from "~/settings/ai/shared/eligibility";
+import {
+  checkLMStudioAvailability,
+  checkOllamaAvailability,
+} from "~/settings/ai/shared/local-provider-availability";
 import { sortProviders } from "~/settings/ai/shared/sort-providers";
 
 export type Provider = {
@@ -23,6 +27,7 @@ export type Provider = {
   icon: ReactNode;
   baseUrl?: string;
   requirements: ProviderRequirement[];
+  checkAvailability?: (baseUrl: string, apiKey: string) => Promise<boolean>;
   links?: {
     download?: { label: string; url: string };
     models?: { label: string; url: string };
@@ -49,6 +54,7 @@ const _PROVIDERS = [
     icon: <LmStudio size={16} />,
     baseUrl: "http://127.0.0.1:1234/v1",
     requirements: [],
+    checkAvailability: checkLMStudioAvailability,
     links: {
       download: {
         label: "Download LM Studio",
@@ -68,6 +74,7 @@ const _PROVIDERS = [
     icon: <Ollama size={16} />,
     baseUrl: "http://127.0.0.1:11434/v1",
     requirements: [],
+    checkAvailability: checkOllamaAvailability,
     links: {
       download: {
         label: "Download Ollama",

--- a/apps/desktop/src/settings/ai/shared/index.tsx
+++ b/apps/desktop/src/settings/ai/shared/index.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { Trans, useLingui } from "@lingui/react/macro";
 import { type AnyFieldApi, useForm } from "@tanstack/react-form";
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ExternalLink } from "lucide-react";
 import { type ReactNode, useState } from "react";
 import { Streamdown } from "streamdown";
@@ -55,6 +55,7 @@ type ProviderConfig = {
   baseUrl?: string;
   disabled?: boolean;
   requirements: ProviderRequirement[];
+  checkAvailability?: (baseUrl: string, apiKey: string) => Promise<boolean>;
   links?: {
     download?: { label: string; url: string };
     models?: { label: string; url: string };
@@ -117,7 +118,7 @@ export function providerRowId(providerType: ProviderType, providerId: string) {
   return `${providerType}:${providerId}`;
 }
 
-function useIsProviderConfigured(
+function useIsProviderReady(
   providerId: string,
   providerType: ProviderType,
   providers: readonly ProviderConfig[],
@@ -127,19 +128,32 @@ function useIsProviderConfigured(
   const providerDef = providers.find((p) => p.id === providerId);
   const config = configuredProviders[providerRowId(providerType, providerId)];
 
-  if (!providerDef) {
-    return false;
-  }
-
-  const baseUrl = String(config?.base_url || providerDef.baseUrl || "").trim();
+  const baseUrl = String(config?.base_url || providerDef?.baseUrl || "").trim();
   const apiKey = String(config?.api_key || "").trim();
-
-  return (
+  const isConfigured =
+    !!providerDef &&
     getProviderSelectionBlockers(providerDef.requirements, {
       isAuthenticated: true,
       isPaid: billing.isPaid,
       config: { base_url: baseUrl, api_key: apiKey },
-    }).length === 0
+    }).length === 0;
+  const checkAvailability = providerDef?.checkAvailability;
+  const availabilityQuery = useQuery({
+    queryKey: [
+      "ai-provider-availability",
+      providerType,
+      providerId,
+      baseUrl,
+      apiKey,
+    ],
+    queryFn: () => checkAvailability?.(baseUrl, apiKey) ?? false,
+    enabled: isConfigured && !!checkAvailability,
+    retry: false,
+    refetchInterval: checkAvailability ? 5_000 : false,
+  });
+
+  return (
+    isConfigured && (!checkAvailability || availabilityQuery.data === true)
   );
 }
 
@@ -163,11 +177,7 @@ export function NonHyprProviderCard({
     useState(false);
   const locked =
     requiresEntitlement(config.requirements, "pro") && !billing.isPaid;
-  const isConfigured = useIsProviderConfigured(
-    config.id,
-    providerType,
-    providers,
-  );
+  const isReady = useIsProviderReady(config.id, providerType, providers);
 
   const requiredFields = getRequiredConfigFields(config.requirements);
   const showApiKey = requiredFields.includes("api_key");
@@ -236,7 +246,7 @@ export function NonHyprProviderCard({
       value={config.id}
       className={cn([
         "bg-muted rounded-[22px] border-2",
-        isConfigured ? "border-border border-solid" : "border-dashed",
+        isReady ? "border-border border-solid" : "border-dashed",
       ])}
     >
       <SettingsAlertToast

--- a/apps/desktop/src/settings/ai/shared/local-provider-availability.test.ts
+++ b/apps/desktop/src/settings/ai/shared/local-provider-availability.test.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  fetch: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/plugin-http", () => ({
+  fetch: mocks.fetch,
+}));
+
+import {
+  checkLMStudioAvailability,
+  checkOllamaAvailability,
+} from "./local-provider-availability";
+
+describe("local provider availability", () => {
+  beforeEach(() => {
+    mocks.fetch.mockReset();
+  });
+
+  it("checks the Ollama version endpoint", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      checkOllamaAvailability("http://127.0.0.1:11434/v1"),
+    ).resolves.toBe(true);
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:11434/api/version",
+      {
+        method: "GET",
+        headers: { Origin: "http://127.0.0.1:11434" },
+      },
+    );
+  });
+
+  it("reports Ollama as unavailable when its server is not running", async () => {
+    mocks.fetch.mockRejectedValueOnce(new Error("connection refused"));
+
+    await expect(
+      checkOllamaAvailability("http://127.0.0.1:11434/v1"),
+    ).resolves.toBe(false);
+  });
+
+  it("checks LM Studio with its optional API key", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response(null, { status: 200 }));
+
+    await expect(
+      checkLMStudioAvailability("http://127.0.0.1:1234/v1", "secret"),
+    ).resolves.toBe(true);
+    expect(mocks.fetch).toHaveBeenCalledWith(
+      "http://127.0.0.1:1234/api/v1/models",
+      {
+        method: "GET",
+        headers: { Authorization: "Bearer secret" },
+      },
+    );
+  });
+
+  it("requires a successful local provider response", async () => {
+    mocks.fetch.mockResolvedValueOnce(new Response(null, { status: 503 }));
+
+    await expect(
+      checkLMStudioAvailability("http://127.0.0.1:1234/v1", ""),
+    ).resolves.toBe(false);
+  });
+});

--- a/apps/desktop/src/settings/ai/shared/local-provider-availability.ts
+++ b/apps/desktop/src/settings/ai/shared/local-provider-availability.ts
@@ -1,0 +1,49 @@
+import { fetch as tauriFetch } from "@tauri-apps/plugin-http";
+import { Effect, pipe } from "effect";
+
+import { REQUEST_TIMEOUT } from "./list-common";
+import { getLMStudioNativeModelsUrl } from "./list-lmstudio";
+
+export async function checkOllamaAvailability(
+  baseUrl: string,
+): Promise<boolean> {
+  return checkEndpoint(() => {
+    const url = new URL(baseUrl);
+    const path = url.pathname.replace(/\/+$/, "");
+    url.pathname = `${path.endsWith("/v1") ? path.slice(0, -3) : path}/api/version`;
+
+    return {
+      url: url.toString(),
+      headers: { Origin: url.origin },
+    };
+  });
+}
+
+export async function checkLMStudioAvailability(
+  baseUrl: string,
+  apiKey: string,
+): Promise<boolean> {
+  return checkEndpoint(() => {
+    const headers: Record<string, string> = {};
+    if (apiKey.trim()) {
+      headers.Authorization = `Bearer ${apiKey.trim()}`;
+    }
+
+    return { url: getLMStudioNativeModelsUrl(baseUrl), headers };
+  });
+}
+
+function checkEndpoint(
+  getRequest: () => { url: string; headers: Record<string, string> },
+): Promise<boolean> {
+  return pipe(
+    Effect.tryPromise(async () => {
+      const { url, headers } = getRequest();
+      const response = await tauriFetch(url, { method: "GET", headers });
+      return response.ok;
+    }),
+    Effect.timeout(REQUEST_TIMEOUT),
+    Effect.catchAll(() => Effect.succeed(false)),
+    Effect.runPromise,
+  );
+}


### PR DESCRIPTION
Probe Ollama and LM Studio before showing configured borders.

<!-- GitButler Footer Boundary Top -->
---
This is **part 2 of 2 in a stack** made with GitButler:
- <kbd>&nbsp;2&nbsp;</kbd> #6068 👈 
- <kbd>&nbsp;1&nbsp;</kbd> #6067 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Settings-only UI and periodic localhost health checks; no changes to auth, billing, or inference paths.
> 
> **Overview**
> **Local LLM providers (Ollama and LM Studio) are only shown as fully ready when their servers actually respond**, not merely when settings look valid.
> 
> Adds optional `checkAvailability` hooks on provider definitions and a shared `useIsProviderReady` flow that still applies eligibility/config rules, then—when a checker exists—polls every 5s via React Query. Provider cards use a **solid** border only when ready; otherwise they stay **dashed** (e.g. daemon stopped).
> 
> New helpers hit Ollama’s version API (with `Origin`) and LM Studio’s native models URL (optional Bearer API key), using Tauri HTTP with the existing request timeout and treating failures/timeouts as unavailable. Unit tests cover success, connection errors, and non-OK responses.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8eb63f51016f18fb5441e08f04519c4edc64b5b6. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->