### PR TITLE
docs(blog): refresh Microsoft Teams notetaker guide

### DIFF
--- a/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
+++ b/apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx
@@ -1,314 +1,280 @@
 ---
-meta_title: "7 Best AI Notetakers for Microsoft Teams in 2026"
-meta_description: "Looking for the best AI notetaker for Microsoft Teams? Compare the top 7 solutions, including native and third-party options."
+meta_title: "Best AI Note Takers for Microsoft Teams (2026)"
+meta_description: "Compare five Microsoft Teams AI note-taking workflows by capture method, bot visibility, storage, recap access, and best fit."
 author:
   - "John Jeong"
 featured: false
 category: "Comparisons"
-date: "2025-09-09"
+date: "2026-07-17"
 ---
 
-Microsoft Teams is one of the harder environments for AI notes because the answer depends on what kind of buyer you are.
+Microsoft Teams already has native AI note-taking. But that does not automatically make it the best workflow for every meeting.
 
-If your company is already standardized on Microsoft and wants the least resistance possible, the native options matter. If you want better portability, more control, or something that works beyond Teams, the third-party tools get more interesting.
+The right choice depends on four practical questions:
 
-## TL;DR
+- Does a visible bot join the meeting?
+- Where are the audio, transcript, and notes stored?
+- Will the notes still be available after the meeting?
+- Do you need a personal note-taking tool or an organization-wide system?
 
-Here's a quick comparison of the [best AI notetakers](/blog/best-ai-meeting-assistant-for-taking-notes) for Microsoft Teams.
+For most people, the decision looks like this:
 
-![ai notetaker comparison for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-1.webp)
+- **Choose Microsoft Intelligent Recap or Copilot** when your organization already works inside Microsoft 365 and wants native administration.
+- **Choose Anarlog** when you want bot-free capture, local transcription, and Markdown files on your own computer.
+- **Choose Tactiq** when you attend Teams meetings through a browser and want live transcription from an extension.
+- **Choose Otter** when you want an automated participant that can attend meetings and prepare notes even when you are absent.
+- **Choose Fireflies** when downstream integrations and automated routing are more important than avoiding a meeting bot.
 
-Keep reading for the detailed trade-offs. The category splits pretty cleanly between native Microsoft convenience and more flexible third-party tools.
+## Microsoft Teams AI note takers compared
 
-**💡 Our selection criteria:**
+| Workflow | Capture method | Visible meeting bot? | Where notes live | Best for |
+| --- | --- | --- | --- | --- |
+| Microsoft Intelligent Recap and Copilot | Native Teams recording, transcription, and meeting audio | No external bot | Microsoft 365 | Organizations already standardized on Microsoft |
+| Anarlog | Desktop audio capture and local transcription | No | Markdown files on your computer | Local-first, bot-free meeting notes |
+| Tactiq | Browser extension using Teams web | No guest participant | Tactiq dashboard | Live transcription in the Teams web app |
+| Otter | Automated guest participant | Yes | Otter workspace | Auto-join, catch-up, and meeting automation |
+| Fireflies | Automated meeting participant | Yes | Fireflies and connected tools | Integration-heavy team workflows |
 
-We evaluated Microsoft's native options and third-party tools based on:
+![Bot-based and bot-free meeting-note workflows use different capture, storage, and AI architectures](/api/assets/blog/articles/best-ai-notetaker-for-microsoft-teams/teams-workflow-architecture.png)
 
-- **Microsoft Teams compatibility** - Must work seamlessly with Teams meetings
-- **AI quality** - Accurate transcription and intelligent summarization capabilities
-- **Privacy and security** - Different deployment options for various compliance needs
-- **Ease of use** - Simple setup and intuitive interface
-- **Pricing value** - Cost-effectiveness for different team sizes and budgets
-- **User feedback** - Real-world reviews and adoption rates
+The biggest difference is not the quality of an AI summary. It is the capture model.
 
-## Native AI Notetaker Solutions for Microsoft Teams
+A native Teams feature inherits Microsoft 365 policies. A meeting bot becomes another participant. A browser extension depends on how you join the call. A local desktop tool records from your device and can keep the transcript outside a vendor-managed meeting database.
 
-Microsoft doesn't offer a free way to get AI-powered meeting notes, summaries, or intelligent transcription analysis from Teams. Teams users with Microsoft 365 Business or Enterprise get meeting transcription with speaker identification, but no AI summaries or intelligent note-taking.
+## Does Microsoft Teams have an AI note taker?
 
-### 1. Microsoft 365 Copilot: The Premium AI Assistant
+Yes. Teams provides both ordinary meeting recaps and AI-enhanced recap features.
 
-![Microsoft 365 Copilot](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-2.webp)
+A standard Teams recap can contain the recording, transcript, shared files, notes, agenda, and follow-up tasks after a meeting that was recorded or transcribed. Intelligent Recap adds AI-generated notes, tasks, topics, chapters, and personalized timeline markers. Microsoft says Intelligent Recap is available through Teams Premium and Microsoft 365 Copilot licensing. [Microsoft documents the current recap experience here](https://support.microsoft.com/en-us/teams/meetings/recap-in-microsoft-teams).
 
-[Microsoft 365 Copilot](https://support.microsoft.com/en-us/office/use-copilot-in-microsoft-teams-meetings-0bf9dd3c-96f7-44e2-8bb8-790bedf066b1) is an AI assistant that works across Word, Excel, PowerPoint, Outlook, and Teams, powered by large language models. For Teams specifically, it transforms how you handle meeting preparation, participation, and follow-up.
+That makes Microsoft's native workflow the logical starting point, not another product you should automatically replace.
 
-**Important Note:** Microsoft 365 Copilot is different from the [free Copilot](https://copilot.microsoft.com) available in browsers and Bing. Copilot does not record meetings itself—you need to provide it with a meeting transcription to generate a summary and AI notes.
+### Best for Microsoft-native administration
 
-#### Microsoft 365 Copilot's Teams Integration Features
+Choose the native option when:
 
-- Cross-app integration across Word, Excel, PowerPoint, Outlook, and Teams
-- Real-time meeting intelligence with context understanding and topic organization
-- Intelligent summarization including decisions, action items, and participant insights
-- Post-meeting Q&A capability for specific questions about meeting content
-- Facilitator feature for virtual meeting moderation and mid-meeting recaps
-- Cross-reference capabilities connecting meetings with past discussions and documents
+- your company already licenses the required Microsoft products,
+- administrators want recording and retention governed through Microsoft 365,
+- participants expect recordings and recaps to remain inside Teams,
+- you do not need local files or a provider-independent archive.
 
-#### Pros
+Microsoft says transcripts can be stored in Exchange, recordings in OneDrive or SharePoint, and AI-generated notes and tasks in participants' Exchange mailboxes. It also says customer data used by Intelligent Recap is not used to train or test AI models. [Its Intelligent Recap privacy documentation explains the storage model in detail](https://learn.microsoft.com/en-us/microsoftteams/privacy/intelligent-recap).
 
-- Native integration eliminates compatibility issues
-- Enterprise-grade security with Microsoft's compliance framework
-- Cross-platform consistency across all Microsoft 365 apps
-- Contextual intelligence beyond basic transcription
-- No meeting bots required—cleaner meeting experience
-- Continuous AI improvements from Microsoft's ongoing development
+### The important limitation
 
-#### Cons
+A durable recap normally depends on recording or transcription.
 
-- Premium pricing at $30/user/month (as of 2026)
-- Requires existing Microsoft 365 subscription
-- Limited customization compared to specialized tools
-- Some advanced features still in preview
-- Performance can vary with audio quality and meeting complexity
+Microsoft also supports a Copilot mode that can generate notes and tasks during a meeting without creating a recording or transcript. However, Copilot will not remain available in the meeting Recap afterward unless recording or transcription was enabled. Microsoft also notes that prompts and responses may still be retained under an organization's Purview policies. [Microsoft explains this distinction in its Copilot support guide](https://support.microsoft.com/en-us/teams/copilot/use-copilot-without-transcribing-or-recording-a-teams-meeting-or-call).
 
-#### Pricing
+So "no transcript" does not necessarily mean "no retained data." Administrators should evaluate the actual retention configuration rather than relying on a feature label.
 
-Microsoft 365 Copilot costs $30 per user per month, in addition to your existing Microsoft 365 Business Premium or Enterprise subscription.
+## 1. Microsoft Intelligent Recap and Copilot
 
-### 2. Teams Premium: Enhanced Meeting Features
+**Best for:** Organizations that want the fewest moving parts inside Microsoft 365.
 
-![Teams Premium](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-3.webp)
+Microsoft's native tools have one major advantage: there is no external meeting participant, separate calendar bot, or additional meeting-notes workspace.
 
-[Teams Premium](https://www.microsoft.com/en-us/microsoft-teams/premium) offers enhanced meeting features between basic Teams and full Copilot functionality.
+Participants can review material from the same Teams meeting surface, while administrators can apply existing Microsoft policies and sensitivity controls.
 
-#### Key Features
+### Strengths
 
-- Intelligent meeting recap with key talking points and decisions
-- Live translation for 40+ languages with real-time transcription
-- Advanced meeting options including custom backgrounds and security controls
-- Basic AI insights for action item extraction and organization
+- Native to the Teams meeting experience
+- No third-party bot waiting in the lobby
+- Recaps can include recordings, transcripts, notes, tasks, and shared content
+- Fits existing Microsoft 365 permissions and retention workflows
+- Available across organization-managed Teams environments
 
-#### Pros
+### Tradeoffs
 
-- More affordable than the full Copilot solution
-- Immediate availability without preview limitations
-- Good transcription accuracy in optimal conditions
-- International team support with live translation
-- Enhanced security features for sensitive meetings
+- AI features depend on licenses and administrator configuration
+- Durable post-meeting AI access generally requires recording or transcription
+- Notes remain tied to the Microsoft 365 environment
+- It is not a local-file workflow
+- External attendees may have different access from internal participants
 
-#### Cons
+Microsoft is the strongest default when the organization already treats Teams and Microsoft 365 as its meeting system of record.
 
-- Limited AI capabilities compared to Copilot
-- Still requires an additional subscription beyond basic Teams
-- Less sophisticated summarization
-- No cross-app integration
-- Basic action item detection
+## 2. Anarlog
 
-#### Pricing
+**Best for:** People who want bot-free Microsoft Teams notes stored as files they control.
 
-Teams Premium is priced at $10 per user per month.
+Anarlog is our open-source, local-first meeting notetaker for macOS. It captures the meeting from your computer, transcribes locally, and stores notes as Markdown on disk.
 
-## Best Third-Party AI Notetakers for Microsoft Teams
+Because capture happens on your device, Anarlog does not need to join the Teams call as a guest participant. It can be used with the Teams desktop or web experience without adding another name to the attendee list.
 
-While Microsoft's native solutions work well for many organizations, third-party tools often provide specialized features, better privacy controls, or more competitive pricing.
+You can use a supported AI provider with your own key or connect a local model. This separates the transcription and note files from the model used to summarize them.
 
-### 1. Anarlog: The Zero Lock-in AI Notepad
+![Anarlog displaying a locally stored meeting summary](/api/assets/blog/articles/best-ai-notetaker-for-microsoft-teams/anarlog-meeting-notes.png)
 
-Anarlog is an open-source AI notepad for meetings built for high-agency people who demand complete control over their data and AI stack. Everything is stored as plain markdown files—not in proprietary databases.
+If the underlying workflow matters more than a feature checklist, see how [bot-free meeting notes differ from meeting-bot workflows](/blog/ai-meeting-notes-without-bot) and what to evaluate in a [local AI meeting-notes system](/blog/local-ai-meeting-notes).
 
-**Full Disclosure:** I'm the co-founder of Anarlog, so I'll try to be as objective as possible in this review.
+### Strengths
 
-**How It Works with Microsoft Teams:** Anarlog doesn't join your Teams meetings as a bot. Instead, it captures both your microphone input and your computer's system audio, so it hears both sides of the conversation. It transcribes your call in real-time. After the meeting ends, you get structured summaries with decisions and action items automatically extracted. No bots to invite, no meeting links to manage.
+- No meeting bot
+- Local transcription
+- Notes stored as ordinary Markdown files
+- Bring-your-own-key and local-model options
+- Open-source and inspectable
+- Works outside Teams as well as inside it
 
-![best ai notetaker for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-4.webp)
+### Tradeoffs
 
-#### Key Features
+- Designed as a personal desktop workflow, not a Teams administrator feature
+- It does not attend meetings for you
+- Each user controls their own files and setup
+- The current download experience is centered on macOS
+- Team distribution requires an intentional file-sharing or knowledge-management workflow
 
-- Works with Zoom, Teams, Google Meet, and in-person meetings without any setup
-- Your choice of AI: managed cloud, bring your own API keys (OpenAI, Anthropic, Mistral, and others), or run local models via Ollama or LM Studio
-- AI chat to query your transcripts and search across your entire meeting history
-- Custom templates for different meeting types
-- Import existing recordings or transcripts
-- 45+ language support including English, Spanish, French, German, Japanese, and more
-- Floating panel and keyboard shortcuts for quick recording controls
-- Smart consent management for enterprises with options from simple pop-ups to verbal consent recognition
+Anarlog is the strongest fit when "private" means controlling the artifact itself: where the transcript lives, which model sees it, and how the notes are retained.
 
-**Pros**
+## 3. Tactiq
 
-- Your choice of AI stack: managed cloud, bring your own keys, or run local models
-- Free forever for local transcription, BYOK, and all core features
-- Can work completely offline, suitable for air-gapped environments
-- Open source codebase allows for inspection, customization, and community contributions
-- Plain markdown files work with Obsidian, Notion, VS Code, or any text editor
+**Best for:** Teams users who join through a browser and want a live transcript without a guest participant.
 
-**Cons**
+Tactiq uses a Chrome or Edge extension to transcribe Teams meetings in real time. Its official instructions require the web version of Teams rather than the desktop application. Transcripts are available afterward through the Tactiq dashboard. [Tactiq documents the Teams web requirement in its current setup guide](https://help.tactiq.io/en/articles/9560779-how-to-use-tactiq-with-microsoft-teams).
 
-- macOS only currently (Windows and Linux versions coming in Q2 2026)
-- No video recording by design
+This is a useful middle ground between a meeting bot and a desktop recorder. The extension operates in the browser session instead of joining the call as another attendee.
 
-#### Pricing
+### Strengths
 
-Anarlog is [free forever](/blog/free-ai-notetakers) for local transcription, BYOK, and all core features. The managed cloud service is $25/month for the easiest setup. Enterprise applies when your organization needs on-premises deployment, SSO integration, or consent management for compliance requirements. [Contact sales for a quote](mailto:founders@char.com).
+- Live transcription inside the browser
+- No guest notetaker waiting for admission
+- Simple for people who already use Teams on the web
+- Transcript available after the meeting
+- Does not require switching the entire organization to a new meeting platform
 
-### 2. Otter AI: The Established Cloud-Based Solution
+### Tradeoffs
 
-[Otter AI](https://otter.ai) is one of the most well-known names in AI transcription, offering cloud-based meeting intelligence that works across Microsoft Teams, [Zoom](/blog/best-ai-notetaker-for-zoom/), and Google Meet.
+- The documented workflow does not support the Teams desktop app
+- Browser and extension changes can affect reliability
+- Some Teams "light meeting" sessions require captions to be enabled
+- A stable internet connection is required
+- Notes live in a separate service rather than as local files
 
-**How It Works with Microsoft Teams:** Otter joins your Teams meetings as a participant. It records the audio, generates real-time transcripts, and creates meeting summaries automatically. Setup involves account creation, calendar connection, and bot invitation. The bot can be invited manually or set to auto-join meetings based on your calendar integration. Recent privacy concerns indicate that Otter sometimes joins meetings without proper consent. Also check: [Is Otter AI Safe?](/blog/is-otter-ai-safe)
+Choose Tactiq when the browser requirement is acceptable and live transcription is more important than local storage.
 
-![Otter ai for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-6.webp)
+## 4. Otter
 
-#### Key Features
+**Best for:** Teams that want an automated participant to attend, transcribe, and prepare meeting notes.
 
-- OtterPilot AI Chat for asking questions about meeting content during or after calls
-- Slide capture automatically screenshots presentations and embeds them in transcripts
-- Custom vocabulary for industry terms, names, and company-specific language
-- Team workspaces with comment threads and assignable action items
-- CRM integrations with Salesforce and HubSpot (Business/Enterprise plans)
-- OtterPilot for Sales extracts insights and pushes notes to CRM (Enterprise only)
+Otter can connect to a Microsoft calendar and automatically join scheduled Teams meetings. Its Notetaker appears as a named guest participant, can transcribe in real time, and can prepare summaries and conversational follow-up features.
 
-#### Pros
+Otter can also attend a meeting when the user is absent. That is a meaningful distinction from local and browser-based tools.
 
-- Mature platform with years of development and proven reliability
-- Strong speaker identification that improves with usage
-- Established integration ecosystem especially valuable for sales teams
-- Mobile app handles both virtual and [in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings) effectively
+Otter explicitly states that its Notetaker cannot join anonymously: it appears as a guest participant and may need to be admitted under the meeting's guest policies. [Otter's current Notetaker documentation describes its Teams behavior and visibility](https://help.otter.ai/hc/en-us/articles/4425393298327-Otter-Notetaker-Overview).
 
-#### Cons
+### Strengths
 
-- Bot-based approach means meetings show an extra participant
-- Monthly minute limitations, even on paid plans
-- Privacy concerns, as all audio and transcripts are processed in Otter's cloud
-- Limited language support with only English, French, and Spanish
-- Complex permission management that teams struggle with
-- Higher pricing for teams—Business plan costs scale quickly for larger organizations
-- No offline capability requires a stable internet connection
+- Calendar synchronization and automatic joining
+- Can capture a meeting when you do not attend
+- Real-time transcription and post-meeting summaries
+- Central workspace for searching previous conversations
+- Works across Teams, Zoom, and Google Meet
 
-#### Pricing
+### Tradeoffs
 
-Free plan: 300 minutes monthly with 30-minute conversation limits. Paid plans start at $16.99/user/month for 1,200 minutes and advanced features.
+- A visible participant joins the call
+- Guest and lobby policies can prevent admission
+- Auto-join settings need careful configuration
+- Meeting data is managed in Otter's workspace
+- The organization still needs a recording-notice and consent policy
 
-### 3. Tactiq: The Browser Extension Approach
+Otter provides pre-meeting and in-meeting notice options, including a named participant and chat announcement. Its enterprise Outlook workflow can add an explicit recording-permission step for Teams meetings. [Otter documents those permission controls here](https://help.otter.ai/hc/en-us/articles/39339238308503-Recording-Permissions-with-Otter).
 
-[Tactiq](https://tactiq.io) is a bot-free AI meeting assistant that works as a Chrome extension to transcribe Microsoft Teams, Google Meet, and Zoom meetings.
+Choose Otter when unattended capture and a centralized meeting archive justify having a visible bot.
 
-**How It Works with Microsoft Teams:** Install the Chrome extension and join your Teams meeting in the browser. A small transcription widget appears showing live captions with speaker identification. After the meeting, you can use one-click AI actions to generate summaries, action items, or ask specific questions about the conversation.
+## 5. Fireflies
 
-![Tactiq for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-7.webp)
+**Best for:** Teams that want meeting notes routed into other business systems.
 
-#### Key Features
+Fireflies uses a meeting participant to record, transcribe, and take notes. Its value is less about disappearing into Teams and more about connecting meeting output to a wider automation workflow.
 
-- Browser-based transcription that works without recording meetings or inviting bots
-- Live transcription widget shows real-time captions during meetings with speaker identification
-- One-click AI actions for generating summaries, action items, and custom follow-ups
-- Custom AI prompts that can be saved and reused across meetings for consistent outputs
-- Multi-language support covering 30+ languages including English, Spanish, French, and German
-- Team Spaces for sharing transcripts and collaborating on meeting insights
-- Upload functionality for transcribing existing audio and video files
-- Screenshot capture to save important visual moments from presentations
+Fireflies' own Teams integration documentation states that its Notetaker joins as a participant and can route the resulting transcript, audio, and notes into connected tools. [The official workflow page describes this capture model](https://fireflies.ai/integrations/workflows/microsoft-teams-meet/workplace).
 
-#### Pros
+### Strengths
 
-- No meeting disruption since there's no bot joining your calls
-- Fast setup just requires installing a Chrome extension
-- Clean user interface that's intuitive
-- Strong privacy positioning as transcripts are processed without recording actual meetings
-- Affordable pricing compared to enterprise-focused alternatives
+- Automated capture through a meeting participant
+- Broad integration catalog
+- Centralized transcripts and recordings
+- Useful for sales, recruiting, and other repeatable workflows
+- Can route meeting output into downstream systems
 
-#### Cons
+### Tradeoffs
 
-- Chrome extension dependency means it only works in browser versions of meeting apps
-- Limited AI credits even on paid plans restrict how much AI processing you can do
-- No mobile app support since it relies on the Chrome extension. If you need an [AI notetaker for in-person meetings](/blog/best-ai-notetaker-for-in-person-meetings), Tactiq won't work.
-- Basic team collaboration features compared to dedicated team platforms
-- Transcription quality varies depending on browser audio quality and meeting conditions
-- No offline capability requires internet connection and browser access
+- A bot is visible in the meeting
+- Lobby and external-participant policies can interfere
+- The resulting archive lives in another cloud workspace
+- Integration breadth can create additional administration
+- Teams need clear controls for auto-join, sharing, and retention
 
-#### Pricing
+Choose Fireflies when meeting output needs to move automatically into a CRM, collaboration tool, or other system of execution.
 
-Free plan: 10 meetings/month and 5 AI credits. Paid plans start at $12/user/month.
+## How to choose the right Teams note-taking workflow
 
-### 4. Fireflies AI: The Conversation Intelligence Platform
+Start with the constraint that would make a tool unacceptable.
 
-[Fireflies](https://fireflies.ai) positions itself as a full conversation intelligence solution for sales teams and growing businesses.
+### Choose Microsoft when administration comes first
 
-**How It Works with Microsoft Teams:** Fireflies joins your Teams meetings as a bot. You can invite it manually to specific meetings or set it to auto-join based on your calendar integration. The bot records, transcribes, and processes the entire conversation, then automatically sends meeting summaries to designated Teams channels. Setup involves creating a Fireflies account, verifying email, connecting your Microsoft calendar, configuring auto-join preferences, setting up Teams channel integrations for receiving summaries, and potentially getting IT approval for the bot.
+Use Intelligent Recap or Copilot if your company already governs meetings through Microsoft 365 and wants recordings, transcripts, access, and retention managed in that environment.
 
-![fireflies ai for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-8.webp)
+### Choose Anarlog when ownership comes first
 
-#### Key Features
+Use Anarlog if you want bot-free capture, local transcription, Markdown files, and control over the AI model used for summaries.
 
-- AskFred AI assistant lets you chat with meeting transcripts and ask specific questions about past conversations
-- Conversation intelligence provides talk-time analytics, sentiment analysis, and speaker behavior insights
-- Video recording capability captures screen shares, slides, and visual content alongside audio transcription
-- 69 language support making it suitable for global teams and multilingual meetings
-- Team analytics show meeting patterns, participation rates, and conversation insights for managers
-- AI Apps and custom prompts for generating specialized outputs like follow-up emails and project updates
+### Choose Tactiq when you work in Teams on the web
 
-#### Pros
+Use Tactiq if a browser extension fits your workflow and live transcription matters more than desktop support or local storage.
 
-- Extensive integration ecosystem with 58+ platforms including major CRMs and productivity tools
-- Strong enterprise features including HIPAA compliance, SSO, and private storage options
-- Robust search functionality lets you find specific moments across all past meetings
-- Unlimited transcription even on the free plan
-- Mobile app support for recording and transcribing in-person conversations
+### Choose Otter when the notetaker must attend for you
 
-#### Cons
+Use Otter if automatic joining and catching up on unattended meetings are core requirements.
 
-- Bot presence can feel intrusive as Fireflies appears as an additional meeting participant
-- Complex interface may overwhelm users who just want simple transcription
-- Storage limitations on lower-tier plans create pressure to upgrade
-- Higher pricing for advanced features compared to basic transcription alternatives
+### Choose Fireflies when integrations come first
 
-#### Pricing
+Use Fireflies if the transcript is only the beginning and the important requirement is routing meeting knowledge into other tools.
 
-Free forever with unlimited transcription, but limited AI summaries and 800 minutes storage. Paid plans start at $18/user/month.
+## A practical deployment checklist
 
-Also check: [Top Fireflies AI Alternatives](/blog/fireflies-ai-alternatives)
+Before standardizing any AI note taker, test the complete meeting lifecycle:
 
-### 5. tl;dv: The Video-Moment AI Notetaker
+1. Define which types of meetings may be recorded or transcribed.
+2. Decide whether a visible bot is acceptable for internal and external calls.
+3. Verify lobby behavior for meetings hosted by another organization.
+4. Identify where audio, transcripts, summaries, and AI prompts are stored.
+5. Confirm what remains available after the meeting ends.
+6. Test deletion, retention, export, and access controls.
+7. Decide where approved decisions and tasks move after the recap.
 
-[tl;dv](https://tldv.io) is a video-first AI notetaker that turns meeting notes into clickable timestamps, making it easy to navigate directly to specific moments in recordings.
+A transcript is not yet an operating system. The useful final step is turning decisions into clear [meeting action items with owners, deadlines, and source context](/blog/meeting-action-items).
 
-**How It Works with Microsoft Teams:** The tl;dv bot joins your Teams meetings automatically, records both audio and video, then generates AI summaries while allowing you to add manual timestamped notes during the call. Setup involves creating a tl;dv account, connecting your calendar, and configuring recording preferences.
+Recording and consent requirements also vary by jurisdiction and meeting context. Review the practical considerations in our guide to [AI meeting-note legality and consent](/blog/is-ai-notetaking-legal), then confirm the policy with qualified counsel for your organization.
 
-![tl;dv for microsoft teams](/api/assets/blog/best-ai-notetaker-for-microsoft-teams/teams-9.webp)
+## Frequently asked questions
 
-#### Key Features
+### Does Microsoft Teams have a built-in AI note taker?
 
-- Timestamped manual notes let you add your own observations during meetings that become clickable moments in recordings
-- AI meeting summaries automatically extract key points, decisions, and action items from every conversation
-- Video moment search allows you to search keywords and jump directly to that point in the recording
-- Sales playbook analysis tracks how well team members follow scripts and handle customer objections
-- Multi-meeting intelligence analyzes patterns and trends across multiple similar meetings
-- Clip creation tools make it easy to cut and share important moments from longer recordings
-- 30+ language transcription supports global teams with multilingual meeting capture
+Yes. Teams supports meeting recaps, while Teams Premium and Microsoft 365 Copilot add AI-generated notes, tasks, summaries, and other Intelligent Recap features. Availability depends on licensing and administrator policy.
 
-#### Pros
+### Can Copilot take notes without recording a Teams meeting?
 
-- Video navigation capabilities make it easy to find and share specific conversation moments
-- Generous free plan offers unlimited recordings and transcriptions without time limits
-- Strong sales coaching features help managers analyze rep performance and objection handling
-- Extensive integration ecosystem connects with most business tools via Zapier
+Copilot can generate notes and tasks during certain meetings without recording or persistent transcription. However, post-meeting access in Recap generally requires recording or transcription. Purview policies may also retain Copilot prompts and responses.
 
-#### Cons
+### Can I take AI meeting notes in Teams without a bot?
 
-- Bot presence required means Teams meetings show an additional participant
-- Video storage demands can consume significant space for frequent, long meetings
-- Limited to three platforms only works with Teams, Zoom, and Google Meet
-- No mobile app restricts access to browser and desktop versions only
-- Learning curve for teams to adopt video-based workflow and timestamp navigation
+Yes. A local desktop recorder such as Anarlog captures from your device, while a browser-extension workflow such as Tactiq operates inside Teams on the web. Neither requires an automated guest participant.
 
-#### Pricing
+### Which options work with the Teams desktop app?
 
-Free forever plan with unlimited recordings. Pro plans start at $29/month for advanced analytics and coaching features.
+Microsoft's native features and local desktop capture work with the Teams desktop application. Otter and Fireflies join the meeting independently of your client. Tactiq's documented workflow requires Teams on the web.
 
----
+### Is a bot-free notetaker automatically more private?
 
-## My take
+No. "Bot-free" only describes how the meeting is captured. You still need to check where audio and transcripts are processed, whether they are retained, which AI model receives them, and how output is shared.
 
-If your company is already deep in Microsoft procurement and wants the most familiar path, start with Copilot.
+## The short answer
 
-If you want something that is not trapped inside Teams, start with Anarlog. It works with Teams, but it is not dependent on Teams. That matters if you care about keeping the notes as files, keeping the AI stack flexible, or keeping the same workflow across Zoom, Meet, and in-person conversations.
+Use Microsoft's native recap when Teams is already your organization's system of record. Use a meeting bot when unattended capture and automation are worth adding another participant. Use a browser extension when you live in Teams web.
 
-You can [download and start using Anarlog](/download) without calendar connections, account setup, or a meeting bot.
+Use a local-first tool when you want the meeting record to remain yours.
 
-&nbsp;
+[Download Anarlog for macOS](/download) if you want Microsoft Teams notes without a meeting bot, with local transcription and Markdown files stored on your computer.


### PR DESCRIPTION
## Summary

- Refresh the Microsoft Teams AI note taker comparison for 2026.
- Compare capture models and data handling using current product evidence.
- Replace broken legacy media references with canonical blog asset paths.

## Validation

- dprint formatting: `pnpm exec dprint fmt apps/web/content/articles/best-ai-notetaker-for-microsoft-teams.mdx`
- `pnpm -F @hypr/web typecheck`
- `pnpm -F @hypr/web build` where content and bundles pass, but prerender requires unavailable production environment variables.
- Desktop and mobile local visual QA.

Linear: ANLG-118

The two referenced blog assets were uploaded to the canonical bucket paths and verified with matching byte sizes and `image/png` content types.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Marketing/content-only changes to one MDX file; no application logic, auth, or data handling.
> 
> **Overview**
> **Rewrites** the Microsoft Teams AI notetaker article as a 2026 comparison framed by **capture model** (native Teams, local desktop, browser extension, meeting bots)—not a long feature list per vendor.
> 
> **Content structure:** Narrows from seven products to **five workflows** (Microsoft Intelligent Recap/Copilot, Anarlog, Tactiq, Otter, Fireflies), drops **tl;dv** and the old separate Teams Premium/Copilot deep-dives, and adds a **comparison table**, decision guide, deployment checklist, and **FAQ** (including Copilot without recording vs durable Recap and Purview retention).
> 
> **Evidence and assets:** Updates **meta title/description** and **date**, adds **Microsoft/Tactiq/Otter/Fireflies** documentation links, and swaps legacy **`/api/assets/blog/best-ai-notetaker-for-microsoft-teams/*.webp`** references for canonical **`/api/assets/blog/articles/best-ai-notetaker-for-microsoft-teams/*.png`** (architecture + Anarlog screenshot). Strengthens internal links to related guides (bot-free notes, local AI notes, action items, legality).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 04486673b98faf867552c7019a294bbb01a021ca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->