### PR TITLE
Focus blank note editor space

### DIFF
--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -9,18 +9,24 @@ const hoisted = vi.hoisted(() => ({
   editorTabs: [{ type: "raw" }, { type: "transcript" }] as EditorView[],
   hotkeys: [] as Array<{ keys: string; callback: () => void }>,
   enhancedEditorProps: [] as Record<string, unknown>[],
+  focusAtTrailingEmptyLine: vi.fn(),
   onBeforeTabChange: vi.fn(),
   rawEditorProps: [] as Record<string, unknown>[],
   sessionMode: "inactive",
   updateSessionTabState: vi.fn(),
 }));
 
-vi.mock("./enhanced", () => ({
-  Enhanced: (props: Record<string, unknown>) => {
-    hoisted.enhancedEditorProps.push(props);
-    return <div data-testid="enhanced-editor" />;
-  },
-}));
+vi.mock("./enhanced", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    Enhanced: React.forwardRef((props: Record<string, unknown>, ref) => {
+      hoisted.enhancedEditorProps.push(props);
+      React.useImperativeHandle(ref, () => createEditorRef());
+      return React.createElement("div", { "data-testid": "enhanced-editor" });
+    }),
+  };
+});
 
 vi.mock("./header", () => ({
   Header: ({
@@ -51,12 +57,24 @@ vi.mock("./header", () => ({
   useEditorTabs: () => hoisted.editorTabs,
 }));
 
-vi.mock("./raw", () => ({
-  RawEditor: (props: Record<string, unknown>) => {
-    hoisted.rawEditorProps.push(props);
-    return <div data-testid="raw-editor" />;
-  },
-}));
+vi.mock("./raw", async () => {
+  const React = await vi.importActual<typeof import("react")>("react");
+
+  return {
+    RawEditor: React.forwardRef((props: Record<string, unknown>, ref) => {
+      hoisted.rawEditorProps.push(props);
+      React.useImperativeHandle(ref, () => createEditorRef());
+      return React.createElement(
+        "div",
+        { "data-testid": "raw-editor" },
+        React.createElement("div", {
+          className: "ProseMirror",
+          "data-testid": "mock-prosemirror",
+        }),
+      );
+    }),
+  };
+});
 
 vi.mock("./search/bar", () => ({
   SearchBar: () => <div data-testid="search-bar" />,
@@ -110,6 +128,22 @@ function formatEditorView(view: EditorView) {
   return view.type === "enhanced" ? `enhanced:${view.id}` : view.type;
 }
 
+function createEditorRef() {
+  return {
+    view: null,
+    commands: {
+      focus: () => {},
+      focusAtStart: () => {},
+      focusAtTrailingEmptyLine: hoisted.focusAtTrailingEmptyLine,
+      focusAtPixelWidth: () => {},
+      insertAtStartAndFocus: () => {},
+      replaceContent: () => {},
+      setSearch: () => {},
+      replace: () => {},
+    },
+  };
+}
+
 function renderNoteInput({
   currentTab = { type: "raw" },
   handleTabChange = vi.fn(),
@@ -148,6 +182,7 @@ describe("NoteInput tab selection", () => {
     hoisted.editorTabs = [{ type: "raw" }, { type: "transcript" }];
     hoisted.hotkeys = [];
     hoisted.enhancedEditorProps = [];
+    hoisted.focusAtTrailingEmptyLine.mockClear();
     hoisted.onBeforeTabChange.mockClear();
     hoisted.rawEditorProps = [];
     hoisted.sessionMode = "inactive";
@@ -273,5 +308,24 @@ describe("NoteInput tab selection", () => {
     ).toMatchObject({
       sessionTitle: "Stored title",
     });
+  });
+
+  it("focuses the trailing body line when blank editor space is clicked", () => {
+    renderNoteInput();
+
+    const scrollContainer = screen.getByTestId("raw-editor").parentElement;
+    expect(scrollContainer).not.toBeNull();
+
+    fireEvent.mouseDown(scrollContainer!, { button: 0 });
+
+    expect(hoisted.focusAtTrailingEmptyLine).toHaveBeenCalledTimes(1);
+  });
+
+  it("lets ProseMirror handle clicks inside the document", () => {
+    renderNoteInput();
+
+    fireEvent.mouseDown(screen.getByTestId("mock-prosemirror"), { button: 0 });
+
+    expect(hoisted.focusAtTrailingEmptyLine).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/note-input/index.test.tsx
+++ b/apps/desktop/src/session/components/note-input/index.test.tsx
@@ -8,6 +8,7 @@ import type { EditorView } from "~/store/zustand/tabs/schema";
 const hoisted = vi.hoisted(() => ({
   editorTabs: [{ type: "raw" }, { type: "transcript" }] as EditorView[],
   hotkeys: [] as Array<{ keys: string; callback: () => void }>,
+  enhancedHasProseMirror: true,
   enhancedEditorProps: [] as Record<string, unknown>[],
   focusAtTrailingEmptyLine: vi.fn(),
   onBeforeTabChange: vi.fn(),
@@ -23,7 +24,14 @@ vi.mock("./enhanced", async () => {
     Enhanced: React.forwardRef((props: Record<string, unknown>, ref) => {
       hoisted.enhancedEditorProps.push(props);
       React.useImperativeHandle(ref, () => createEditorRef());
-      return React.createElement("div", { "data-testid": "enhanced-editor" });
+      return React.createElement(
+        "div",
+        { "data-testid": "enhanced-editor" },
+        React.createElement("button", { type: "button" }, "Retry summary"),
+        hoisted.enhancedHasProseMirror
+          ? React.createElement("div", { className: "ProseMirror" })
+          : null,
+      );
     }),
   };
 });
@@ -181,6 +189,7 @@ describe("NoteInput tab selection", () => {
   beforeEach(() => {
     hoisted.editorTabs = [{ type: "raw" }, { type: "transcript" }];
     hoisted.hotkeys = [];
+    hoisted.enhancedHasProseMirror = true;
     hoisted.enhancedEditorProps = [];
     hoisted.focusAtTrailingEmptyLine.mockClear();
     hoisted.onBeforeTabChange.mockClear();
@@ -326,6 +335,25 @@ describe("NoteInput tab selection", () => {
 
     fireEvent.mouseDown(screen.getByTestId("mock-prosemirror"), { button: 0 });
 
+    expect(hoisted.focusAtTrailingEmptyLine).not.toHaveBeenCalled();
+  });
+
+  it("preserves controls when the enhanced view has no editor", () => {
+    hoisted.editorTabs = [
+      { type: "enhanced", id: "summary-1" },
+      { type: "raw" },
+    ];
+    hoisted.enhancedHasProseMirror = false;
+    renderNoteInput({
+      currentTab: { type: "enhanced", id: "summary-1" },
+    });
+
+    const wasNotCancelled = fireEvent.mouseDown(
+      screen.getByRole("button", { name: "Retry summary" }),
+      { button: 0 },
+    );
+
+    expect(wasNotCancelled).toBe(true);
     expect(hoisted.focusAtTrailingEmptyLine).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -1,5 +1,6 @@
 import {
   forwardRef,
+  type MouseEventHandler,
   type UIEventHandler,
   useCallback,
   useDeferredValue,
@@ -258,12 +259,27 @@ const NoteInputContent = forwardRef<
       search?.close();
     }, [currentTab]);
 
-    const handleContainerClick = () => {
+    const handleContainerMouseDown: MouseEventHandler<HTMLDivElement> = (
+      event,
+    ) => {
       if (!isEditableTab) {
         return;
       }
 
-      internalEditorRef.current?.commands.focus();
+      if (event.button !== 0) {
+        return;
+      }
+
+      const target = event.target;
+      if (
+        target instanceof Element &&
+        target.closest(".ProseMirror") !== null
+      ) {
+        return;
+      }
+
+      event.preventDefault();
+      internalEditorRef.current?.commands.focusAtTrailingEmptyLine();
     };
 
     return (
@@ -289,7 +305,7 @@ const NoteInputContent = forwardRef<
         <div className="relative flex-1 overflow-hidden">
           <div
             ref={scrollRef}
-            onClick={handleContainerClick}
+            onMouseDown={handleContainerMouseDown}
             onScroll={onScroll}
             className={cn([
               "h-full px-3",

--- a/apps/desktop/src/session/components/note-input/index.tsx
+++ b/apps/desktop/src/session/components/note-input/index.tsx
@@ -271,10 +271,23 @@ const NoteInputContent = forwardRef<
       }
 
       const target = event.target;
+      if (!(target instanceof Element)) {
+        return;
+      }
+
+      if (target.closest(".ProseMirror") !== null) {
+        return;
+      }
+
       if (
-        target instanceof Element &&
-        target.closest(".ProseMirror") !== null
+        target.closest(
+          "button, a, input, textarea, select, [role='button'], [contenteditable='true']",
+        ) !== null
       ) {
+        return;
+      }
+
+      if (event.currentTarget.querySelector(".ProseMirror") === null) {
         return;
       }
 

--- a/packages/editor/src/note/index.tsx
+++ b/packages/editor/src/note/index.tsx
@@ -89,7 +89,10 @@ import {
 } from "./linked-item-open-behavior";
 import { schema } from "./schema";
 import { normalizeTitleHeadingDoc, titleHeadingPlugin } from "./title-layout";
-import { trailingEmptyLineClickPlugin } from "./trailing-empty-line-click";
+import {
+  focusTrailingEmptyLine,
+  trailingEmptyLineClickPlugin,
+} from "./trailing-empty-line-click";
 
 export type { MentionConfig, FileHandlerConfig, PlaceholderFunction };
 export { schema };
@@ -115,6 +118,7 @@ export interface SearchReplaceParams {
 export interface EditorCommands {
   focus: () => void;
   focusAtStart: () => void;
+  focusAtTrailingEmptyLine: () => void;
   focusAtPixelWidth: (pixelWidth: number) => void;
   insertAtStartAndFocus: (content: string) => void;
   replaceContent: (content: JSONContent) => void;
@@ -379,6 +383,7 @@ function ViewCapture({
 const noopCommands: EditorCommands = {
   focus: () => {},
   focusAtStart: () => {},
+  focusAtTrailingEmptyLine: () => {},
   focusAtPixelWidth: () => {},
   insertAtStartAndFocus: () => {},
   replaceContent: () => {},
@@ -407,6 +412,9 @@ function EditorCommandsBridge({
             view.state.tr.setSelection(Selection.atStart(view.state.doc)),
           );
           view.focus();
+        },
+        focusAtTrailingEmptyLine: () => {
+          focusTrailingEmptyLine(view);
         },
         focusAtPixelWidth: (pixelWidth: number) => {
           const blockStart = Selection.atStart(view.state.doc).from;

--- a/packages/editor/src/note/trailing-empty-line-click.test.ts
+++ b/packages/editor/src/note/trailing-empty-line-click.test.ts
@@ -30,6 +30,29 @@ describe("handleTrailingEmptyLineMouseDown", () => {
     expect(view.focus).toHaveBeenCalled();
   });
 
+  it("adds a body paragraph when clicking below a title-only document", () => {
+    const { view, getState } = createView([
+      schema.node("heading", { level: 1 }, [schema.text("Weekly sync")]),
+    ]);
+    const event = createMouseEvent({ target: view.dom, clientY: 40 });
+
+    const handled = handleTrailingEmptyLineMouseDown(view, event);
+
+    expect(handled).toBe(true);
+    expect(getState().doc.toJSON()).toEqual({
+      type: "doc",
+      content: [
+        {
+          type: "heading",
+          attrs: { level: 1 },
+          content: [{ type: "text", text: "Weekly sync" }],
+        },
+        { type: "paragraph" },
+      ],
+    });
+    expect(getState().selection.from).toBe(getState().doc.content.size - 1);
+  });
+
   it("uses an existing trailing empty paragraph instead of adding another", () => {
     const { view, getState } = createView([
       schema.node("paragraph", null, [schema.text("Follow up")]),

--- a/packages/editor/src/note/trailing-empty-line-click.ts
+++ b/packages/editor/src/note/trailing-empty-line-click.ts
@@ -40,7 +40,17 @@ export function handleTrailingEmptyLineMouseDown(
 
   event.preventDefault();
 
+  focusTrailingEmptyLine(view);
+  return true;
+}
+
+export function focusTrailingEmptyLine(view: EditorView) {
   const { doc } = view.state;
+  const paragraph = view.state.schema.nodes.paragraph;
+  if (!paragraph) {
+    return false;
+  }
+
   const lastChild = doc.lastChild;
   if (lastChild?.type === paragraph && !lastChild.textContent.trim()) {
     view.dispatch(view.state.tr.setSelection(Selection.atEnd(doc)));


### PR DESCRIPTION
Rebuild the unique behavior from #5872 on current main: clicks on blank note padding focus or create the trailing body line while clicks inside ProseMirror continue through the editor plugin. Includes title-only and interaction regression coverage.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized note-editing UX and editor command wiring with regression tests; no auth, data, or API changes.
> 
> **Overview**
> Restores **click blank padding → focus or create trailing body line** behavior for session note editors (raw and enhanced tabs), aligned with the existing ProseMirror trailing-empty-line plugin for clicks below the document.
> 
> **NoteInput** switches the scroll container from `onClick` + generic `focus()` to **`onMouseDown`** with guards: left button only, skip targets inside `.ProseMirror`, interactive controls, or when no editor is mounted; then **`focusAtTrailingEmptyLine`** on the note editor ref.
> 
> **Editor package** extracts **`focusTrailingEmptyLine`** from the mousedown handler and exposes it as **`focusAtTrailingEmptyLine`** on `EditorCommands` / `NoteEditorRef`. Tests cover title-only docs (add body paragraph), padding vs in-document clicks, and enhanced summary UI when ProseMirror is absent.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8ed5cd769f2f896738e6a5e6794c77f5f4042956. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->