### PR TITLE
Restore startup after incomplete legacy migration

### DIFF
--- a/apps/desktop/src/i18n/locales/af/messages.po
+++ b/apps/desktop/src/i18n/locales/af/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/am/messages.po
+++ b/apps/desktop/src/i18n/locales/am/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ar/messages.po
+++ b/apps/desktop/src/i18n/locales/ar/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/as/messages.po
+++ b/apps/desktop/src/i18n/locales/as/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/az/messages.po
+++ b/apps/desktop/src/i18n/locales/az/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ba/messages.po
+++ b/apps/desktop/src/i18n/locales/ba/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/be/messages.po
+++ b/apps/desktop/src/i18n/locales/be/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bg/messages.po
+++ b/apps/desktop/src/i18n/locales/bg/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bn/messages.po
+++ b/apps/desktop/src/i18n/locales/bn/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bo/messages.po
+++ b/apps/desktop/src/i18n/locales/bo/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/br/messages.po
+++ b/apps/desktop/src/i18n/locales/br/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/bs/messages.po
+++ b/apps/desktop/src/i18n/locales/bs/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ca/messages.po
+++ b/apps/desktop/src/i18n/locales/ca/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cs/messages.po
+++ b/apps/desktop/src/i18n/locales/cs/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/cy/messages.po
+++ b/apps/desktop/src/i18n/locales/cy/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/da/messages.po
+++ b/apps/desktop/src/i18n/locales/da/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/de/messages.po
+++ b/apps/desktop/src/i18n/locales/de/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/el/messages.po
+++ b/apps/desktop/src/i18n/locales/el/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/en/messages.po
+++ b/apps/desktop/src/i18n/locales/en/messages.po
@@ -1383,6 +1383,7 @@ msgstr "Resume listening"
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr "Retry"
 

--- a/apps/desktop/src/i18n/locales/es/messages.po
+++ b/apps/desktop/src/i18n/locales/es/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/et/messages.po
+++ b/apps/desktop/src/i18n/locales/et/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/eu/messages.po
+++ b/apps/desktop/src/i18n/locales/eu/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fa/messages.po
+++ b/apps/desktop/src/i18n/locales/fa/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ff/messages.po
+++ b/apps/desktop/src/i18n/locales/ff/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fi/messages.po
+++ b/apps/desktop/src/i18n/locales/fi/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fo/messages.po
+++ b/apps/desktop/src/i18n/locales/fo/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/fr/messages.po
+++ b/apps/desktop/src/i18n/locales/fr/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ga/messages.po
+++ b/apps/desktop/src/i18n/locales/ga/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gl/messages.po
+++ b/apps/desktop/src/i18n/locales/gl/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/gu/messages.po
+++ b/apps/desktop/src/i18n/locales/gu/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ha/messages.po
+++ b/apps/desktop/src/i18n/locales/ha/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/he/messages.po
+++ b/apps/desktop/src/i18n/locales/he/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hi/messages.po
+++ b/apps/desktop/src/i18n/locales/hi/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hr/messages.po
+++ b/apps/desktop/src/i18n/locales/hr/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ht/messages.po
+++ b/apps/desktop/src/i18n/locales/ht/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hu/messages.po
+++ b/apps/desktop/src/i18n/locales/hu/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/hy/messages.po
+++ b/apps/desktop/src/i18n/locales/hy/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/id/messages.po
+++ b/apps/desktop/src/i18n/locales/id/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ig/messages.po
+++ b/apps/desktop/src/i18n/locales/ig/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/is/messages.po
+++ b/apps/desktop/src/i18n/locales/is/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/it/messages.po
+++ b/apps/desktop/src/i18n/locales/it/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ja/messages.po
+++ b/apps/desktop/src/i18n/locales/ja/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/jv/messages.po
+++ b/apps/desktop/src/i18n/locales/jv/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ka/messages.po
+++ b/apps/desktop/src/i18n/locales/ka/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kk/messages.po
+++ b/apps/desktop/src/i18n/locales/kk/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/km/messages.po
+++ b/apps/desktop/src/i18n/locales/km/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/kn/messages.po
+++ b/apps/desktop/src/i18n/locales/kn/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ko/messages.po
+++ b/apps/desktop/src/i18n/locales/ko/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ku/messages.po
+++ b/apps/desktop/src/i18n/locales/ku/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ky/messages.po
+++ b/apps/desktop/src/i18n/locales/ky/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/la/messages.po
+++ b/apps/desktop/src/i18n/locales/la/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lb/messages.po
+++ b/apps/desktop/src/i18n/locales/lb/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lg/messages.po
+++ b/apps/desktop/src/i18n/locales/lg/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ln/messages.po
+++ b/apps/desktop/src/i18n/locales/ln/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lo/messages.po
+++ b/apps/desktop/src/i18n/locales/lo/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lt/messages.po
+++ b/apps/desktop/src/i18n/locales/lt/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/lv/messages.po
+++ b/apps/desktop/src/i18n/locales/lv/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mg/messages.po
+++ b/apps/desktop/src/i18n/locales/mg/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mi/messages.po
+++ b/apps/desktop/src/i18n/locales/mi/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mk/messages.po
+++ b/apps/desktop/src/i18n/locales/mk/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ml/messages.po
+++ b/apps/desktop/src/i18n/locales/ml/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mn/messages.po
+++ b/apps/desktop/src/i18n/locales/mn/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mr/messages.po
+++ b/apps/desktop/src/i18n/locales/mr/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ms/messages.po
+++ b/apps/desktop/src/i18n/locales/ms/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/mt/messages.po
+++ b/apps/desktop/src/i18n/locales/mt/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/my/messages.po
+++ b/apps/desktop/src/i18n/locales/my/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ne/messages.po
+++ b/apps/desktop/src/i18n/locales/ne/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nl/messages.po
+++ b/apps/desktop/src/i18n/locales/nl/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/nn/messages.po
+++ b/apps/desktop/src/i18n/locales/nn/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/no/messages.po
+++ b/apps/desktop/src/i18n/locales/no/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ny/messages.po
+++ b/apps/desktop/src/i18n/locales/ny/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/oc/messages.po
+++ b/apps/desktop/src/i18n/locales/oc/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/or/messages.po
+++ b/apps/desktop/src/i18n/locales/or/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pa/messages.po
+++ b/apps/desktop/src/i18n/locales/pa/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pl/messages.po
+++ b/apps/desktop/src/i18n/locales/pl/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ps/messages.po
+++ b/apps/desktop/src/i18n/locales/ps/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/pt/messages.po
+++ b/apps/desktop/src/i18n/locales/pt/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ro/messages.po
+++ b/apps/desktop/src/i18n/locales/ro/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ru/messages.po
+++ b/apps/desktop/src/i18n/locales/ru/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sa/messages.po
+++ b/apps/desktop/src/i18n/locales/sa/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sd/messages.po
+++ b/apps/desktop/src/i18n/locales/sd/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/si/messages.po
+++ b/apps/desktop/src/i18n/locales/si/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sk/messages.po
+++ b/apps/desktop/src/i18n/locales/sk/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sl/messages.po
+++ b/apps/desktop/src/i18n/locales/sl/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sn/messages.po
+++ b/apps/desktop/src/i18n/locales/sn/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/so/messages.po
+++ b/apps/desktop/src/i18n/locales/so/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sq/messages.po
+++ b/apps/desktop/src/i18n/locales/sq/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sr/messages.po
+++ b/apps/desktop/src/i18n/locales/sr/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/su/messages.po
+++ b/apps/desktop/src/i18n/locales/su/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sv/messages.po
+++ b/apps/desktop/src/i18n/locales/sv/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/sw/messages.po
+++ b/apps/desktop/src/i18n/locales/sw/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ta/messages.po
+++ b/apps/desktop/src/i18n/locales/ta/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/te/messages.po
+++ b/apps/desktop/src/i18n/locales/te/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tg/messages.po
+++ b/apps/desktop/src/i18n/locales/tg/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/th/messages.po
+++ b/apps/desktop/src/i18n/locales/th/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tk/messages.po
+++ b/apps/desktop/src/i18n/locales/tk/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tl/messages.po
+++ b/apps/desktop/src/i18n/locales/tl/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tr/messages.po
+++ b/apps/desktop/src/i18n/locales/tr/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/tt/messages.po
+++ b/apps/desktop/src/i18n/locales/tt/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uk/messages.po
+++ b/apps/desktop/src/i18n/locales/uk/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/ur/messages.po
+++ b/apps/desktop/src/i18n/locales/ur/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/uz/messages.po
+++ b/apps/desktop/src/i18n/locales/uz/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/vi/messages.po
+++ b/apps/desktop/src/i18n/locales/vi/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/wo/messages.po
+++ b/apps/desktop/src/i18n/locales/wo/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/xh/messages.po
+++ b/apps/desktop/src/i18n/locales/xh/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yi/messages.po
+++ b/apps/desktop/src/i18n/locales/yi/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/yo/messages.po
+++ b/apps/desktop/src/i18n/locales/yo/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zh/messages.po
+++ b/apps/desktop/src/i18n/locales/zh/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/i18n/locales/zu/messages.po
+++ b/apps/desktop/src/i18n/locales/zu/messages.po
@@ -1383,6 +1383,7 @@ msgstr ""
 
 #: src/chat/components/message/error.tsx
 #: src/session/components/note-input/enhanced/enhance-error.tsx
+#: src/settings/general/storage/legacy-cleanup.tsx
 msgid "Retry"
 msgstr ""
 

--- a/apps/desktop/src/settings/general/storage/legacy-cleanup.test.tsx
+++ b/apps/desktop/src/settings/general/storage/legacy-cleanup.test.tsx
@@ -13,11 +13,15 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 const mocks = vi.hoisted(() => ({
   cleanupLegacyFiles: vi.fn(),
   getLegacyCleanupStatus: vi.fn(),
+  getLegacyImportReport: vi.fn(),
+  runLegacyImport: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-db", () => ({
   cleanupLegacyFiles: mocks.cleanupLegacyFiles,
   getLegacyCleanupStatus: mocks.getLegacyCleanupStatus,
+  getLegacyImportReport: mocks.getLegacyImportReport,
+  runLegacyImport: mocks.runLegacyImport,
 }));
 
 vi.mock("@lingui/react/macro", () => ({
@@ -62,6 +66,36 @@ describe("LegacyMigrationCleanupRow", () => {
       deletedFileCount: 12,
       deletedBytes: 2048,
     });
+    mocks.getLegacyImportReport.mockResolvedValue({
+      state: {
+        phase: "cutover",
+        latestRunId: "run-1",
+        parityVerified: true,
+        cutoverAt: null,
+        rollbackUntil: null,
+        lastError: "",
+        updatedAt: "2026-07-16T00:00:00Z",
+      },
+      latestRun: {
+        id: "run-1",
+        importerVersion: 1,
+        sourceRoot: "/Users/test/Anarlog",
+        dryRun: false,
+        status: "completed",
+        discoveredCount: 12,
+        importedCount: 12,
+        matchedCount: 0,
+        skippedCount: 0,
+        conflictCount: 0,
+        errorCount: 0,
+        startedAt: "2026-07-16T00:00:00Z",
+        completedAt: "2026-07-16T00:00:01Z",
+        error: "",
+      },
+      items: [],
+      targets: [],
+    });
+    mocks.runLegacyImport.mockResolvedValue("run-2");
   });
 
   afterEach(() => {
@@ -126,6 +160,87 @@ describe("LegacyMigrationCleanupRow", () => {
     expect(
       screen.getByText("1 legacy file changed after migration"),
     ).toBeTruthy();
+    expect(screen.getByRole("button", { name: "Retry" })).toBeTruthy();
     expect(screen.queryByRole("button", { name: "Clean Up" })).toBeNull();
+  });
+
+  it("retries an incomplete migration and refreshes its status", async () => {
+    mocks.getLegacyCleanupStatus
+      .mockResolvedValueOnce({
+        migrationVerified: false,
+        available: false,
+        alreadyCleaned: false,
+        fileCount: 0,
+        totalBytes: 0,
+        sourceRoot: "/Users/test/Anarlog",
+        blockingReason: "SQLite migration verification is incomplete",
+      })
+      .mockResolvedValue({
+        migrationVerified: true,
+        available: true,
+        alreadyCleaned: false,
+        fileCount: 12,
+        totalBytes: 2048,
+        sourceRoot: "/Users/test/Anarlog",
+        blockingReason: null,
+      });
+    mocks.getLegacyImportReport.mockResolvedValueOnce({
+      state: {
+        phase: "shadow",
+        latestRunId: "run-1",
+        parityVerified: false,
+        cutoverAt: null,
+        rollbackUntil: null,
+        lastError: "completed_with_issues",
+        updatedAt: "2026-07-16T00:00:00Z",
+      },
+      latestRun: {
+        id: "run-1",
+        importerVersion: 1,
+        sourceRoot: "/Users/test/Anarlog",
+        dryRun: false,
+        status: "completed_with_issues",
+        discoveredCount: 12,
+        importedCount: 11,
+        matchedCount: 0,
+        skippedCount: 1,
+        conflictCount: 0,
+        errorCount: 1,
+        startedAt: "2026-07-16T00:00:00Z",
+        completedAt: "2026-07-16T00:00:01Z",
+        error: "",
+      },
+      items: [
+        {
+          sourcePath: "sessions/session-1/_memo.md",
+          sourceKind: "session_document",
+          sourceSha256: "hash",
+          status: "partial",
+          discoveredCount: 1,
+          importedCount: 0,
+          matchedCount: 0,
+          skippedCount: 1,
+          conflictCount: 0,
+          error: "missing session dependency",
+        },
+      ],
+      targets: [],
+    });
+
+    renderRow();
+    expect(
+      await screen.findByText(
+        "sessions/session-1/_memo.md: missing session dependency",
+      ),
+    ).toBeTruthy();
+
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+
+    await waitFor(() =>
+      expect(mocks.runLegacyImport).toHaveBeenCalledWith(false),
+    );
+    await waitFor(() =>
+      expect(screen.getByText("Migration complete")).toBeTruthy(),
+    );
   });
 });

--- a/apps/desktop/src/settings/general/storage/legacy-cleanup.tsx
+++ b/apps/desktop/src/settings/general/storage/legacy-cleanup.tsx
@@ -3,12 +3,18 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import {
   CheckCircle2Icon,
   Loader2Icon,
+  RotateCcwIcon,
   Trash2Icon,
   TriangleAlertIcon,
 } from "lucide-react";
 import { useState } from "react";
 
-import { cleanupLegacyFiles, getLegacyCleanupStatus } from "@hypr/plugin-db";
+import {
+  cleanupLegacyFiles,
+  getLegacyCleanupStatus,
+  getLegacyImportReport,
+  runLegacyImport,
+} from "@hypr/plugin-db";
 import { Button } from "@hypr/ui/components/ui/button";
 import {
   Dialog,
@@ -19,15 +25,21 @@ import {
   DialogTitle,
 } from "@hypr/ui/components/ui/dialog";
 
-const QUERY_KEY = ["legacy-migration-cleanup"] as const;
+const QUERY_KEY = ["legacy-migration"] as const;
 
 export function LegacyMigrationCleanupRow() {
   const { t } = useLingui();
   const queryClient = useQueryClient();
   const [confirmationOpen, setConfirmationOpen] = useState(false);
-  const statusQuery = useQuery({
+  const migrationQuery = useQuery({
     queryKey: QUERY_KEY,
-    queryFn: getLegacyCleanupStatus,
+    queryFn: async () => {
+      const [status, report] = await Promise.all([
+        getLegacyCleanupStatus(),
+        getLegacyImportReport(),
+      ]);
+      return { status, report };
+    },
   });
   const cleanupMutation = useMutation({
     mutationFn: cleanupLegacyFiles,
@@ -36,10 +48,36 @@ export function LegacyMigrationCleanupRow() {
       await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
     },
   });
+  const retryMutation = useMutation({
+    mutationFn: () => runLegacyImport(false),
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    },
+  });
 
-  const status = statusQuery.data;
+  const status = migrationQuery.data?.status;
+  const report = migrationQuery.data?.report;
+  const migrationIssue = (() => {
+    if (retryMutation.error) return retryMutation.error.message;
+
+    const latestRun = report?.latestRun;
+    if (!latestRun) return status?.blockingReason ?? null;
+    if (latestRun.error.trim()) return latestRun.error;
+
+    const issueItem = report.items.find(
+      (item) => item.status === "error" || item.status === "partial",
+    );
+    if (issueItem?.error.trim()) {
+      return `${issueItem.sourcePath}: ${issueItem.error}`;
+    }
+    if (issueItem) {
+      return `${issueItem.sourcePath}: ${issueItem.status}`;
+    }
+
+    return status?.blockingReason ?? null;
+  })();
   const statusCopy = (() => {
-    if (statusQuery.isLoading) {
+    if (migrationQuery.isLoading) {
       return {
         state: "loading" as const,
         label: t`Checking migration...`,
@@ -47,7 +85,7 @@ export function LegacyMigrationCleanupRow() {
       };
     }
 
-    if (statusQuery.error || !status) {
+    if (migrationQuery.error || !status) {
       return {
         state: "warning" as const,
         label: t`Migration status unavailable`,
@@ -60,8 +98,7 @@ export function LegacyMigrationCleanupRow() {
         state: "warning" as const,
         label: t`Migration needs attention`,
         description:
-          status.blockingReason ??
-          t`SQLite migration verification is incomplete`,
+          migrationIssue ?? t`SQLite migration verification is incomplete`,
       };
     }
 
@@ -91,28 +128,40 @@ export function LegacyMigrationCleanupRow() {
   return (
     <>
       <div className="grid grid-cols-[minmax(0,1fr)_9rem] items-center gap-3">
-        <div className="flex min-w-0 items-center gap-1.5 text-sm">
+        <div className="flex min-w-0 items-start gap-1.5 text-sm">
           {statusCopy.state === "loading" && (
-            <Loader2Icon className="text-muted-foreground size-4 shrink-0 animate-spin" />
+            <Loader2Icon className="text-muted-foreground mt-0.5 size-4 shrink-0 animate-spin" />
           )}
           {statusCopy.state === "success" && (
-            <CheckCircle2Icon className="size-4 shrink-0 text-green-600" />
+            <CheckCircle2Icon className="mt-0.5 size-4 shrink-0 text-green-600" />
           )}
           {statusCopy.state === "warning" && (
-            <TriangleAlertIcon className="size-4 shrink-0 text-yellow-600" />
+            <TriangleAlertIcon className="mt-0.5 size-4 shrink-0 text-yellow-600" />
           )}
-          <span className="shrink-0 font-medium">{statusCopy.label}</span>
-          {statusCopy.description && (
-            <>
-              <span className="text-muted-foreground" aria-hidden="true">
-                ·
-              </span>
-              <span className="text-muted-foreground truncate">
+          <div className="min-w-0">
+            <p className="font-medium">{statusCopy.label}</p>
+            {statusCopy.description && (
+              <p className="text-muted-foreground mt-0.5 text-xs break-words">
                 {statusCopy.description}
-              </span>
-            </>
-          )}
+              </p>
+            )}
+          </div>
         </div>
+        {status && !status.migrationVerified && (
+          <Button
+            variant="outline"
+            className="h-9 w-full justify-center"
+            onClick={() => retryMutation.mutate()}
+            disabled={retryMutation.isPending}
+          >
+            {retryMutation.isPending ? (
+              <Loader2Icon className="size-4 animate-spin" aria-hidden="true" />
+            ) : (
+              <RotateCcwIcon className="size-4" aria-hidden="true" />
+            )}
+            {t`Retry`}
+          </Button>
+        )}
         {status?.migrationVerified && status.available && (
           <Button
             variant="destructive"

--- a/plugins/db/src/import/mod.rs
+++ b/plugins/db/src/import/mod.rs
@@ -12,52 +12,70 @@ pub async fn import_legacy_data<R: tauri::Runtime>(
     app: &tauri::AppHandle<R>,
     pool: &SqlitePool,
 ) -> crate::Result<()> {
-    if !legacy_import_required(pool).await? {
+    if !legacy_import_attempt_required(pool).await? {
         return Ok(());
     }
 
     let vault_base = resolve_startup_vault_base(app)?;
-    let run_id = legacy_vault::import_legacy_vault(pool, &vault_base, false).await?;
-    require_startup_ready_import(pool, &run_id).await
-}
+    let run_id = match legacy_vault::import_legacy_vault(pool, &vault_base, false).await {
+        Ok(run_id) => run_id,
+        Err(crate::Error::Io(error)) => {
+            tracing::warn!(
+                %error,
+                "legacy import could not read its source files; continuing with recovery copies intact"
+            );
+            return Ok(());
+        }
+        Err(error) => return Err(error),
+    };
 
-async fn require_startup_ready_import(pool: &SqlitePool, run_id: &str) -> crate::Result<()> {
-    if legacy_import_required(pool).await? {
-        return Err(std::io::Error::other(format!(
-            "legacy import {run_id} did not pass parity verification; source files were left unchanged",
-        ))
-        .into());
+    if !legacy_migration_verified(pool).await? {
+        tracing::warn!(
+            %run_id,
+            "legacy import needs attention; continuing with recovery copies intact"
+        );
     }
 
     Ok(())
 }
 
-async fn legacy_import_required(pool: &SqlitePool) -> Result<bool, sqlx::Error> {
-    let startup_ready: bool = sqlx::query_scalar(
+async fn legacy_import_attempt_required(pool: &SqlitePool) -> Result<bool, sqlx::Error> {
+    let attempted: bool = sqlx::query_scalar(
         "SELECT EXISTS(
            SELECT 1
            FROM storage_migration_state AS state
-           LEFT JOIN migration_import_runs AS run ON run.id = state.latest_run_id
+           JOIN migration_import_runs AS run ON run.id = state.latest_run_id
            WHERE state.id = 'legacy_v1'
-             AND (
-               (state.importer_version = ? AND state.parity_verified = 1)
-               OR (
-                 run.importer_version = ?
-                 AND run.dry_run = 0
-                 AND run.status = 'completed_with_conflicts'
-                 AND run.conflict_count > 0
-                 AND run.skipped_count = 0
-                 AND run.error_count = 0
-               )
+             AND run.importer_version = ?
+             AND run.dry_run = 0
+             AND run.status IN (
+               'completed',
+               'completed_with_conflicts',
+               'completed_with_issues',
+               'failed'
              )
          )",
     )
     .bind(hypr_db_app::LEGACY_IMPORTER_VERSION)
-    .bind(hypr_db_app::LEGACY_IMPORTER_VERSION)
     .fetch_one(pool)
     .await?;
 
-    Ok(!startup_ready)
+    Ok(!attempted)
+}
+
+pub(crate) async fn legacy_migration_verified(pool: &SqlitePool) -> Result<bool, sqlx::Error> {
+    sqlx::query_scalar(
+        "SELECT EXISTS(
+           SELECT 1
+           FROM storage_migration_state
+           WHERE id = 'legacy_v1'
+             AND importer_version = ?
+             AND parity_verified = 1
+         )",
+    )
+    .bind(hypr_db_app::LEGACY_IMPORTER_VERSION)
+    .fetch_one(pool)
+    .await
 }
 
 pub async fn rerun_legacy_import(pool: &SqlitePool, dry_run: bool) -> crate::Result<String> {
@@ -198,11 +216,11 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn verified_current_import_is_not_repeated_at_startup() {
+    async fn migration_verification_uses_current_importer_version() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
 
-        assert!(legacy_import_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
 
         sqlx::query(
             "UPDATE storage_migration_state
@@ -214,10 +232,7 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(!legacy_import_required(db.pool()).await.unwrap());
-        require_startup_ready_import(db.pool(), "verified-run")
-            .await
-            .unwrap();
+        assert!(legacy_migration_verified(db.pool()).await.unwrap());
 
         sqlx::query(
             "UPDATE storage_migration_state
@@ -228,32 +243,43 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(legacy_import_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
     }
 
     #[tokio::test]
-    async fn incomplete_import_still_blocks_startup() {
+    async fn completed_issue_run_is_not_repeated_automatically() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
 
-        let error = require_startup_ready_import(db.pool(), "run-with-errors")
-            .await
-            .unwrap_err();
+        assert!(legacy_import_attempt_required(db.pool()).await.unwrap());
+        assert_eq!(
+            finish_issue_run(db.pool(), "issue-run", "partial", 1, 0).await,
+            "completed_with_issues"
+        );
 
-        assert!(
-            error
-                .to_string()
-                .contains("did not pass parity verification")
-        );
-        assert!(
-            error
-                .to_string()
-                .contains("source files were left unchanged")
-        );
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
     }
 
     #[tokio::test]
-    async fn conflict_only_import_allows_startup_without_verifying_parity() {
+    async fn failed_source_scan_is_left_for_explicit_retry() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        hypr_db_app::prepare_schema(&db).await.unwrap();
+
+        hypr_db_app::begin_legacy_import_run(db.pool(), "failed-run", "/vault", false)
+            .await
+            .unwrap();
+        hypr_db_app::fail_legacy_import_run(db.pool(), "failed-run", "permission denied")
+            .await
+            .unwrap();
+
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+    }
+
+    #[tokio::test]
+    async fn conflict_only_import_preserves_cleanup_guard() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
 
@@ -269,10 +295,8 @@ mod tests {
         .await
         .unwrap();
         assert!(!parity_verified);
-        assert!(!legacy_import_required(db.pool()).await.unwrap());
-        require_startup_ready_import(db.pool(), "conflict-run")
-            .await
-            .unwrap();
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
 
         let cleanup_status = cleanup::get_status(db.pool()).await.unwrap();
         assert!(!cleanup_status.migration_verified);
@@ -281,7 +305,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn legacy_completed_with_issues_conflicts_remain_retryable() {
+    async fn legacy_completed_with_issues_conflicts_remain_unverified() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
         finish_issue_run(db.pool(), "legacy-conflict-run", "conflict", 0, 1).await;
@@ -293,16 +317,12 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(legacy_import_required(db.pool()).await.unwrap());
-        assert!(
-            require_startup_ready_import(db.pool(), "legacy-conflict-run")
-                .await
-                .is_err()
-        );
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
     }
 
     #[tokio::test]
-    async fn legacy_conflict_only_run_is_retried_once_and_then_allows_startup() {
+    async fn explicit_retry_normalizes_legacy_conflict_only_run() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
         let sqlite_document = r#"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"SQLite note"}]}]}"#;
@@ -384,11 +404,8 @@ mod tests {
         .await
         .unwrap();
 
-        assert!(legacy_import_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
         let recovery_run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
-            .await
-            .unwrap();
-        require_startup_ready_import(db.pool(), &recovery_run_id)
             .await
             .unwrap();
 
@@ -445,20 +462,13 @@ mod tests {
         assert!(!cleanup_status.available);
         assert!(cleanup_status.blocking_reason.is_some());
 
-        assert!(!legacy_import_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
         let run_count_before_second_startup: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
                 .fetch_one(db.pool())
                 .await
                 .unwrap();
-        if legacy_import_required(db.pool()).await.unwrap() {
-            let run_id = legacy_vault::import_legacy_vault(db.pool(), vault.path(), false)
-                .await
-                .unwrap();
-            require_startup_ready_import(db.pool(), &run_id)
-                .await
-                .unwrap();
-        }
         let run_count_after_second_startup: i64 =
             sqlx::query_scalar("SELECT COUNT(*) FROM migration_import_runs")
                 .fetch_one(db.pool())
@@ -471,7 +481,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn skipped_and_error_imports_remain_blocking_and_retryable() {
+    async fn skipped_and_error_imports_remain_unverified_for_explicit_retry() {
         for (run_id, item_status, skipped_count) in
             [("skipped-run", "partial", 1), ("error-run", "error", 0)]
         {
@@ -482,17 +492,13 @@ mod tests {
                 finish_issue_run(db.pool(), run_id, item_status, skipped_count, 0).await,
                 "completed_with_issues"
             );
-            assert!(legacy_import_required(db.pool()).await.unwrap());
-            assert!(
-                require_startup_ready_import(db.pool(), run_id)
-                    .await
-                    .is_err()
-            );
+            assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+            assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
         }
     }
 
     #[tokio::test]
-    async fn orphaned_session_children_remain_blocking_and_retryable() {
+    async fn orphaned_session_children_remain_unverified_for_explicit_retry() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
         let vault = tempfile::tempdir().unwrap();
@@ -526,16 +532,12 @@ mod tests {
 
         assert_eq!(run, ("completed_with_issues".to_string(), 1, 0, 1));
         assert_eq!(target_status, "missing_dependency");
-        assert!(legacy_import_required(db.pool()).await.unwrap());
-        assert!(
-            require_startup_ready_import(db.pool(), &run_id)
-                .await
-                .is_err()
-        );
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
     }
 
     #[tokio::test]
-    async fn document_and_transcript_conflicts_preserve_both_stores_and_allow_startup() {
+    async fn document_and_transcript_conflicts_preserve_both_stores() {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
         let sqlite_document = r#"{"type":"doc","content":[{"type":"paragraph","content":[{"type":"text","text":"SQLite note"}]}]}"#;
@@ -647,10 +649,8 @@ mod tests {
         .await
         .unwrap();
         assert!(!parity_verified);
-        assert!(!legacy_import_required(db.pool()).await.unwrap());
-        require_startup_ready_import(db.pool(), &run_id)
-            .await
-            .unwrap();
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
 
         let cleanup_status = cleanup::get_status(db.pool()).await.unwrap();
         assert!(!cleanup_status.migration_verified);
@@ -719,9 +719,7 @@ mod tests {
             .await
             .unwrap();
 
-        require_startup_ready_import(db.pool(), &run_id)
-            .await
-            .unwrap();
+        assert!(legacy_migration_verified(db.pool()).await.unwrap());
         let target_statuses: Vec<String> = sqlx::query_scalar(
             "SELECT status FROM migration_import_targets WHERE run_id = ? ORDER BY target_id",
         )
@@ -763,7 +761,8 @@ mod tests {
 
         let db = crate::runtime::open_app_db(Some(&db_path)).await.unwrap();
         assert!(db.cloudsync_enabled());
-        assert!(legacy_import_required(db.pool()).await.unwrap());
+        assert!(!legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(legacy_import_attempt_required(db.pool()).await.unwrap());
 
         let run_id = legacy_vault::import_legacy_vault(db.pool(), &vault, false)
             .await
@@ -791,7 +790,8 @@ mod tests {
         assert_eq!(state_before.0, run_id);
         assert!(state_before.1);
         assert_eq!(state_before.2, hypr_db_app::LEGACY_IMPORTER_VERSION);
-        assert!(!legacy_import_required(db.pool()).await.unwrap());
+        assert!(legacy_migration_verified(db.pool()).await.unwrap());
+        assert!(!legacy_import_attempt_required(db.pool()).await.unwrap());
 
         db.pool().close().await;
         drop(db);
@@ -805,7 +805,10 @@ mod tests {
         let reopened = crate::runtime::open_app_db(Some(&db_path)).await.unwrap();
         assert!(reopened.cloudsync_enabled());
 
-        if legacy_import_required(reopened.pool()).await.unwrap() {
+        if legacy_import_attempt_required(reopened.pool())
+            .await
+            .unwrap()
+        {
             legacy_vault::import_legacy_vault(reopened.pool(), &vault, false)
                 .await
                 .unwrap();
@@ -831,9 +834,11 @@ mod tests {
         assert_eq!(state_after, state_before);
         assert_eq!(run_count_after, run_count_before);
         assert_eq!(stored_title, "Imported before restart");
-        assert!(!legacy_import_required(reopened.pool()).await.unwrap());
-        require_startup_ready_import(reopened.pool(), &run_id)
-            .await
-            .unwrap();
+        assert!(legacy_migration_verified(reopened.pool()).await.unwrap());
+        assert!(
+            !legacy_import_attempt_required(reopened.pool())
+                .await
+                .unwrap()
+        );
     }
 }

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -172,7 +172,15 @@ pub fn init_with_cloudsync<R: tauri::Runtime>(
             hypr_tauri_utils::block_on(hypr_db_app::prepare_schema(db.as_ref()))?;
             hypr_tauri_utils::block_on(import::import_legacy_data(app.app_handle(), db.pool()))?;
             if let Some(config) = startup_config.clone() {
-                if let Err(error) = hypr_tauri_utils::block_on(db.cloudsync_configure(config)) {
+                let migration_verified =
+                    hypr_tauri_utils::block_on(import::legacy_migration_verified(db.pool()))?;
+                if !migration_verified {
+                    tracing::warn!(
+                        "startup CloudSync configuration skipped until legacy migration is verified"
+                    );
+                } else if let Err(error) =
+                    hypr_tauri_utils::block_on(db.cloudsync_configure(config))
+                {
                     tracing::warn!(%error, "failed to configure startup cloudsync");
                 } else {
                     let sync_db = std::sync::Arc::clone(&db);
@@ -267,6 +275,15 @@ mod test {
         .await
         .unwrap();
         hypr_db_app::prepare_schema(&db).await.unwrap();
+        sqlx::query(
+            "UPDATE storage_migration_state
+             SET importer_version = ?, parity_verified = 1
+             WHERE id = 'legacy_v1'",
+        )
+        .bind(hypr_db_app::LEGACY_IMPORTER_VERSION)
+        .execute(db.pool())
+        .await
+        .unwrap();
 
         (dir, Arc::new(runtime::PluginDbRuntime::new(Arc::new(db))))
     }
@@ -535,6 +552,41 @@ mod test {
         assert_eq!(status["network_initialized"], false);
 
         runtime.logout_cloudsync(false).await.unwrap();
+        assert_eq!(
+            runtime.cloudsync_status().await.unwrap()["configured"],
+            false
+        );
+    }
+
+    #[tokio::test]
+    async fn cloudsync_waits_for_legacy_migration_verification() {
+        let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
+        sqlx::query(
+            "UPDATE storage_migration_state
+             SET parity_verified = 0, last_error = 'completed_with_issues'
+             WHERE id = 'legacy_v1'",
+        )
+        .execute(runtime.pool())
+        .await
+        .unwrap();
+
+        let error = runtime
+            .configure_cloudsync_token(
+                "managed-database-id".to_string(),
+                "token".to_string(),
+                "user-a".to_string(),
+            )
+            .await
+            .unwrap_err();
+
+        assert!(matches!(&error, crate::Error::Io(_)));
+        assert!(
+            error
+                .to_string()
+                .contains("migration needs attention before CloudSync can start")
+        );
+        assert!(runtime.start_cloudsync().await.is_err());
+        assert!(runtime.sync_cloudsync_now().await.is_err());
         assert_eq!(
             runtime.cloudsync_status().await.unwrap()["configured"],
             false

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -60,6 +60,19 @@ impl PluginDbRuntime {
         Ok(())
     }
 
+    async fn ensure_legacy_migration_verified(&self) -> Result<()> {
+        self.ensure_app_schema().await?;
+        if crate::import::legacy_migration_verified(self.db.pool()).await? {
+            return Ok(());
+        }
+
+        let _ = self.db.cloudsync_suspend().await;
+        Err(std::io::Error::other(
+            "legacy data migration needs attention before CloudSync can start",
+        )
+        .into())
+    }
+
     pub async fn execute(
         &self,
         sql: String,
@@ -126,6 +139,7 @@ impl PluginDbRuntime {
     }
 
     pub async fn configure_cloudsync(&self, config_json: String) -> Result<()> {
+        self.ensure_legacy_migration_verified().await?;
         let config = serde_json::from_str(&config_json)?;
         self.db.cloudsync_configure(config).await?;
         Ok(())
@@ -140,6 +154,7 @@ impl PluginDbRuntime {
         if !self.db.cloudsync_enabled() {
             return Err(hypr_db_core::CloudsyncRuntimeError::Unavailable.into());
         }
+        self.ensure_legacy_migration_verified().await?;
 
         if !self.claim_cloudsync_workspace(workspace_id).await? {
             return Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch);
@@ -214,7 +229,7 @@ impl PluginDbRuntime {
     }
 
     pub async fn start_cloudsync(&self) -> Result<()> {
-        self.ensure_app_schema().await?;
+        self.ensure_legacy_migration_verified().await?;
         self.db.cloudsync_start().await?;
         Ok(())
     }
@@ -234,6 +249,7 @@ impl PluginDbRuntime {
     }
 
     pub async fn sync_cloudsync_now(&self) -> Result<serde_json::Value> {
+        self.ensure_legacy_migration_verified().await?;
         Ok(serde_json::to_value(
             self.db.cloudsync_trigger_sync().await?,
         )?)


### PR DESCRIPTION
Continue with recovery copies intact, expose an explicit retry with the exact migration issue, and keep CloudSync suspended until parity verification succeeds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes startup import semantics and gates CloudSync on migration verification, which affects data sync timing but reduces risk of blocking launches or syncing before parity is proven.
> 
> **Overview**
> **Incomplete or failed SQLite legacy imports no longer block app startup.** Startup runs import at most once per “attempted” run (including `completed_with_issues` / `failed`), logs warnings when parity is not verified or source I/O fails, and leaves recovery copies on disk instead of erroring out.
> 
> **General → Storage migration UI** now loads the import report alongside cleanup status, surfaces the **specific** failure (run error, partial item path, or blocking reason), and adds a **Retry** action that calls `runLegacyImport(false)` when migration is not verified.
> 
> **CloudSync stays off until `parity_verified`.** Plugin setup skips startup CloudSync configuration when migration is unverified, and runtime configure/start/sync paths reject with a clear message until legacy migration passes verification—cleanup of legacy files remains gated the same way.
> 
> Locale `.po` files only add the `Retry` string reference for `legacy-cleanup.tsx`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 880d1c353291b23ec6c42aca1e871d6809facb1f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->