### PR TITLE
Use semantic toast variants

### DIFF
--- a/apps/desktop/src/main.tsx
+++ b/apps/desktop/src/main.tsx
@@ -32,9 +32,11 @@ import { refreshLegacySettingsSnapshots } from "./settings/legacy-snapshots";
 import { migratePlaintextAiProviderApiKeys } from "./settings/providers";
 import { initializeApplicationSettings } from "./settings/queries";
 import { initializeAppExitFlush } from "./shared/app-exit";
+import { useConfigValue } from "./shared/config";
 import { ErrorComponent, NotFoundComponent } from "./shared/control";
 import { bootstrapThemeFromSettings } from "./shared/theme/apply";
 import { AppThemeProvider } from "./shared/theme/provider";
+import type { ThemePreference } from "./shared/theme/resolve";
 import { createAITaskStore } from "./store/zustand/ai-task";
 import { listenerStore } from "./store/zustand/listener/instance";
 
@@ -93,6 +95,7 @@ function AppRoot() {
     return createManager().start();
   });
   const isMainWindow = getCurrentWebviewWindowLabel() === "main";
+  const theme = useConfigValue("theme") as ThemePreference;
   useRemoteSessionDeletionUndoListener(isMainWindow);
 
   return (
@@ -102,7 +105,7 @@ function AppRoot() {
         {isMainWindow ? <TaskManager /> : null}
         {isMainWindow ? <FloatingMeetingWindowHost /> : null}
         {isMainWindow ? <EventListeners /> : null}
-        <Toaster position="bottom-right" />
+        <Toaster position="bottom-right" theme={theme} />
       </TinyTickProvider>
     </QueryClientProvider>
   );

--- a/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
+++ b/apps/desktop/src/session/components/outer-header/metadata/participants/input.tsx
@@ -397,12 +397,12 @@ function useEventContactEnhancement(sessionId: string) {
       const toastId = `event-contact-enhancement-${humanId}`;
 
       if (extraction.contacts.length === 0 || !applied.matched) {
-        sonnerToast.message("No contact detail found", { id: toastId });
+        sonnerToast.info("No contact detail found", { id: toastId });
         return;
       }
 
       if (changed === 0) {
-        sonnerToast.message("Contact already up to date", { id: toastId });
+        sonnerToast.info("Contact already up to date", { id: toastId });
         return;
       }
 

--- a/apps/desktop/src/settings/ai/llm/select.tsx
+++ b/apps/desktop/src/settings/ai/llm/select.tsx
@@ -267,7 +267,7 @@ export function SelectProviderAndModel() {
       <SettingsAlertToast
         id="llm-settings-alert"
         description={alertDescription}
-        variant={hasError ? "error" : "default"}
+        variant={hasError ? "error" : "warning"}
       />
 
       <h3 className="text-md font-sans font-semibold">

--- a/apps/desktop/src/settings/ai/stt/select.tsx
+++ b/apps/desktop/src/settings/ai/stt/select.tsx
@@ -225,7 +225,7 @@ export function SelectProviderAndModel() {
       <SettingsAlertToast
         id="stt-settings-alert"
         description={alertDescription}
-        variant={hasError ? "error" : "default"}
+        variant={hasError ? "error" : "warning"}
       />
       {!alertDescription && <TranscriptionLanguageWarningToast />}
 

--- a/apps/desktop/src/stt/useRunBatch.test.ts
+++ b/apps/desktop/src/stt/useRunBatch.test.ts
@@ -19,7 +19,7 @@ const {
   useBillingAccessMock,
   useConfigValueMock,
   isSupportedLanguagesBatchMock,
-  sonnerToastMessageMock,
+  sonnerToastWarningMock,
   deleteProcessedAudioForRetentionMock,
   createTranscriptMock,
   appendTranscriptWordsAndHintsMock,
@@ -34,7 +34,7 @@ const {
   useBillingAccessMock: vi.fn(),
   useConfigValueMock: vi.fn(),
   isSupportedLanguagesBatchMock: vi.fn(),
-  sonnerToastMessageMock: vi.fn(),
+  sonnerToastWarningMock: vi.fn(),
   deleteProcessedAudioForRetentionMock: vi.fn(),
   createTranscriptMock: vi.fn(),
   appendTranscriptWordsAndHintsMock: vi.fn(),
@@ -56,7 +56,7 @@ vi.mock("./useSTTConnection", () => ({
 
 vi.mock("@hypr/ui/components/ui/toast", () => ({
   sonnerToast: {
-    message: sonnerToastMessageMock,
+    warning: sonnerToastWarningMock,
   },
 }));
 
@@ -381,7 +381,7 @@ describe("useRunBatch", () => {
       }),
       expect.any(Object),
     );
-    expect(sonnerToastMessageMock).toHaveBeenCalledWith(
+    expect(sonnerToastWarningMock).toHaveBeenCalledWith(
       "Using a batch transcription provider",
       expect.objectContaining({
         description:
@@ -412,7 +412,7 @@ describe("useRunBatch", () => {
       }),
       expect.any(Object),
     );
-    expect(sonnerToastMessageMock).toHaveBeenCalledWith(
+    expect(sonnerToastWarningMock).toHaveBeenCalledWith(
       "Using a batch transcription provider",
       expect.objectContaining({
         description:

--- a/apps/desktop/src/stt/useRunBatch.ts
+++ b/apps/desktop/src/stt/useRunBatch.ts
@@ -225,7 +225,7 @@ export const useRunBatch = (sessionId: string) => {
         : fallbackTarget;
 
       if (!shouldUseSelectedTarget) {
-        sonnerToast.message("Using a batch transcription provider", {
+        sonnerToast.warning("Using a batch transcription provider", {
           description: `${
             selectedTarget
               ? selectedProviderLabel(conn, selectedModel)

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -8,11 +8,13 @@ type ToasterProps = ComponentProps<typeof Sonner>;
 const Toaster = ({
   theme = "system",
   position = "bottom-right",
+  richColors = true,
   ...props
 }: ToasterProps) => (
   <Sonner
     theme={theme}
     position={position}
+    richColors={richColors}
     className="toaster group"
     toastOptions={{
       classNames: {


### PR DESCRIPTION
Enable Sonner rich colors, sync toast theme with the app, and classify informational and warning notifications by intent.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only toast styling and API swaps with no auth, data, or transcription logic changes beyond which Sonner method is called.
> 
> **Overview**
> Improves toast semantics and appearance by turning on Sonner **rich colors**, wiring the global **Toaster** to the user’s **theme** preference from config, and routing notifications through the right variant APIs.
> 
> **Neutral** contact-enhancement outcomes now use `sonnerToast.info` instead of generic `message`. **Batch transcription fallbacks** and **LLM/STT settings** “needs configuration” alerts use **warning** (replacing `default` on the settings alert), so they read as caution rather than plain text. Tests mock and assert `warning` where applicable.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2ec80bf9d6e4d26c67ddd474a55a853ff8ea361b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->