### PR TITLE
Replace transcript scroll chips with side controls

### DIFF
--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -10,13 +10,10 @@ const mocks = vi.hoisted(() => ({
   scrollDetection: {
     isAtTop: true,
     isAtBottom: true,
+    canScroll: false,
     autoScrollEnabled: true,
     scrollTarget: null as "top" | "bottom" | null,
   },
-  chatMode: "FloatingClosed" as
-    | "FloatingClosed"
-    | "FloatingOpen"
-    | "RightPanelOpen",
 }));
 
 vi.mock("react-hotkeys-hook", () => ({
@@ -36,14 +33,6 @@ vi.mock("~/audio-player", () => ({
 
 vi.mock("~/audio-player/provider", () => ({
   useAudioTime: () => ({ current: 0 }),
-}));
-
-vi.mock("~/contexts/shell", () => ({
-  useShell: () => ({
-    chat: {
-      mode: mocks.chatMode,
-    },
-  }),
 }));
 
 vi.mock("./selection-menu", () => ({
@@ -86,9 +75,9 @@ describe("TranscriptViewer", () => {
     mocks.scrollToTop.mockReset();
     mocks.scrollDetection.isAtTop = true;
     mocks.scrollDetection.isAtBottom = true;
+    mocks.scrollDetection.canScroll = false;
     mocks.scrollDetection.autoScrollEnabled = true;
     mocks.scrollDetection.scrollTarget = null;
-    mocks.chatMode = "FloatingClosed";
   });
 
   it("does not pin inactive transcript sessions to the bottom on open", () => {
@@ -151,8 +140,26 @@ describe("TranscriptViewer", () => {
     );
   });
 
-  it("does not show a scroll chip before scroll movement starts", () => {
+  it("does not show scroll controls when the transcript cannot scroll", () => {
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(screen.queryByRole("button", { name: "Scroll to top" })).toBeNull();
+    expect(
+      screen.queryByRole("button", { name: "Scroll to bottom" }),
+    ).toBeNull();
+  });
+
+  it("renders right-side scroll controls when the transcript can scroll", () => {
+    mocks.scrollDetection.isAtTop = false;
     mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -163,53 +170,31 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
-  });
-
-  it("does not show the bottom chip after upward scroll movement in active sessions", () => {
-    mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.isAtBottom = false;
-    mocks.scrollDetection.scrollTarget = "bottom";
-
-    render(
-      <TranscriptViewer
-        transcriptIds={["transcript-1"]}
-        liveSegments={[]}
-        currentActive
-        scrollRef={createRef()}
-      />,
+    const controls = document.querySelector(
+      "[data-transcript-scroll-controls]",
     );
+    const topButton = screen.getByRole("button", { name: "Scroll to top" });
+    const bottomButton = screen.getByRole("button", {
+      name: "Scroll to bottom",
+    });
 
-    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
-    expect(mocks.scrollToBottom).not.toHaveBeenCalled();
-  });
+    topButton.click();
+    bottomButton.click();
 
-  it("shows the bottom chip after upward scroll movement in inactive sessions", () => {
-    mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.isAtBottom = false;
-    mocks.scrollDetection.scrollTarget = "bottom";
-
-    render(
-      <TranscriptViewer
-        transcriptIds={["transcript-1"]}
-        liveSegments={[]}
-        currentActive={false}
-        scrollRef={createRef()}
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: "Go to bottom" });
-    button.click();
-
-    expect(button.firstElementChild?.tagName.toLowerCase()).toBe("svg");
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    expect(controls?.className).toContain("right-1");
+    expect(controls?.className).toContain("top-1/2");
+    expect(controls?.className).toContain("bg-muted/70");
+    expect(controls?.className).toContain("border-border/60");
+    expect((topButton as HTMLButtonElement).disabled).toBe(false);
+    expect((bottomButton as HTMLButtonElement).disabled).toBe(false);
+    expect(topButton.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(bottomButton.firstElementChild?.tagName.toLowerCase()).toBe("svg");
+    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
     expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("does not show the top chip after downward scroll movement in active sessions", () => {
-    mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.scrollTarget = "top";
+  it("keeps scroll controls visible inside both edge thresholds", () => {
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -220,42 +205,17 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
-    expect(mocks.scrollToTop).not.toHaveBeenCalled();
+    expect(
+      screen.getByRole("button", { name: "Scroll to top" }),
+    ).not.toBeNull();
+    expect(
+      screen.getByRole("button", { name: "Scroll to bottom" }),
+    ).not.toBeNull();
   });
 
-  it("shows the top chip after downward scroll movement in inactive sessions", () => {
-    mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.scrollTarget = "top";
-
-    render(
-      <TranscriptViewer
-        transcriptIds={["transcript-1"]}
-        liveSegments={[]}
-        currentActive={false}
-        scrollRef={createRef()}
-      />,
-    );
-
-    const button = screen.getByRole("button", { name: "Go to top" });
-    button.click();
-
-    expect(button.firstElementChild?.tagName.toLowerCase()).toBe("svg");
-    expect(button.className).not.toContain("bg-linear-to-t");
-    expect(button.className).not.toContain("shadow");
-    expect(button.className).not.toContain("scale");
-    expect(button.style.top).toBe(
-      "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
-    );
-    expect(button.style.bottom).toBe("");
-    expect(screen.queryByRole("button", { name: "Go to bottom" })).toBeNull();
-    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
-  });
-
-  it("renders the bottom chip near the bottom without translucent styling", () => {
-    mocks.scrollDetection.isAtTop = false;
+  it("disables the top control at the top", () => {
     mocks.scrollDetection.isAtBottom = false;
-    mocks.scrollDetection.scrollTarget = "bottom";
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -266,21 +226,22 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    const button = screen.getByRole("button", { name: "Go to bottom" });
+    const topButton = screen.getByRole("button", { name: "Scroll to top" });
+    const bottomButton = screen.getByRole("button", {
+      name: "Scroll to bottom",
+    });
 
-    expect(button.style.bottom).toBe(
-      "var(--transcript-scroll-chip-bottom, calc(1.5rem + env(safe-area-inset-bottom)))",
-    );
-    expect(button.style.top).toBe("");
-    expect(button.className).not.toContain("/85");
-    expect(button.className).not.toContain("/90");
-    expect(button.className).not.toContain("opacity");
+    bottomButton.click();
+
+    expect((topButton as HTMLButtonElement).disabled).toBe(true);
+    expect((bottomButton as HTMLButtonElement).disabled).toBe(false);
+    expect(mocks.scrollToTop).not.toHaveBeenCalled();
+    expect(mocks.scrollToBottom).toHaveBeenCalledTimes(1);
   });
 
-  it("hides the scroll chip while floating chat is expanded", () => {
+  it("disables the bottom control at the bottom", () => {
     mocks.scrollDetection.isAtTop = false;
-    mocks.scrollDetection.scrollTarget = "top";
-    mocks.chatMode = "FloatingOpen";
+    mocks.scrollDetection.canScroll = true;
 
     render(
       <TranscriptViewer
@@ -291,6 +252,16 @@ describe("TranscriptViewer", () => {
       />,
     );
 
-    expect(screen.queryByRole("button", { name: "Go to top" })).toBeNull();
+    const topButton = screen.getByRole("button", { name: "Scroll to top" });
+    const bottomButton = screen.getByRole("button", {
+      name: "Scroll to bottom",
+    });
+
+    topButton.click();
+
+    expect((topButton as HTMLButtonElement).disabled).toBe(false);
+    expect((bottomButton as HTMLButtonElement).disabled).toBe(true);
+    expect(mocks.scrollToTop).toHaveBeenCalledTimes(1);
+    expect(mocks.scrollToBottom).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.test.tsx
@@ -10,6 +10,7 @@ const mocks = vi.hoisted(() => ({
   scrollDetection: {
     isAtTop: true,
     isAtBottom: true,
+    isNearBottom: true,
     canScroll: false,
     autoScrollEnabled: true,
     scrollTarget: null as "top" | "bottom" | null,
@@ -75,6 +76,7 @@ describe("TranscriptViewer", () => {
     mocks.scrollToTop.mockReset();
     mocks.scrollDetection.isAtTop = true;
     mocks.scrollDetection.isAtBottom = true;
+    mocks.scrollDetection.isNearBottom = true;
     mocks.scrollDetection.canScroll = false;
     mocks.scrollDetection.autoScrollEnabled = true;
     mocks.scrollDetection.scrollTarget = null;
@@ -98,6 +100,26 @@ describe("TranscriptViewer", () => {
   });
 
   it("keeps active transcript sessions pinned to the bottom", () => {
+    render(
+      <TranscriptViewer
+        transcriptIds={["transcript-1"]}
+        liveSegments={[]}
+        currentActive
+        scrollRef={createRef()}
+      />,
+    );
+
+    expect(
+      screen
+        .getByTestId("render-transcript")
+        .getAttribute("data-should-scroll-to-end"),
+    ).toBe("true");
+  });
+
+  it("keeps active transcript sessions pinned near the exact bottom edge", () => {
+    mocks.scrollDetection.isAtBottom = false;
+    mocks.scrollDetection.isNearBottom = true;
+
     render(
       <TranscriptViewer
         transcriptIds={["transcript-1"]}

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -52,6 +52,7 @@ export function TranscriptViewer({
   const {
     isAtTop,
     isAtBottom,
+    isNearBottom,
     canScroll,
     autoScrollEnabled,
     scrollToTop,
@@ -87,7 +88,7 @@ export function TranscriptViewer({
 
   usePlaybackAutoScroll(containerRef, deferredCurrentMs, isPlaying);
   const shouldAutoScroll = currentActive && autoScrollEnabled;
-  const shouldScrollLastTranscriptToEnd = currentActive && isAtBottom;
+  const shouldScrollLastTranscriptToEnd = currentActive && isNearBottom;
   useAutoScroll(
     containerRef,
     [transcriptIds, liveSegments, shouldAutoScroll],

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/index.tsx
@@ -21,7 +21,6 @@ import {
 
 import { useAudioPlayer } from "~/audio-player";
 import { useAudioTime } from "~/audio-player/provider";
-import { useShell } from "~/contexts/shell";
 import type { Segment } from "~/stt/live-segment";
 
 const LIVE_TRANSCRIPT_PLACEHOLDER_ID = "__live-transcript__";
@@ -37,7 +36,6 @@ export function TranscriptViewer({
   currentActive: boolean;
   scrollRef: RefObject<HTMLDivElement | null>;
 }) {
-  const { chat } = useShell();
   const containerRef = useRef<HTMLDivElement>(null);
   const [scrollElement, setScrollElement] = useState<HTMLDivElement | null>(
     null,
@@ -54,8 +52,8 @@ export function TranscriptViewer({
   const {
     isAtTop,
     isAtBottom,
+    canScroll,
     autoScrollEnabled,
-    scrollTarget,
     scrollToTop,
     scrollToBottom,
   } = useScrollDetection(containerRef, currentActive);
@@ -102,26 +100,6 @@ export function TranscriptViewer({
         ? [LIVE_TRANSCRIPT_PLACEHOLDER_ID]
         : [];
 
-  const canShowScrollChip = !currentActive && (!isAtTop || !isAtBottom);
-  const scrollChip =
-    chat.mode === "FloatingOpen" || !canShowScrollChip
-      ? null
-      : scrollTarget === "bottom" && !isAtBottom
-        ? {
-            icon: ArrowDownIcon,
-            label: "Go to bottom",
-            onClick: scrollToBottom,
-          }
-        : scrollTarget === "top" && !isAtTop
-          ? {
-              icon: ArrowUpIcon,
-              label: "Go to top",
-              onClick: scrollToTop,
-            }
-          : null;
-  const ScrollChipIcon = scrollChip?.icon;
-  const isBottomScrollChip = scrollTarget === "bottom";
-
   const handleSelectionAction = (action: string, selectedText: string) => {
     if (action === "copy") {
       void navigator.clipboard.writeText(selectedText);
@@ -167,32 +145,42 @@ export function TranscriptViewer({
         />
       </div>
 
-      {scrollChip && (
-        <button
-          data-transcript-scroll-chip
-          onClick={scrollChip.onClick}
-          style={{
-            [isBottomScrollChip ? "bottom" : "top"]: isBottomScrollChip
-              ? "var(--transcript-scroll-chip-bottom, calc(1.5rem + env(safe-area-inset-bottom)))"
-              : "var(--transcript-scroll-chip-top, calc(1.5rem + env(safe-area-inset-top)))",
-          }}
+      {canScroll && (
+        <div
+          data-transcript-scroll-controls
           className={cn([
-            "absolute left-1/2 z-30 inline-flex -translate-x-1/2 items-center gap-1.5",
-            "border-border bg-muted text-foreground rounded-full border px-3 py-1.5",
-            "hover:bg-muted active:bg-muted",
-            "text-xs font-light",
-            "transition-[top,bottom,background-color,border-color] duration-150",
+            "absolute top-1/2 right-1 z-40 flex -translate-y-1/2 flex-col overflow-hidden",
+            "border-border/60 bg-muted/70 text-foreground rounded-full border",
           ])}
         >
-          {ScrollChipIcon && (
-            <ScrollChipIcon
-              aria-hidden="true"
-              className="size-3"
-              strokeWidth={2.25}
-            />
-          )}
-          {scrollChip.label}
-        </button>
+          <button
+            type="button"
+            aria-label="Scroll to top"
+            onClick={scrollToTop}
+            disabled={isAtTop}
+            className={cn([
+              "flex size-8 items-center justify-center",
+              "hover:bg-muted/85 active:bg-muted/85",
+              "disabled:pointer-events-none disabled:opacity-30",
+            ])}
+          >
+            <ArrowUpIcon aria-hidden="true" className="size-3.5" />
+          </button>
+          <div className="bg-border/70 h-px w-full" />
+          <button
+            type="button"
+            aria-label="Scroll to bottom"
+            onClick={scrollToBottom}
+            disabled={isAtBottom}
+            className={cn([
+              "flex size-8 items-center justify-center",
+              "hover:bg-muted/85 active:bg-muted/85",
+              "disabled:pointer-events-none disabled:opacity-30",
+            ])}
+          >
+            <ArrowDownIcon aria-hidden="true" className="size-3.5" />
+          </button>
+        </div>
       )}
     </div>
   );

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
@@ -28,7 +28,7 @@ function setScrollMetrics(
 }
 
 describe("useScrollDetection", () => {
-  it("reports overflow even when the viewport is near both edges", () => {
+  it("keeps one scroll edge available when the viewport is near both edges", () => {
     const element = document.createElement("div");
     setScrollMetrics(element, {
       clientHeight: 100,
@@ -44,6 +44,14 @@ describe("useScrollDetection", () => {
 
     expect(result.current.canScroll).toBe(true);
     expect(result.current.isAtTop).toBe(true);
+    expect(result.current.isAtBottom).toBe(false);
+
+    act(() => {
+      element.scrollTop = 50;
+      element.dispatchEvent(new Event("scroll"));
+    });
+
+    expect(result.current.isAtTop).toBe(false);
     expect(result.current.isAtBottom).toBe(true);
   });
 

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
@@ -28,6 +28,25 @@ function setScrollMetrics(
 }
 
 describe("useScrollDetection", () => {
+  it("reports overflow even when the viewport is near both edges", () => {
+    const element = document.createElement("div");
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 150,
+      scrollTop: 0,
+    });
+    const containerRef = createRef<HTMLDivElement>();
+    containerRef.current = element;
+
+    const { result } = renderHook(() =>
+      useScrollDetection(containerRef, false),
+    );
+
+    expect(result.current.canScroll).toBe(true);
+    expect(result.current.isAtTop).toBe(true);
+    expect(result.current.isAtBottom).toBe(true);
+  });
+
   it("preserves manual scroll-away state when a transcript becomes active again", () => {
     const element = document.createElement("div");
     setScrollMetrics(element, {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.test.tsx
@@ -45,6 +45,7 @@ describe("useScrollDetection", () => {
     expect(result.current.canScroll).toBe(true);
     expect(result.current.isAtTop).toBe(true);
     expect(result.current.isAtBottom).toBe(false);
+    expect(result.current.isNearBottom).toBe(true);
 
     act(() => {
       element.scrollTop = 50;
@@ -53,6 +54,23 @@ describe("useScrollDetection", () => {
 
     expect(result.current.isAtTop).toBe(false);
     expect(result.current.isAtBottom).toBe(true);
+    expect(result.current.isNearBottom).toBe(true);
+  });
+
+  it("keeps the live transcript pinned near the exact bottom edge", () => {
+    const element = document.createElement("div");
+    setScrollMetrics(element, {
+      clientHeight: 100,
+      scrollHeight: 1000,
+      scrollTop: 850,
+    });
+    const containerRef = createRef<HTMLDivElement>();
+    containerRef.current = element;
+
+    const { result } = renderHook(() => useScrollDetection(containerRef, true));
+
+    expect(result.current.isAtBottom).toBe(false);
+    expect(result.current.isNearBottom).toBe(true);
   });
 
   it("preserves manual scroll-away state when a transcript becomes active again", () => {

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -13,6 +13,7 @@ export function useScrollDetection(
 ) {
   const [isAtTop, setIsAtTop] = useState(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const [canScroll, setCanScroll] = useState(false);
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
   const [scrollTarget, setScrollTarget] = useState<"top" | "bottom" | null>(
     null,
@@ -29,15 +30,23 @@ export function useScrollDetection(
 
     lastScrollTopRef.current = element.scrollTop;
 
-    const handleScroll = () => {
+    const updateScrollState = () => {
       const topThreshold = 40;
       const bottomThreshold = 100;
       const distanceToBottom =
         element.scrollHeight - element.scrollTop - element.clientHeight;
+      const hasOverflow = element.scrollHeight - element.clientHeight > 1;
       const isNearTop = element.scrollTop < topThreshold;
       const isNearBottom = distanceToBottom < bottomThreshold;
-      setIsAtTop(isNearTop);
-      setIsAtBottom(isNearBottom);
+      setCanScroll(hasOverflow);
+      setIsAtTop(!hasOverflow || isNearTop);
+      setIsAtBottom(!hasOverflow || isNearBottom);
+
+      return isNearBottom;
+    };
+
+    const handleScroll = () => {
+      const isNearBottom = updateScrollState();
 
       const currentTop = element.scrollTop;
       const prevTop = lastScrollTopRef.current;
@@ -62,7 +71,28 @@ export function useScrollDetection(
 
     element.addEventListener("scroll", handleScroll);
     handleScroll();
-    return () => element.removeEventListener("scroll", handleScroll);
+
+    const resizeObserver =
+      typeof ResizeObserver === "undefined"
+        ? null
+        : new ResizeObserver(updateScrollState);
+    resizeObserver?.observe(element);
+
+    const mutationObserver =
+      typeof MutationObserver === "undefined"
+        ? null
+        : new MutationObserver(updateScrollState);
+    mutationObserver?.observe(element, {
+      childList: true,
+      characterData: true,
+      subtree: true,
+    });
+
+    return () => {
+      element.removeEventListener("scroll", handleScroll);
+      resizeObserver?.disconnect();
+      mutationObserver?.disconnect();
+    };
   }, [containerRef]);
 
   useEffect(() => {
@@ -97,6 +127,7 @@ export function useScrollDetection(
   return {
     isAtTop,
     isAtBottom,
+    canScroll,
     autoScrollEnabled,
     scrollTarget,
     scrollToTop,

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -31,16 +31,16 @@ export function useScrollDetection(
     lastScrollTopRef.current = element.scrollTop;
 
     const updateScrollState = () => {
-      const topThreshold = 40;
       const bottomThreshold = 100;
       const distanceToBottom =
         element.scrollHeight - element.scrollTop - element.clientHeight;
       const hasOverflow = element.scrollHeight - element.clientHeight > 1;
-      const isNearTop = element.scrollTop < topThreshold;
       const isNearBottom = distanceToBottom < bottomThreshold;
+      const isAtExactTop = element.scrollTop <= 1;
+      const isAtExactBottom = !isAtExactTop && distanceToBottom <= 1;
       setCanScroll(hasOverflow);
-      setIsAtTop(!hasOverflow || isNearTop);
-      setIsAtBottom(!hasOverflow || isNearBottom);
+      setIsAtTop(!hasOverflow || isAtExactTop);
+      setIsAtBottom(!hasOverflow || isAtExactBottom);
 
       return isNearBottom;
     };

--- a/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
+++ b/apps/desktop/src/session/components/note-input/transcript/renderer/viewport-hooks.ts
@@ -13,6 +13,7 @@ export function useScrollDetection(
 ) {
   const [isAtTop, setIsAtTop] = useState(true);
   const [isAtBottom, setIsAtBottom] = useState(true);
+  const [isNearBottom, setIsNearBottom] = useState(true);
   const [canScroll, setCanScroll] = useState(false);
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
   const [scrollTarget, setScrollTarget] = useState<"top" | "bottom" | null>(
@@ -41,6 +42,7 @@ export function useScrollDetection(
       setCanScroll(hasOverflow);
       setIsAtTop(!hasOverflow || isAtExactTop);
       setIsAtBottom(!hasOverflow || isAtExactBottom);
+      setIsNearBottom(!hasOverflow || isNearBottom);
 
       return isNearBottom;
     };
@@ -127,6 +129,7 @@ export function useScrollDetection(
   return {
     isAtTop,
     isAtBottom,
+    isNearBottom,
     canScroll,
     autoScrollEnabled,
     scrollTarget,

--- a/apps/desktop/src/styles/globals.css
+++ b/apps/desktop/src/styles/globals.css
@@ -240,13 +240,6 @@
   [data-settings-content] [data-slot="select-trigger"]:hover {
     box-shadow: none !important;
   }
-
-  [data-chat-floating-anchor]:has([data-chat-cta-trigger]:is(:hover, :focus-visible, :focus-within))
-    [data-transcript-scroll-chip] {
-    --transcript-scroll-chip-bottom: calc(
-      3.75rem + env(safe-area-inset-bottom)
-    );
-  }
 }
 
 /* Search result highlighting styles — matches transcript's bg-yellow-200/50 and bg-yellow-500 */


### PR DESCRIPTION
Rebuild the unique behavior from #5882 on current main: use persistent right-side top/bottom controls, disable each edge appropriately, and derive visibility from real overflow. Includes renderer and viewport regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Desktop transcript UI and scroll hooks only; behavior is covered by updated unit tests with no auth, data, or API impact.
> 
> **Overview**
> Replaces the old **single floating scroll chip** (inactive-only, direction after scroll movement, hidden when floating chat is open) with **persistent right-side top/bottom controls** whenever the transcript actually overflows.
> 
> **`useScrollDetection`** now exposes **`canScroll`**, **`isNearBottom`**, and stricter edge detection (exact top/bottom vs. near-bottom threshold). Live pinning uses **`isNearBottom`** instead of **`isAtBottom`**. Overflow and edges refresh on **resize** and **DOM mutations**, not only scroll. **`TranscriptViewer`** drops **`useShell`** / chat-mode gating and disables each button at the corresponding edge.
> 
> Removes **globals.css** rules that nudged the old chip above the floating chat CTA. Tests are updated for the new UI and scroll behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b187b439f44fbd25b48eccc55e90717399e595d0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->