### PR TITLE
Remove calendar prompt from landing hero

### DIFF
--- a/apps/web/src/routes/index.tsx
+++ b/apps/web/src/routes/index.tsx
@@ -369,16 +369,6 @@ function Component() {
               Jot notes during the call. Anarlog turns them into an editable
               summary.
             </p>
-            <p className="mx-auto mt-3 max-w-xl text-sm leading-6 text-[#6f675d]">
-              Connect Google Calendar or Outlook Calendar to view upcoming
-              events and attach private notes and memos.{" "}
-              <a
-                href="https://docs.anarlog.so/calendar"
-                className="underline underline-offset-4 hover:text-[#181613]"
-              >
-                Learn about calendar connections.
-              </a>
-            </p>
             <div className="mt-8 flex flex-wrap justify-center gap-x-5 gap-y-3 text-sm">
               <DownloadButton />
             </div>


### PR DESCRIPTION
## What changed

Removed the Google and Outlook Calendar connection prompt and documentation link from the landing-page hero.

## Why

The hero should focus on the core private-meeting notepad message and download action without asking visitors to connect a calendar.

## Validation

- `pnpm -F @hypr/web typecheck`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change on the marketing landing route with no logic or routing impact.
> 
> **Overview**
> Removes the secondary hero paragraph that told visitors to connect **Google Calendar** or **Outlook Calendar** and linked to `docs.anarlog.so/calendar`.
> 
> The hero now goes from the main notepad/summary line straight to the download control and workflow demo, without calendar setup as an above-the-fold message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 309b75f1c4e7cac2547a85e13e0499d49be92b3e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->