### PR TITLE
Fix generated summary handoff

### DIFF
--- a/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.test.tsx
@@ -160,21 +160,6 @@ describe("EnhancedEditor", () => {
     });
   });
 
-  it("keeps the editor mounted outside layout while hidden", () => {
-    render(
-      <EnhancedEditor
-        sessionId="session-1"
-        enhancedNoteId="note-1"
-        content={hoisted.content}
-        isHidden
-      />,
-    );
-
-    const dropTarget = screen.getByText("Note editor").parentElement;
-
-    expect(dropTarget?.classList.contains("hidden")).toBe(true);
-  });
-
   it("does not rerender the editor when its props are unchanged", () => {
     const view = render(
       <EnhancedEditor

--- a/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/editor.tsx
@@ -7,7 +7,6 @@ import {
   type JSONContent,
   type NoteEditorRef,
 } from "@hypr/editor/note";
-import { cn } from "@hypr/utils";
 
 import { AudioDropTarget } from "../audio-drop-target";
 import { useNoteFileHandlerConfig } from "../file-handler";
@@ -35,7 +34,6 @@ const EnhancedEditorInner = forwardRef<
     enhancedNoteId: string;
     content: string;
     contentOverride?: JSONContent;
-    isHidden?: boolean;
     onNavigateToTitle?: (pixelWidth?: number) => void;
     onViewReady?: (view: EditorView) => void;
     onViewDisposed?: (view: EditorView) => void;
@@ -48,7 +46,6 @@ const EnhancedEditorInner = forwardRef<
       enhancedNoteId,
       content,
       contentOverride,
-      isHidden = false,
       onNavigateToTitle,
       onViewReady,
       onViewDisposed,
@@ -93,7 +90,7 @@ const EnhancedEditorInner = forwardRef<
 
     return (
       <AudioDropTarget
-        className={cn(["h-full", isHidden && "hidden"])}
+        className="h-full"
         targetProps={audioDropTargetProps}
         isActive={isAudioDragActive}
       >

--- a/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.test.tsx
@@ -73,11 +73,9 @@ vi.mock("./editor", () => ({
   EnhancedEditor: ({
     content,
     contentOverride,
-    isHidden = false,
   }: {
     content: string;
     contentOverride?: { content?: unknown[] };
-    isHidden?: boolean;
   }) => {
     const [mountId] = useState(() => {
       hoisted.enhancedEditorMountCount += 1;
@@ -100,11 +98,7 @@ vi.mock("./editor", () => ({
     };
 
     return (
-      <div
-        data-testid="enhanced-editor"
-        data-mount-id={mountId}
-        hidden={isHidden}
-      >
+      <div data-testid="enhanced-editor" data-mount-id={mountId}>
         <span>Enhanced editor</span>
         <span>{content}</span>
         {contentOverride ? <span>{collectText(contentOverride)}</span> : null}
@@ -172,7 +166,7 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByTestId("enhanced-editor").hidden).toBe(true);
+    expect(screen.queryByTestId("enhanced-editor")).toBeNull();
     expect(screen.getByRole("status")).not.toBeNull();
     expect(screen.getByText("Analyzing structure...")).not.toBeNull();
     expect(
@@ -191,7 +185,7 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByTestId("enhanced-editor").hidden).toBe(true);
+    expect(screen.queryByTestId("enhanced-editor")).toBeNull();
     expect(screen.getByText("Streaming summary")).not.toBeNull();
     expect(screen.getByTestId("summary-title-space")).not.toBeNull();
     expect(screen.getByText("Generating title...")).not.toBeNull();
@@ -211,20 +205,18 @@ describe("Enhanced", () => {
       <Enhanced sessionId="session-1" enhancedNoteId="note-1" />,
     );
 
-    const editor = screen.getByTestId("enhanced-editor");
-    expect(editor.hidden).toBe(true);
+    expect(screen.queryByTestId("enhanced-editor")).toBeNull();
     expect(screen.getByText("Generated summary")).not.toBeNull();
 
     hoisted.content = "Stored summary";
     view.rerender(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByTestId("enhanced-editor")).toBe(editor);
-    expect(editor.hidden).toBe(false);
+    expect(screen.getByTestId("enhanced-editor")).not.toBeNull();
     expect(screen.getByText("Stored summary")).not.toBeNull();
     expect(hoisted.enhancedEditorMountCount).toBe(1);
   });
 
-  it("preserves the editor instance across the streaming handoff", () => {
+  it("remounts the editor with persisted content after generation", () => {
     hoisted.content = "Stored summary";
     const view = render(
       <Enhanced sessionId="session-1" enhancedNoteId="note-1" />,
@@ -240,8 +232,7 @@ describe("Enhanced", () => {
     };
     view.rerender(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByTestId("enhanced-editor")).toBe(editor);
-    expect(editor.hidden).toBe(true);
+    expect(screen.queryByTestId("enhanced-editor")).toBeNull();
 
     hoisted.content = "Updated summary";
     hoisted.enhanceTask = {
@@ -253,9 +244,9 @@ describe("Enhanced", () => {
     };
     view.rerender(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByTestId("enhanced-editor")).toBe(editor);
-    expect(editor.hidden).toBe(false);
-    expect(hoisted.enhancedEditorMountCount).toBe(1);
+    expect(screen.getByTestId("enhanced-editor")).not.toBe(editor);
+    expect(screen.getByText("Updated summary")).not.toBeNull();
+    expect(hoisted.enhancedEditorMountCount).toBe(2);
   });
 
   it("keeps the completed stream visible over an empty stored document", () => {
@@ -273,7 +264,7 @@ describe("Enhanced", () => {
 
     render(<Enhanced sessionId="session-1" enhancedNoteId="note-1" />);
 
-    expect(screen.getByTestId("enhanced-editor").hidden).toBe(true);
+    expect(screen.queryByTestId("enhanced-editor")).toBeNull();
     expect(screen.getByText("Generated summary")).not.toBeNull();
   });
   it("keeps the title row while streaming for an already titled session", () => {

--- a/apps/desktop/src/session/components/note-input/enhanced/index.tsx
+++ b/apps/desktop/src/session/components/note-input/enhanced/index.tsx
@@ -74,29 +74,27 @@ export const Enhanced = forwardRef<
       return <ConfigError />;
     }
 
-    return (
-      <>
-        {showStreaming ? (
-          <StreamingView
-            key="streaming"
-            sessionId={sessionId}
-            sessionTitle={sessionTitle}
-            enhancedNoteId={enhancedNoteId}
-          />
-        ) : null}
-        <EnhancedEditor
-          key="editor"
-          ref={showStreaming ? null : ref}
+    if (showStreaming) {
+      return (
+        <StreamingView
           sessionId={sessionId}
           sessionTitle={sessionTitle}
           enhancedNoteId={enhancedNoteId}
-          content={enhancedNote.content}
-          isHidden={showStreaming}
-          onNavigateToTitle={onNavigateToTitle}
-          onViewReady={onViewReady}
-          onViewDisposed={onViewDisposed}
         />
-      </>
+      );
+    }
+
+    return (
+      <EnhancedEditor
+        ref={ref}
+        sessionId={sessionId}
+        sessionTitle={sessionTitle}
+        enhancedNoteId={enhancedNoteId}
+        content={enhancedNote.content}
+        onNavigateToTitle={onNavigateToTitle}
+        onViewReady={onViewReady}
+        onViewDisposed={onViewDisposed}
+      />
     );
   },
 );


### PR DESCRIPTION
Mount the summary editor from persisted content after generation so initial summaries and regenerations cannot reveal stale focused editor state.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes when the ProseMirror editor mounts/unmounts during enhance flows, which can affect focus, refs, and regeneration UX but is localized to the enhanced note input.
> 
> **Overview**
> Fixes **generated summary handoff** by no longer keeping `EnhancedEditor` mounted (hidden) while `StreamingView` is shown.
> 
> **`Enhanced`** now renders **either** the streaming UI **or** the persisted-note editor, so generation and regeneration hand off from SQLite content with a **fresh editor mount** instead of revealing prior focus/selection state.
> 
> Removes the **`isHidden`** prop and hidden layout styling from **`EnhancedEditor`**; tests now assert the editor is absent during streaming and **remounts** when persisted content arrives (including after an in-session regenerate).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b11bf7b4f3c1258b7f4564c5cf77fa491300db60. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->