### PR TITLE
Recover live transcription after batch fallback

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/screens/batch.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/batch.test.tsx
@@ -1,0 +1,54 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { BatchState } from "./batch";
+
+vi.mock("@hypr/ui/components/ui/dancing-sticks", () => ({
+  DancingSticks: () => null,
+}));
+
+vi.mock("~/stt/contexts", () => ({
+  useListener: (selector: (state: unknown) => unknown) =>
+    selector({ live: { amplitude: { mic: 0, speaker: 0 } } }),
+}));
+
+describe("BatchState", () => {
+  afterEach(cleanup);
+
+  it("identifies intentional batch transcription", () => {
+    render(<BatchState requestedLiveTranscription={false} error={null} />);
+
+    expect(screen.getByText("Batch transcription mode")).not.toBeNull();
+    expect(
+      screen.getByText(
+        "Recording continues. Your transcript will be generated after you stop.",
+      ),
+    ).not.toBeNull();
+  });
+
+  it("explains transient fallback and reconnection", () => {
+    render(
+      <BatchState
+        requestedLiveTranscription
+        error={{ type: "connection_timeout" }}
+      />,
+    );
+
+    expect(screen.getByText("Reconnecting live transcription")).not.toBeNull();
+    expect(screen.getByText(/while we reconnect/)).not.toBeNull();
+    expect(screen.getByText(/complete transcript/)).not.toBeNull();
+  });
+
+  it("does not promise reconnection after an authentication failure", () => {
+    render(
+      <BatchState
+        requestedLiveTranscription
+        error={{ type: "authentication_failed", provider: "Deepgram" }}
+      />,
+    );
+
+    expect(screen.getByText("Live transcription stopped")).not.toBeNull();
+    expect(screen.queryByText(/while we reconnect/)).toBeNull();
+    expect(screen.getByText(/complete transcript/)).not.toBeNull();
+  });
+});

--- a/apps/desktop/src/session/components/note-input/transcript/screens/batch.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/screens/batch.tsx
@@ -12,8 +12,19 @@ export function BatchState({
 }) {
   const amplitude = useListener((state) => state.live.amplitude);
   const isFallbackFromLive = requestedLiveTranscription === true;
-  const continuation =
-    "Recording continues and audio will be saved when you stop.";
+  const isReconnecting = isFallbackFromLive && isRetryable(error);
+  const title = isFallbackFromLive
+    ? isReconnecting
+      ? "Reconnecting live transcription"
+      : error
+        ? "Live transcription stopped"
+        : "Live transcription unavailable"
+    : "Batch transcription mode";
+  const description = isFallbackFromLive
+    ? `${error ? `${degradedMessage(error)}. ` : ""}Recording continues${
+        isReconnecting ? " while we reconnect" : ""
+      }. A complete transcript will be generated after you stop.`
+    : "Recording continues. Your transcript will be generated after you stop.";
 
   return (
     <div
@@ -31,19 +42,17 @@ export function BatchState({
         />
       </div>
       <div className="flex max-w-md flex-col gap-2">
-        <p className="text-base font-medium">
-          {isFallbackFromLive
-            ? "Live transcription stopped"
-            : "Recording continues"}
-        </p>
+        <p className="text-base font-medium">{title}</p>
         <p className="text-muted-foreground text-sm leading-relaxed">
-          {isFallbackFromLive
-            ? `${error ? degradedMessage(error) : "Live transcription is unavailable."} ${continuation}`
-            : `${continuation}`}
+          {description}
         </p>
       </div>
     </div>
   );
+}
+
+function isRetryable(error: DegradedError | null) {
+  return error !== null && error.type !== "authentication_failed";
 }
 
 function degradedMessage(error: DegradedError): string {

--- a/apps/desktop/src/store/zustand/listener/general-live.ts
+++ b/apps/desktop/src/store/zustand/listener/general-live.ts
@@ -114,6 +114,9 @@ const createSessionEventHandlers = <T extends LiveStore>(
           live.requestedLiveTranscription =
             payload.requested_live_transcription;
           live.liveTranscriptionActive = payload.live_transcription_active;
+          live.needsBatchRepair ||=
+            payload.requested_live_transcription &&
+            (!payload.live_transcription_active || payload.degraded !== null);
         });
         return;
       }
@@ -158,6 +161,11 @@ const createSessionEventHandlers = <T extends LiveStore>(
         : (currentLive.finalizingBySession[targetSessionId]?.seconds ?? 0);
     const onStopped = get().takeOnStopped(targetSessionId);
     const unlisteners = currentLive.eventUnlistenersBySession[targetSessionId];
+    const needsBatchRepair =
+      currentLive.sessionId === targetSessionId
+        ? currentLive.needsBatchRepair
+        : (currentLive.finalizingBySession[targetSessionId]?.needsBatchRepair ??
+          false);
 
     clearLiveEventUnlisteners(unlisteners);
 
@@ -182,6 +190,7 @@ const createSessionEventHandlers = <T extends LiveStore>(
         audioPath: payload.audio_path ?? null,
         requestedLiveTranscription: payload.requested_live_transcription,
         liveTranscriptionActive: payload.live_transcription_active,
+        needsBatchRepair,
       });
     }
   },

--- a/apps/desktop/src/store/zustand/listener/general-shared.ts
+++ b/apps/desktop/src/store/zustand/listener/general-shared.ts
@@ -41,9 +41,10 @@ export type GeneralState = {
     degraded: DegradedError | null;
     requestedLiveTranscription: boolean | null;
     liveTranscriptionActive: boolean | null;
+    needsBatchRepair: boolean;
     finalizingBySession: Record<
       string,
-      { startedAtMs: number; seconds: number }
+      { startedAtMs: number; seconds: number; needsBatchRepair: boolean }
     >;
     triggerAppIds: string[] | null;
   };
@@ -65,6 +66,7 @@ const initialLiveState: LiveState = {
   degraded: null,
   requestedLiveTranscription: null,
   liveTranscriptionActive: null,
+  needsBatchRepair: false,
   finalizingBySession: {},
   triggerAppIds: null,
 };
@@ -125,6 +127,7 @@ export const markLiveStartRequested = (live: LiveState, sessionId: string) => {
   live.lastError = null;
   live.requestedLiveTranscription = null;
   live.liveTranscriptionActive = null;
+  live.needsBatchRepair = false;
 };
 
 export const markLiveActive = (
@@ -144,16 +147,29 @@ export const markLiveActive = (
   live.degraded = degraded;
   live.requestedLiveTranscription = requestedLiveTranscription;
   live.liveTranscriptionActive = liveTranscriptionActive;
+  live.needsBatchRepair ||=
+    requestedLiveTranscription &&
+    (!liveTranscriptionActive || degraded !== null);
 };
 
 export const markLiveFinalizing = (live: LiveState, sessionId: string) => {
-  const seconds = live.sessionId === sessionId ? live.seconds : 0;
+  const existing = live.finalizingBySession[sessionId];
+  const seconds =
+    live.sessionId === sessionId ? live.seconds : (existing?.seconds ?? 0);
+  const needsBatchRepair =
+    live.sessionId === sessionId
+      ? live.needsBatchRepair
+      : (existing?.needsBatchRepair ?? false);
   if (live.sessionId === sessionId) {
     live.status = "finalizing";
     live.loading = true;
     live.intervalId = undefined;
   }
-  live.finalizingBySession[sessionId] = { startedAtMs: Date.now(), seconds };
+  live.finalizingBySession[sessionId] = {
+    startedAtMs: existing?.startedAtMs ?? Date.now(),
+    seconds,
+    needsBatchRepair,
+  };
 };
 
 export const markLiveInactive = (live: LiveState, error: string | null) => {
@@ -167,6 +183,7 @@ export const markLiveInactive = (live: LiveState, error: string | null) => {
   live.degraded = null;
   live.requestedLiveTranscription = null;
   live.liveTranscriptionActive = null;
+  live.needsBatchRepair = false;
   live.muted = initialLiveState.muted;
   live.triggerAppIds = null;
 };
@@ -185,6 +202,7 @@ export const markLiveStartFailed = (live: LiveState) => {
   live.degraded = null;
   live.requestedLiveTranscription = null;
   live.liveTranscriptionActive = null;
+  live.needsBatchRepair = false;
   live.triggerAppIds = null;
 };
 

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -78,6 +78,7 @@ import { createListenerStore } from ".";
 import {
   getLiveCaptureUiMode,
   markLiveActive,
+  markLiveStartRequested,
   updateLiveProgress,
 } from "./general-shared";
 
@@ -116,6 +117,7 @@ describe("General Listener Slice", () => {
       expect(state.live.seconds).toBe(0);
       expect(state.live.eventUnlistenersBySession).toEqual({});
       expect(state.live.intervalId).toBeUndefined();
+      expect(state.live.needsBatchRepair).toBe(false);
       expect(state.batch).toEqual({});
     });
   });
@@ -190,6 +192,22 @@ describe("General Listener Slice", () => {
 
       expect(store.getState().live.status).toBe("active");
       expect(store.getState().live.lastError).toBe("socket closed");
+    });
+
+    test("markLiveActive preserves the need for batch repair after recovery", () => {
+      const intervalId = setInterval(() => {}, 1000);
+
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          markLiveActive(draft.live, "session-1", intervalId, true, false, {
+            type: "connection_timeout",
+          });
+          markLiveActive(draft.live, "session-1", intervalId, true, true, null);
+        }),
+      );
+
+      clearInterval(intervalId);
+      expect(store.getState().live.needsBatchRepair).toBe(true);
     });
   });
 
@@ -644,6 +662,7 @@ describe("General Listener Slice", () => {
       expect(store.getState().live.finalizingBySession["session-1"]).toEqual({
         startedAtMs: expect.any(Number),
         seconds: 42,
+        needsBatchRepair: false,
       });
     });
   });
@@ -674,6 +693,101 @@ describe("General Listener Slice", () => {
       expect(listenCaptureLifecycleMock).toHaveBeenCalledTimes(1);
       expect(listenCaptureStatusMock).toHaveBeenCalledTimes(1);
       expect(listenCaptureDataMock).toHaveBeenCalledTimes(1);
+    });
+
+    test("finalizing sessions keep the batch repair flag when another session starts", async () => {
+      let lifecycleHandler:
+        | ((event: {
+            payload:
+              | {
+                  type: "started";
+                  session_id: string;
+                  requested_live_transcription: boolean;
+                  live_transcription_active: boolean;
+                  degraded: { type: "connection_timeout" } | null;
+                }
+              | {
+                  type: "finalizing";
+                  session_id: string;
+                }
+              | {
+                  type: "stopped";
+                  session_id: string;
+                  audio_path: string;
+                  requested_live_transcription: boolean;
+                  live_transcription_active: boolean;
+                  error: null;
+                };
+          }) => void)
+        | undefined;
+      const onStopped = vi.fn();
+      listenCaptureLifecycleMock.mockImplementationOnce((handler) => {
+        lifecycleHandler = handler;
+        return Promise.resolve(() => {});
+      });
+      getCaptureSnapshotMock.mockResolvedValueOnce({
+        status: "ok",
+        data: {
+          activeSessionId: "session-a",
+          finalizingSessionIds: [],
+          liveTranscriptionActive: true,
+          requestedLiveTranscription: true,
+          state: "active",
+        },
+      });
+      store.getState().setOnStopped("session-a", onStopped);
+
+      await store.getState().attachLiveSession("session-a");
+      lifecycleHandler?.({
+        payload: {
+          type: "started",
+          session_id: "session-a",
+          requested_live_transcription: true,
+          live_transcription_active: false,
+          degraded: { type: "connection_timeout" },
+        },
+      });
+      lifecycleHandler?.({
+        payload: {
+          type: "started",
+          session_id: "session-a",
+          requested_live_transcription: true,
+          live_transcription_active: true,
+          degraded: null,
+        },
+      });
+      lifecycleHandler?.({
+        payload: {
+          type: "finalizing",
+          session_id: "session-a",
+        },
+      });
+      store.setState((state) =>
+        mutate(state, (draft) => {
+          markLiveStartRequested(draft.live, "session-b");
+        }),
+      );
+      lifecycleHandler?.({
+        payload: {
+          type: "finalizing",
+          session_id: "session-a",
+        },
+      });
+      lifecycleHandler?.({
+        payload: {
+          type: "stopped",
+          session_id: "session-a",
+          audio_path: "/tmp/session.wav",
+          requested_live_transcription: true,
+          live_transcription_active: true,
+          error: null,
+        },
+      });
+
+      expect(onStopped).toHaveBeenCalledWith(
+        "session-a",
+        expect.objectContaining({ needsBatchRepair: true }),
+      );
     });
 
     test("attachLiveSession ignores overlapping attaches for the same session", async () => {
@@ -888,6 +1002,7 @@ describe("General Listener Slice", () => {
           draft.live.finalizingBySession["session-a"] = {
             startedAtMs: 123,
             seconds: 0,
+            needsBatchRepair: false,
           };
         }),
       );
@@ -904,6 +1019,7 @@ describe("General Listener Slice", () => {
           draft.live.finalizingBySession["session-a"] = {
             startedAtMs: 123,
             seconds: 0,
+            needsBatchRepair: false,
           };
         }),
       );

--- a/apps/desktop/src/store/zustand/listener/transcript.ts
+++ b/apps/desktop/src/store/zustand/listener/transcript.ts
@@ -29,6 +29,7 @@ export type OnStoppedCallback = (
     audioPath: string | null;
     requestedLiveTranscription: boolean;
     liveTranscriptionActive: boolean;
+    needsBatchRepair: boolean;
   },
 ) => void;
 

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -129,6 +129,7 @@ describe("getPostCaptureAction", () => {
         {
           audioPath: "/tmp/session.wav",
           liveTranscriptionActive: false,
+          needsBatchRepair: false,
         },
         true,
       ),
@@ -141,10 +142,24 @@ describe("getPostCaptureAction", () => {
         {
           audioPath: "/tmp/session.wav",
           liveTranscriptionActive: true,
+          needsBatchRepair: false,
         },
         true,
       ),
     ).toBe("enhance_only");
+  });
+
+  test("repairs the full transcript after live transcription recovered", () => {
+    expect(
+      getPostCaptureAction(
+        {
+          audioPath: "/tmp/session.wav",
+          liveTranscriptionActive: true,
+          needsBatchRepair: true,
+        },
+        true,
+      ),
+    ).toBe("batch_then_enhance");
   });
 
   test("does nothing when batch fallback is needed but no transcription connection is available", () => {
@@ -153,6 +168,7 @@ describe("getPostCaptureAction", () => {
         {
           audioPath: "/tmp/session.wav",
           liveTranscriptionActive: false,
+          needsBatchRepair: false,
         },
         false,
       ),
@@ -165,6 +181,7 @@ describe("getPostCaptureAction", () => {
         {
           audioPath: null,
           liveTranscriptionActive: false,
+          needsBatchRepair: false,
         },
         true,
       ),
@@ -284,6 +301,7 @@ describe("useStartListening", () => {
         audioPath: "/tmp/session.wav",
         requestedLiveTranscription: false,
         liveTranscriptionActive: false,
+        needsBatchRepair: false,
       });
     });
 
@@ -312,6 +330,7 @@ describe("useStartListening", () => {
         audioPath: "/tmp/session.wav",
         requestedLiveTranscription: true,
         liveTranscriptionActive: true,
+        needsBatchRepair: false,
       });
     });
 
@@ -366,6 +385,7 @@ describe("useStartListening", () => {
       audioPath: "/tmp/session.wav",
       requestedLiveTranscription: true,
       liveTranscriptionActive: true,
+      needsBatchRepair: false,
     });
 
     expect(resetEnhanceTasksMock).not.toHaveBeenCalled();
@@ -395,6 +415,7 @@ describe("useStartListening", () => {
         audioPath: "/tmp/session.wav",
         requestedLiveTranscription: false,
         liveTranscriptionActive: false,
+        needsBatchRepair: false,
       });
     });
 

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -40,10 +40,11 @@ export function getPostCaptureAction(
   details: {
     audioPath: string | null;
     liveTranscriptionActive: boolean;
+    needsBatchRepair: boolean;
   },
   canRunBatch: boolean,
 ) {
-  if (details.liveTranscriptionActive) {
+  if (details.liveTranscriptionActive && !details.needsBatchRepair) {
     return "enhance_only" as const;
   }
 

--- a/crates/listener-core/src/actors/session/supervisor.rs
+++ b/crates/listener-core/src/actors/session/supervisor.rs
@@ -1,6 +1,7 @@
 mod children;
 mod mode;
 
+use ractor::concurrency::Duration;
 use ractor::{Actor, ActorCell, ActorProcessingErr, ActorRef, SupervisionEvent};
 use tracing::Instrument;
 
@@ -14,6 +15,14 @@ use owhisper_client::AdapterKind;
 use self::children::{ChildKind, RESTART_BUDGET};
 use self::mode::SessionModeState;
 
+const LISTENER_RETRY_DELAYS: [Duration; 5] = [
+    Duration::from_secs(2),
+    Duration::from_secs(5),
+    Duration::from_secs(10),
+    Duration::from_secs(20),
+    Duration::from_secs(30),
+];
+
 pub struct SessionState {
     ctx: SessionContext,
     source_cell: Option<ActorCell>,
@@ -22,6 +31,7 @@ pub struct SessionState {
     source_restarts: hypr_supervisor::RestartTracker,
     recorder_restarts: hypr_supervisor::RestartTracker,
     mode: SessionModeState,
+    listener_retry_attempt: usize,
     shutting_down: bool,
 }
 
@@ -30,6 +40,7 @@ pub struct SessionActor;
 #[derive(Debug)]
 pub enum SessionMsg {
     Shutdown,
+    RetryListener,
     UpdateConfig(SessionConfigUpdate),
 }
 
@@ -74,6 +85,7 @@ impl Actor for SessionActor {
                 source_restarts: hypr_supervisor::RestartTracker::new(),
                 recorder_restarts: hypr_supervisor::RestartTracker::new(),
                 mode,
+                listener_retry_attempt: 0,
                 shutting_down: false,
             })
         }
@@ -134,6 +146,9 @@ impl Actor for SessionActor {
                 state.shutting_down = true;
                 children::shutdown_children(state, "session_stop").await;
                 myself.stop(None);
+            }
+            SessionMsg::RetryListener => {
+                retry_listener(myself, state).await;
             }
             SessionMsg::UpdateConfig(update) => {
                 update_config(myself, state, update).await;
@@ -369,7 +384,65 @@ async fn handle_listener_failure(
         tracing::warn!("listener_failed_stopping_session");
         stop_after_listener_failure(myself, state, degraded).await;
     } else {
+        let should_retry = should_retry_listener_failure(&degraded);
         enter_batch_fallback(state, degraded).await;
+        if should_retry {
+            schedule_listener_retry(myself, state);
+        }
+    }
+}
+
+fn should_retry_listener_failure(degraded: &DegradedError) -> bool {
+    !matches!(degraded, DegradedError::AuthenticationFailed { .. })
+}
+
+fn schedule_listener_retry(myself: &ActorRef<SessionMsg>, state: &mut SessionState) {
+    let delay = listener_retry_delay(state.listener_retry_attempt);
+    state.listener_retry_attempt = state.listener_retry_attempt.saturating_add(1);
+    tracing::info!(
+        ?delay,
+        attempt = state.listener_retry_attempt,
+        "listener_retry_scheduled"
+    );
+    myself.send_after(delay, || SessionMsg::RetryListener);
+}
+
+fn listener_retry_delay(attempt: usize) -> Duration {
+    LISTENER_RETRY_DELAYS[attempt.min(LISTENER_RETRY_DELAYS.len() - 1)]
+}
+
+async fn retry_listener(myself: ActorRef<SessionMsg>, state: &mut SessionState) {
+    if state.shutting_down || state.listener_cell.is_some() || !state.mode.should_retry_listener() {
+        return;
+    }
+
+    let replay_duration_secs = children::prepare_listener_refresh(state).await;
+    let replay_offset_secs =
+        (state.ctx.started_at_instant.elapsed().as_secs_f64() - replay_duration_secs).max(0.0);
+
+    match children::spawn_listener(myself.get_cell(), &state.ctx, Some(replay_offset_secs)).await {
+        Ok(listener_cell) => {
+            tracing::info!(
+                attempts = state.listener_retry_attempt,
+                "listener_reconnected"
+            );
+            state.listener_cell = Some(listener_cell);
+            state.listener_retry_attempt = 0;
+            state.mode.on_listener_attached();
+            children::attach_listener_to_source(state).await;
+            emit_active_lifecycle_event(state, None).await;
+        }
+        Err(error) => {
+            tracing::warn!(?error, "listener_retry_failed");
+            handle_listener_failure(
+                &myself,
+                state,
+                DegradedError::UpstreamUnavailable {
+                    message: mode::classify_connection_failure(&state.ctx.params.base_url),
+                },
+            )
+            .await;
+        }
     }
 }
 
@@ -586,6 +659,7 @@ mod tests {
             source_restarts: RestartTracker::new(),
             recorder_restarts: RestartTracker::new(),
             mode: SessionModeState::new(TranscriptionMode::Live, TranscriptionMode::Live),
+            listener_retry_attempt: 0,
             shutting_down: false,
         }
     }
@@ -685,6 +759,25 @@ mod tests {
         assert!(!should_stop_on_listener_failure(&state));
     }
 
+    #[test]
+    fn transient_listener_failures_retry_with_capped_backoff() {
+        assert!(should_retry_listener_failure(
+            &DegradedError::ConnectionTimeout
+        ));
+        assert_eq!(listener_retry_delay(0), Duration::from_secs(2));
+        assert_eq!(listener_retry_delay(3), Duration::from_secs(20));
+        assert_eq!(listener_retry_delay(20), Duration::from_secs(30));
+    }
+
+    #[test]
+    fn authentication_failures_do_not_retry() {
+        assert!(!should_retry_listener_failure(
+            &DegradedError::AuthenticationFailed {
+                provider: "test".to_string(),
+            }
+        ));
+    }
+
     #[tokio::test]
     async fn stop_after_listener_failure_emits_degraded_active_event() {
         let runtime = Arc::new(RecordingRuntime {
@@ -764,6 +857,7 @@ mod tests {
             source_restarts: RestartTracker::new(),
             recorder_restarts: RestartTracker::new(),
             mode: SessionModeState::new(TranscriptionMode::Live, TranscriptionMode::Live),
+            listener_retry_attempt: 0,
             shutting_down: false,
         };
 

--- a/crates/listener-core/src/actors/session/supervisor/mode.rs
+++ b/crates/listener-core/src/actors/session/supervisor/mode.rs
@@ -28,11 +28,17 @@ impl SessionModeState {
 
     pub(super) fn on_listener_attached(&mut self) {
         self.current_transcription_mode = TranscriptionMode::Live;
+        self.listener_buffering_enabled = true;
     }
 
     pub(super) fn enter_batch_fallback(&mut self) {
         self.current_transcription_mode = TranscriptionMode::Batch;
         self.listener_buffering_enabled = false;
+    }
+
+    pub(super) fn should_retry_listener(&self) -> bool {
+        self.requested_transcription_mode == TranscriptionMode::Live
+            && self.current_transcription_mode == TranscriptionMode::Batch
     }
 
     pub(super) fn listener_routing(&self, listener_cell: Option<&ActorCell>) -> ListenerRouting {
@@ -119,6 +125,21 @@ mod tests {
         assert!(matches!(
             state.listener_routing(None),
             ListenerRouting::Dropped
+        ));
+    }
+
+    #[test]
+    fn reattaching_listener_restores_live_mode_and_buffering() {
+        let mut state = SessionModeState::new(TranscriptionMode::Live, TranscriptionMode::Live);
+        state.enter_batch_fallback();
+
+        assert!(state.should_retry_listener());
+        state.on_listener_attached();
+
+        assert!(state.should_spawn_listener());
+        assert!(matches!(
+            state.listener_routing(None),
+            ListenerRouting::Buffering
         ));
     }
 


### PR DESCRIPTION
Show clear batch status, retry transient live failures, and batch-repair degraded sessions on stop.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes live capture lifecycle, listener retry scheduling, and post-stop transcription routing; incorrect `needsBatchRepair` handling could skip or duplicate batch work.
> 
> **Overview**
> When live transcription drops mid-session, the **session supervisor** now **retries** reconnecting the listener on a capped backoff (2–30s), skips retries for **authentication** failures, and **restores live mode** (including audio buffering) after a successful reconnect.
> 
> The desktop **batch fallback UI** (`BatchState`) now separates intentional batch mode from live fallback, shows **“Reconnecting live transcription”** only for retryable errors, and still promises a **complete transcript after stop**.
> 
> Listener store state tracks **`needsBatchRepair`** whenever live was requested but transcription was degraded or inactive (sticky through finalizing, including when another session starts). **`getPostCaptureAction`** uses that flag so sessions that **reconnected live** still run **batch-then-enhance** on stop to rebuild the full transcript from saved audio.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5ac4db1213d3ca320af394553c7c7fb9bf0a623e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->