### PR TITLE
Update connected calendar privacy policy

### DIFF
--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-05-03"
+date: "2026-07-16"
 title: "Privacy Policy"
 summary: "How we collect, use, and protect your personal information"
 ---
@@ -35,15 +35,15 @@ When you use the Service, we may automatically collect:
 
 Analytics and telemetry events are designed to avoid raw meeting audio, transcript text, note content, and summary text.
 
-### 3.3 Google Calendar and Other Connected Calendar Accounts
+### 3.3 Google Calendar and Microsoft Outlook Calendar Accounts
 
-If you connect Google Calendar or another supported calendar provider, we collect and process the data needed to sync calendars and events into Anarlog. This may include:
+If you connect Google Calendar or Microsoft Outlook Calendar through Microsoft Graph, we collect and process the data needed to display your calendars and upcoming events in Anarlog and let you create personal notes and memos associated with those events. This may include:
 
 - **Calendar Information:** Calendar IDs, names, colors, access or ownership metadata, and source or account identifiers
 - **Event Information:** Event IDs, titles, descriptions, locations, meeting links, start and end times, time zones, recurrence metadata, organizer details, and attendee details such as names, email addresses, and RSVP status
-- **Connection Information:** Provider connection IDs, connection status, and the Google account identity associated with the connection
+- **Connection Information:** Provider connection IDs, connection status, and the Google or Microsoft account identity associated with the connection
 
-We use this data only to provide the user-facing calendar features you enable in Anarlog. We do not use Google Calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
+We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
 
 ## 4. How We Use Your Information
 
@@ -53,7 +53,7 @@ We use your information to:
 - Process transactions and manage your account
 - Send technical notices, updates, and support messages
 - Send marketing communications (newsletters, product announcements, updates) — you may opt out at any time
-- Provide and improve calendar sync features when you connect Google Calendar
+- Display calendars and upcoming events and support event-related notes and memos when you connect Google Calendar or Microsoft Outlook Calendar
 - Respond to your comments, questions, and requests
 - Protect against fraud and other illegal activities
 - Comply with legal obligations
@@ -70,7 +70,7 @@ No method of transmission over the Internet or electronic storage is 100% secure
 
 ### 6.1 We Do Not Sell Your Data
 
-We do not sell, trade, or rent your personal information to third parties, including Google user data.
+We do not sell, trade, or rent your personal information to third parties, including connected calendar data.
 
 ### 6.2 Service Providers
 
@@ -81,20 +81,20 @@ We may share your information with third-party service providers who perform ser
 - **Payment processors** (e.g., Stripe) for processing payments securely
 - **Analytics services** (e.g., PostHog, Google Analytics) for understanding how users interact with our Service
 - **Speech-to-text providers** (e.g., Deepgram, AssemblyAI, Soniox) for cloud-based transcription when you enable this feature
-- **AI model providers** (e.g., via OpenRouter) for cloud-based AI features when you enable them
+- **AI model providers** for optional cloud-based AI features when you enable them
 - **Error monitoring services** (e.g., Sentry) for identifying and fixing issues
 - **Email services** (e.g., Loops) for sending transactional and marketing communications
 
-### 6.3 Google User Data Sharing
+### 6.3 Connected Calendar Data Sharing
 
-When you connect Google Calendar, we may share Google user data only:
+When you connect Google Calendar or Microsoft Outlook Calendar, we may share connected calendar data only:
 
 - With service providers directly involved in authenticating the connection, syncing calendars and events, and delivering the calendar features you enable
 - For security purposes, such as investigating abuse, preventing fraud, or fixing integration failures
 - To comply with applicable law, regulation, legal process, or enforceable governmental request
 - As part of a merger, acquisition, or asset sale, subject to applicable legal requirements
 
-We do not sell Google user data or transfer it to third parties for advertising, marketing, or data broker purposes.
+We do not sell connected calendar data or transfer it to third parties for advertising, marketing, or data broker purposes.
 
 ### 6.4 Legal Requirements
 
@@ -112,7 +112,7 @@ You may request account deletion at any time by contacting us at hello@anarlog.s
 
 ### 7.3 Data Retention
 
-If you connect Google Calendar, synced calendar and event data is retained locally on your device until you delete it, disconnect the account, or remove local Anarlog data. On our systems, we retain limited connection metadata while the integration is active and for up to 30 days after disconnection or account deletion, except where a longer period is required by law. If you delete your account, we will delete your cloud-stored data within 30 days, except where required to retain it for legal purposes.
+If you connect Google Calendar or Microsoft Outlook Calendar, synced calendar and event data is retained locally on your device until you delete it, disconnect the account, or remove local Anarlog data. On our systems, we retain limited connection metadata while the integration is active and for up to 30 days after disconnection or account deletion, except where a longer period is required by law. If you delete your account, we will delete your cloud-stored data within 30 days, except where required to retain it for legal purposes.
 
 ### 7.4 Analytics and Telemetry Controls
 
@@ -121,7 +121,7 @@ If you connect Google Calendar, synced calendar and event data is retained local
 
 ### 7.5 Connected Account Controls
 
-You can disconnect Google Calendar in your account integrations settings. Disconnecting stops future syncs. Calendar and event data already synced locally to your device remains until you remove it or delete local app data.
+You can disconnect Google Calendar or Microsoft Outlook Calendar in your account integrations settings. Disconnecting stops future syncs. Calendar and event data already synced locally to your device remains until you remove it or delete local app data.
 
 ## 8. International Data Transfers
 


### PR DESCRIPTION
Remove the OpenRouter example and describe Google Calendar and Outlook use for upcoming events and event-related notes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only legal copy changes with no application or data-handling code modified.
> 
> **Overview**
> Updates the **Privacy Policy** (`privacy.mdx`) effective date to **2026-07-16** and aligns calendar-related disclosures with **Microsoft Outlook** alongside Google Calendar.
> 
> **Connected calendars (§3.3, §4, §6–§7):** Wording shifts from Google-only / generic “calendar sync” to **Google Calendar and Microsoft Outlook Calendar (Microsoft Graph)**. It states that connected data is used to **show calendars and upcoming events** and to support **personal notes and memos tied to those events**. Sections on selling data, sharing with service providers, retention, and disconnect controls now refer to **connected calendar data** for both providers (Google Workspace Limited Use policy remains for Google APIs).
> 
> **Third parties (§6.2):** The **OpenRouter** example is removed from the AI model providers list; copy now refers generically to optional cloud AI providers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492e26d35ea98d5b340c354a24579b893545472a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->