### PR TITLE
Add branded OAuth callback

### DIFF
--- a/apps/web/netlify/edge-functions/oauth-callback.ts
+++ b/apps/web/netlify/edge-functions/oauth-callback.ts
@@ -1,0 +1,18 @@
+const NANGO_CALLBACK_URL = "https://api.nango.dev/oauth/callback";
+
+export default (request: Request): Response => {
+  const query = new URL(request.url).search;
+
+  return new Response(null, {
+    status: 308,
+    headers: {
+      "cache-control": "no-store",
+      location: `${NANGO_CALLBACK_URL}${query}`,
+    },
+  });
+};
+
+export const config = {
+  path: "/oauth/callback",
+  method: ["GET"],
+};

--- a/apps/web/src/functions/oauth-callback-edge.test.ts
+++ b/apps/web/src/functions/oauth-callback-edge.test.ts
@@ -1,0 +1,28 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import oauthCallback, {
+  config,
+} from "../../netlify/edge-functions/oauth-callback.ts";
+
+test("redirects OAuth callbacks to Nango without changing the query string", () => {
+  const query =
+    "code=a%2Fb+c&state=first&scope=Calendars.Read%20offline_access&state=second&empty=";
+  const response = oauthCallback(
+    new Request(`https://anarlog.so/oauth/callback?${query}`),
+  );
+
+  assert.equal(response.status, 308);
+  assert.equal(
+    response.headers.get("location"),
+    `https://api.nango.dev/oauth/callback?${query}`,
+  );
+  assert.equal(response.headers.get("cache-control"), "no-store");
+});
+
+test("registers only the GET callback route", () => {
+  assert.deepEqual(config, {
+    path: "/oauth/callback",
+    method: ["GET"],
+  });
+});

--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -369,6 +369,16 @@ function Component() {
               Jot notes during the call. Anarlog turns them into an editable
               summary.
             </p>
+            <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-[#6f675d]">
+              Connect Google Calendar or Outlook Calendar to view upcoming
+              events and attach private notes and memos.{" "}
+              <a
+                href="https://docs.anarlog.so/calendar"
+                className="underline underline-offset-4 hover:text-[#181613]"
+              >
+                Learn about calendar connections.
+              </a>
+            </p>
             <div className="mt-8 flex flex-wrap justify-center gap-x-5 gap-y-3 text-sm">
               <DownloadButton />
             </div>


### PR DESCRIPTION
Adds a production 308 OAuth callback on anarlog.so that preserves provider query parameters, plus clear homepage copy for Google Calendar and Outlook Calendar access.

Verified with targeted tests, web typechecking, and a successful production Netlify deploy.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches production OAuth callback routing; a misconfigured redirect could break calendar connections, though behavior is narrow and covered by tests.
> 
> **Overview**
> Adds a **Netlify edge handler** on `GET /oauth/callback` that returns a **308** to `https://api.nango.dev/oauth/callback` with the **original query string unchanged**, plus `Cache-Control: no-store`, so calendar OAuth can use the **anarlog.so** callback URL while Nango still completes the flow.
> 
> **Tests** cover redirect status, location, cache header, and edge route config (`path` / `method`).
> 
> The **marketing homepage** hero gains a short line on connecting **Google Calendar** or **Outlook Calendar** for upcoming events and private notes, with a link to calendar docs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 804c497c6173fbcddc2316cdd7b9de62665bd7aa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->