### PR TITLE
Smooth floating chat transitions

### DIFF
--- a/apps/desktop/src/chat/components/persistent-chat.test.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.test.tsx
@@ -135,8 +135,10 @@ describe("PersistentChatPanel", () => {
       expect(panel?.style.height).toBe("");
       expect(panel?.style.maxHeight).toBe("100%");
       expect(panel?.style.transformOrigin).toBe("bottom center");
+      expect(panel?.style.willChange).toBe("transform");
+      expect(panel?.style.clipPath).toBe("");
       expect(panel?.className).toContain("rounded-[24px]");
-      expect(panel?.dataset.chatPanelReveal).toBe("bottom-up");
+      expect(panel?.dataset.chatPanelReveal).toBe("lift");
     });
   });
 

--- a/apps/desktop/src/chat/components/persistent-chat.tsx
+++ b/apps/desktop/src/chat/components/persistent-chat.tsx
@@ -1,5 +1,5 @@
 import { AnimatePresence, motion } from "motion/react";
-import { useEffect, useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 
 import { cn } from "@hypr/utils";
@@ -11,15 +11,12 @@ import { chatFloatingPanelShellClassNames } from "~/chat/surface";
 import { useShell } from "~/contexts/shell";
 
 const FLOATING_CHAT_INPUT_MAX_WIDTH = 640;
-const FLOATING_CHAT_INPUT_HEIGHT = 40;
 const FLOATING_CHAT_SHELL_INSET = 4;
 const FLOATING_PANEL_MIN_WIDTH = 476;
 const FLOATING_PANEL_DEFAULT_MAX_WIDTH =
   FLOATING_CHAT_INPUT_MAX_WIDTH + FLOATING_CHAT_SHELL_INSET * 2;
-const FLOATING_PANEL_REVEAL_HEIGHT =
-  FLOATING_CHAT_INPUT_HEIGHT + FLOATING_CHAT_SHELL_INSET;
-const FLOATING_PANEL_RADIUS = 24;
 const FLOATING_PANEL_TOP_CLEARANCE = 46;
+const FLOATING_PANEL_EASE = [0.22, 1, 0.36, 1] as const;
 
 type FloatingContainerRect = {
   top: number;
@@ -38,11 +35,9 @@ export function PersistentChatPanel({
   const { chat } = useShell();
   const isVisible = chat.mode === "FloatingOpen";
 
-  const [hasBeenOpened, setHasBeenOpened] = useState(false);
   const [containerRect, setContainerRect] =
     useState<FloatingContainerRect | null>(null);
   const [draftHasContent, setDraftHasContent] = useState(false);
-  const observerRef = useRef<ResizeObserver | null>(null);
 
   const getActiveContainer = () => {
     return (
@@ -62,12 +57,6 @@ export function PersistentChatPanel({
     return toFloatingContainerRect(anchor.getBoundingClientRect());
   };
 
-  useEffect(() => {
-    if (isVisible && !hasBeenOpened) {
-      setHasBeenOpened(true);
-    }
-  }, [isVisible, hasBeenOpened]);
-
   useHotkeys(
     "esc",
     () => chat.sendEvent({ type: "CLOSE" }),
@@ -81,87 +70,55 @@ export function PersistentChatPanel({
   );
 
   useLayoutEffect(() => {
-    const nextRect = getContainerRect();
-
-    if (!isVisible || !nextRect) {
-      setContainerRect(null);
-      return;
-    }
-    setContainerRect(nextRect);
-  }, [isVisible, hasBeenOpened, floatingContainerRef]);
-
-  useEffect(() => {
     const root = floatingContainerRef.current;
     const container = getActiveContainer();
 
     if (!isVisible || !root || !container) {
-      if (observerRef.current) {
-        observerRef.current.disconnect();
-        observerRef.current = null;
-      }
       return;
     }
 
     const updateRect = () => {
-      setContainerRect(getContainerRect());
+      const nextRect = getContainerRect();
+      setContainerRect((currentRect) =>
+        areFloatingContainerRectsEqual(currentRect, nextRect)
+          ? currentRect
+          : nextRect,
+      );
     };
 
-    observerRef.current = new ResizeObserver(updateRect);
+    updateRect();
+    const observer = new ResizeObserver(updateRect);
     if (root !== container) {
-      observerRef.current.observe(root);
+      observer.observe(root);
     }
-    observerRef.current.observe(container);
+    observer.observe(container);
     window.addEventListener("resize", updateRect);
     window.addEventListener("scroll", updateRect, true);
 
     return () => {
-      observerRef.current?.disconnect();
-      observerRef.current = null;
+      observer.disconnect();
       window.removeEventListener("resize", updateRect);
       window.removeEventListener("scroll", updateRect, true);
     };
-  }, [isVisible, hasBeenOpened, floatingContainerRef]);
-
-  if (!hasBeenOpened) {
-    return null;
-  }
+  }, [isVisible, floatingContainerRef]);
 
   const panelMotion = {
-    initial: {
-      y: 0,
-      opacity: 1,
-      scale: 1,
-      clipPath: `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
-    },
-    animate: {
-      y: 0,
-      opacity: 1,
-      scale: 1,
-      clipPath: `inset(0 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
-    },
-    exit: {
-      y: 8,
-      opacity: 0,
-      scale: 0.99,
-      clipPath: `inset(calc(100% - ${FLOATING_PANEL_REVEAL_HEIGHT}px) 0 0 0 round ${FLOATING_PANEL_RADIUS}px)`,
-    },
+    initial: { y: 10, scale: 0.985 },
+    animate: { y: 0, scale: 1 },
+    exit: { y: 6, scale: 0.99 },
   };
-  const panelTransition = {
-    opacity: { duration: 0.18, ease: [0.22, 1, 0.36, 1] },
-    scale: { duration: 0.2, ease: [0.22, 1, 0.36, 1] },
-    y: { duration: 0.22, ease: [0.22, 1, 0.36, 1] },
-    clipPath: { duration: 0.32, ease: [0.22, 1, 0.36, 1] },
-  };
+  const panelTransition = { duration: 0.18, ease: FLOATING_PANEL_EASE };
   const panelStyle = {
     width: "100%",
     minWidth: `min(${FLOATING_PANEL_MIN_WIDTH}px, 100%)`,
     maxWidth: `${FLOATING_PANEL_DEFAULT_MAX_WIDTH}px`,
     maxHeight: "100%",
     transformOrigin: "bottom center",
+    willChange: "transform",
   };
 
   return (
-    <AnimatePresence>
+    <AnimatePresence initial={false}>
       {isVisible && (
         <motion.div
           className="pointer-events-none fixed z-100"
@@ -172,13 +129,14 @@ export function PersistentChatPanel({
                   left: containerRect.left,
                   width: containerRect.width,
                   height: containerRect.height,
+                  willChange: "opacity",
                 }
               : { display: "none" }
           }
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
           exit={{ opacity: 0 }}
-          transition={{ duration: 0.2 }}
+          transition={{ duration: 0.12, ease: FLOATING_PANEL_EASE }}
         >
           <div
             data-chat-floating-frame
@@ -201,7 +159,7 @@ export function PersistentChatPanel({
           >
             <motion.div
               data-chat-panel
-              data-chat-panel-reveal="bottom-up"
+              data-chat-panel-reveal="lift"
               data-chat-size="floating"
               className={cn([
                 "relative flex min-h-0 flex-col overflow-hidden",
@@ -236,4 +194,16 @@ function toFloatingContainerRect(rect: DOMRect): FloatingContainerRect {
     width: rect.width,
     height: rect.height,
   };
+}
+
+function areFloatingContainerRectsEqual(
+  currentRect: FloatingContainerRect | null,
+  nextRect: FloatingContainerRect | null,
+) {
+  return (
+    currentRect?.top === nextRect?.top &&
+    currentRect?.left === nextRect?.left &&
+    currentRect?.width === nextRect?.width &&
+    currentRect?.height === nextRect?.height
+  );
 }

--- a/apps/desktop/src/shared/chat-cta.test.tsx
+++ b/apps/desktop/src/shared/chat-cta.test.tsx
@@ -55,12 +55,9 @@ describe("ChatCTA", () => {
     expect(surface?.className).toContain("absolute");
     expect(surface?.className).toContain("bottom-0");
     expect(surface?.className).toContain("left-1/2");
-    expect(surface?.className).toContain("w-[min(640px,calc(100cqw_-_2rem))]");
+    expect(surface?.className).toContain("w-[180px]");
     expect(surface?.className).toContain(
-      "[clip-path:inset(0_max(0px,calc(50%_-_90px))_0_max(0px,calc(50%_-_90px))_round_32px)]",
-    );
-    expect(surface?.className).toContain(
-      "transition-[clip-path,height,padding,background-color,border-color,box-shadow]",
+      "transition-[width,height,padding,background-color,border-color,box-shadow]",
     );
     expect(surface?.className).toContain("origin-bottom");
     expect(surface?.className).toContain("h-2");
@@ -99,26 +96,22 @@ describe("ChatCTA", () => {
     );
     expect(surface?.className).toContain("group-hover/anarlog-chat-cta:h-10");
     expect(surface?.className).toContain(
-      "group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+      "group-hover/anarlog-chat-cta:w-[min(640px,calc(100cqw_-_2rem))]",
     );
     expect(surface?.className).toContain(
-      "group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)]",
+      "group-focus-visible/anarlog-chat-cta:w-[min(640px,calc(100cqw_-_2rem))]",
     );
+    expect(surface?.className).not.toContain("clip-path");
     expect(surface?.className).not.toContain("inset_0_0_0_1px");
     expect(button.querySelectorAll("svg")).toHaveLength(0);
-    expect(label.className).toContain("max-w-0");
     expect(label.className).toContain("opacity-0");
     expect(label.className).toContain("text-white/55");
     expect(label.className).not.toContain("ml-2");
     expect(label.className).toContain(
       "group-hover/anarlog-chat-cta:text-muted-foreground",
     );
-    expect(label.className).toContain(
-      "group-hover/anarlog-chat-cta:max-w-full",
-    );
-    expect(label.className).toContain(
-      "group-focus-within/anarlog-chat-cta:max-w-full",
-    );
+    expect(label.className).toContain("transition-opacity");
+    expect(label.className).not.toContain("max-w");
   });
 
   it("uses a compact hover rectangle for the floating trigger", () => {

--- a/apps/desktop/src/shared/chat-cta.tsx
+++ b/apps/desktop/src/shared/chat-cta.tsx
@@ -37,24 +37,23 @@ export function ChatCTA({
         data-chat-cta-surface
         aria-hidden="true"
         className={cn([
-          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[min(640px,calc(100cqw_-_2rem))] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent dark:h-3",
-          "[clip-path:inset(0_max(0px,calc(50%_-_90px))_0_max(0px,calc(50%_-_90px))_round_32px)]",
-          "origin-bottom bg-[linear-gradient(180deg,#faf8f6_0%,#e3e1df_100%)] px-0 text-sm shadow-[0_0_0_1px_rgba(0,0,0,0.1),0_4px_12px_rgba(0,0,0,0.16),0_4px_16px_rgba(0,0,0,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)] transition-[clip-path,height,padding,background-color,border-color,box-shadow] duration-200 ease-out dark:bg-[linear-gradient(180deg,#211d1d_0%,#574f3b_100%)] dark:shadow-[0_4px_12px_rgba(33,29,29,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)]",
+          "pointer-events-none absolute bottom-0 left-1/2 inline-flex h-2 w-[180px] -translate-x-1/2 items-center overflow-hidden rounded-full border border-transparent dark:h-3",
+          "origin-bottom bg-[linear-gradient(180deg,#faf8f6_0%,#e3e1df_100%)] px-0 text-sm shadow-[0_0_0_1px_rgba(0,0,0,0.1),0_4px_12px_rgba(0,0,0,0.16),0_4px_16px_rgba(0,0,0,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)] transition-[width,height,padding,background-color,border-color,box-shadow] duration-150 ease-[cubic-bezier(0.22,1,0.36,1)] dark:bg-[linear-gradient(180deg,#211d1d_0%,#574f3b_100%)] dark:shadow-[0_4px_12px_rgba(33,29,29,0.1),inset_0_-1px_0_rgba(0,0,0,0.25),inset_0_1px_0_rgba(255,255,255,0.4)]",
           "group-hover/anarlog-chat-cta:border-border/70 group-focus-visible/anarlog-chat-cta:border-border/70 group-hover/anarlog-chat-cta:bg-[#f4f4f5] group-focus-visible/anarlog-chat-cta:bg-[#f4f4f5] dark:group-hover/anarlog-chat-cta:bg-[#202020] dark:group-focus-visible/anarlog-chat-cta:bg-[#202020]",
           "group-hover/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] group-focus-visible/anarlog-chat-cta:shadow-[0_16px_42px_rgba(0,0,0,0.26)] dark:group-hover/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)] dark:group-focus-visible/anarlog-chat-cta:shadow-[0_18px_52px_rgba(0,0,0,0.64)]",
-          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:px-4 group-hover/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)] dark:group-hover/anarlog-chat-cta:h-10",
-          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:px-4 group-focus-visible/anarlog-chat-cta:[clip-path:inset(0_0_0_0_round_9999px)] dark:group-focus-visible/anarlog-chat-cta:h-10",
+          "group-hover/anarlog-chat-cta:h-10 group-hover/anarlog-chat-cta:w-[min(640px,calc(100cqw_-_2rem))] group-hover/anarlog-chat-cta:px-4 dark:group-hover/anarlog-chat-cta:h-10",
+          "group-focus-visible/anarlog-chat-cta:h-10 group-focus-visible/anarlog-chat-cta:w-[min(640px,calc(100cqw_-_2rem))] group-focus-visible/anarlog-chat-cta:px-4 dark:group-focus-visible/anarlog-chat-cta:h-10",
           "group-focus-visible/anarlog-chat-cta:ring-ring group-focus-visible/anarlog-chat-cta:ring-2 group-focus-visible/anarlog-chat-cta:ring-offset-2",
         ])}
       >
         <span
           aria-hidden="true"
           className={cn([
-            "max-w-0 min-w-0 flex-1 truncate text-left opacity-0",
+            "min-w-0 flex-1 truncate text-left opacity-0",
             "group-focus-within/anarlog-chat-cta:text-muted-foreground group-hover/anarlog-chat-cta:text-muted-foreground text-white/55",
-            "transition-[max-width,opacity] duration-200 ease-out",
-            "group-hover/anarlog-chat-cta:max-w-full group-hover/anarlog-chat-cta:opacity-100",
-            "group-focus-within/anarlog-chat-cta:max-w-full group-focus-within/anarlog-chat-cta:opacity-100",
+            "transition-opacity duration-100 ease-out",
+            "group-hover/anarlog-chat-cta:opacity-100",
+            "group-focus-within/anarlog-chat-cta:opacity-100",
           ])}
         >
           {resolvedLabel}


### PR DESCRIPTION
Replace repaint-heavy clip-path reveals with lightweight width and transform motion, and avoid redundant opening renders.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop UI and motion-only changes with updated unit tests; no auth, data, or API surface changes.
> 
> **Overview**
> **Floating chat open/close** no longer uses `clip-path` reveals or a “first open only” mount gate. The panel animates with a short **lift** (`y` + `scale`) and opacity on the overlay, sets `willChange` on transform/opacity, and only updates anchor geometry when the measured rect actually changes.
> 
> **Chat CTA hover** expands the pill from a fixed **180px** handle to the wide input via **width/height** transitions instead of `clip-path`; the placeholder label fades in with **opacity** only (no `max-w` animation).
> 
> Tests assert the new reveal mode (`lift`), empty `clipPath`, and the updated CTA class behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 50992a02a284755d36f179a0d5185409dfaea094. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->