### PR TITLE
fix(onboarding): tolerate invalid event metadata

### DIFF
--- a/apps/desktop/src/onboarding/final.test.tsx
+++ b/apps/desktop/src/onboarding/final.test.tsx
@@ -130,3 +130,25 @@ it("reuses the blank fallback session when persistence is retried", async () => 
   expect(mocks.createSession).toHaveBeenCalledTimes(1);
   consoleError.mockRestore();
 });
+
+it("ignores concurrent finish attempts", async () => {
+  const onContinue = vi.fn();
+  let resolveWelcomeSession: (sessionId: string) => void = () => {};
+  mocks.getOrCreateWelcomeSession.mockReturnValue(
+    new Promise((resolve) => {
+      resolveWelcomeSession = resolve;
+    }),
+  );
+
+  render(<FinalSection onContinue={onContinue} />);
+  const button = screen.getByRole("button", { name: "Open Anarlog" });
+  fireEvent.click(button);
+  fireEvent.click(button);
+  resolveWelcomeSession("welcome-session");
+
+  await waitFor(() => {
+    expect(onContinue).toHaveBeenCalledWith("welcome-session");
+  });
+  expect(mocks.getOrCreateWelcomeSession).toHaveBeenCalledTimes(1);
+  expect(onContinue).toHaveBeenCalledTimes(1);
+});

--- a/apps/desktop/src/onboarding/final.test.tsx
+++ b/apps/desktop/src/onboarding/final.test.tsx
@@ -93,7 +93,7 @@ it("shows a retryable error when onboarding cannot be persisted", async () => {
     ).disabled,
   ).toBe(true);
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Retry");
+    expect(screen.getByRole("alert").textContent).toBe("Open Anarlog");
   });
   expect(
     (

--- a/apps/desktop/src/onboarding/final.test.tsx
+++ b/apps/desktop/src/onboarding/final.test.tsx
@@ -88,14 +88,12 @@ it("shows a retryable error when onboarding cannot be persisted", async () => {
   expect(
     (
       screen.getByRole("button", {
-        name: "Opening Anarlog",
+        name: "Open Anarlog",
       }) as HTMLButtonElement
     ).disabled,
   ).toBe(true);
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe(
-      "Couldn't open Anarlog. Please try again.",
-    );
+    expect(screen.getByRole("alert").textContent).toBe("Retry");
   });
   expect(
     (

--- a/apps/desktop/src/onboarding/final.test.tsx
+++ b/apps/desktop/src/onboarding/final.test.tsx
@@ -93,7 +93,9 @@ it("shows a retryable error when onboarding cannot be persisted", async () => {
     ).disabled,
   ).toBe(true);
   await waitFor(() => {
-    expect(screen.getByRole("alert").textContent).toBe("Open Anarlog");
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Couldn't open Anarlog. Please try again.",
+    );
   });
   expect(
     (
@@ -103,5 +105,28 @@ it("shows a retryable error when onboarding cannot be persisted", async () => {
     ).disabled,
   ).toBe(false);
   expect(onContinue).not.toHaveBeenCalled();
+  consoleError.mockRestore();
+});
+
+it("reuses the blank fallback session when persistence is retried", async () => {
+  const onContinue = vi.fn();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mocks.getOrCreateWelcomeSession.mockRejectedValue(
+    new Error("malformed JSON"),
+  );
+  mocks.createSession.mockResolvedValue("blank-session");
+  mocks.setOnboardingNeeded
+    .mockResolvedValueOnce({ status: "error", error: "settings unavailable" })
+    .mockResolvedValueOnce({ status: "ok", data: null });
+
+  render(<FinalSection onContinue={onContinue} />);
+  fireEvent.click(screen.getByRole("button", { name: "Open Anarlog" }));
+  await screen.findByRole("alert");
+  fireEvent.click(screen.getByRole("button", { name: "Open Anarlog" }));
+
+  await waitFor(() => {
+    expect(onContinue).toHaveBeenCalledWith("blank-session");
+  });
+  expect(mocks.createSession).toHaveBeenCalledTimes(1);
   consoleError.mockRestore();
 });

--- a/apps/desktop/src/onboarding/final.test.tsx
+++ b/apps/desktop/src/onboarding/final.test.tsx
@@ -1,0 +1,109 @@
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
+import { afterEach, beforeEach, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  analyticsEvent: vi.fn(),
+  createSession: vi.fn(),
+  flushAutomaticRelaunch: vi.fn(),
+  getOrCreateWelcomeSession: vi.fn(),
+  setOnboardingNeeded: vi.fn(),
+  setPendingWelcomeSession: vi.fn(),
+  stopSfx: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-analytics", () => ({
+  commands: { event: mocks.analyticsEvent },
+}));
+
+vi.mock("@hypr/plugin-opener2", () => ({
+  commands: { openUrl: vi.fn() },
+}));
+
+vi.mock("@hypr/plugin-sfx", () => ({
+  commands: { stop: mocks.stopSfx },
+}));
+
+vi.mock("./welcome-note", () => ({
+  getOrCreateWelcomeSession: mocks.getOrCreateWelcomeSession,
+  setPendingWelcomeSession: mocks.setPendingWelcomeSession,
+}));
+
+vi.mock("~/session/queries", () => ({
+  createSession: mocks.createSession,
+}));
+
+vi.mock("~/shared/relaunch", () => ({
+  flushAutomaticRelaunch: mocks.flushAutomaticRelaunch,
+}));
+
+vi.mock("~/types/tauri.gen", () => ({
+  commands: { setOnboardingNeeded: mocks.setOnboardingNeeded },
+}));
+
+import { FinalSection, finishOnboarding } from "./final";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mocks.analyticsEvent.mockResolvedValue(null);
+  mocks.flushAutomaticRelaunch.mockResolvedValue(false);
+  mocks.getOrCreateWelcomeSession.mockResolvedValue("welcome-session");
+  mocks.setOnboardingNeeded.mockResolvedValue({ status: "ok", data: null });
+  mocks.stopSfx.mockResolvedValue(null);
+});
+
+afterEach(cleanup);
+
+it("opens a blank note when welcome-note creation fails", async () => {
+  const onContinue = vi.fn();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mocks.getOrCreateWelcomeSession.mockRejectedValueOnce(
+    new Error("malformed JSON"),
+  );
+  mocks.createSession.mockResolvedValueOnce("blank-session");
+
+  await finishOnboarding(onContinue);
+
+  expect(mocks.createSession).toHaveBeenCalledTimes(1);
+  expect(onContinue).toHaveBeenCalledWith("blank-session");
+  consoleError.mockRestore();
+});
+
+it("shows a retryable error when onboarding cannot be persisted", async () => {
+  const onContinue = vi.fn();
+  const consoleError = vi.spyOn(console, "error").mockImplementation(() => {});
+  mocks.setOnboardingNeeded.mockResolvedValueOnce({
+    status: "error",
+    error: "settings unavailable",
+  });
+
+  render(<FinalSection onContinue={onContinue} />);
+  fireEvent.click(screen.getByRole("button", { name: "Open Anarlog" }));
+
+  expect(
+    (
+      screen.getByRole("button", {
+        name: "Opening Anarlog",
+      }) as HTMLButtonElement
+    ).disabled,
+  ).toBe(true);
+  await waitFor(() => {
+    expect(screen.getByRole("alert").textContent).toBe(
+      "Couldn't open Anarlog. Please try again.",
+    );
+  });
+  expect(
+    (
+      screen.getByRole("button", {
+        name: "Open Anarlog",
+      }) as HTMLButtonElement
+    ).disabled,
+  ).toBe(false);
+  expect(onContinue).not.toHaveBeenCalled();
+  consoleError.mockRestore();
+});

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -1,7 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { Trans } from "@lingui/react/macro";
 import { Loader2Icon } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -70,13 +70,14 @@ export function FinalSection({
   onContinue: (sessionId: string) => void;
 }) {
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const welcomeSessionRef = useRef<string | null>(null);
 
   const handleContinue = async () => {
     if (status === "loading") return;
 
     setStatus("loading");
     try {
-      await finishOnboarding(onContinue);
+      await finishOnboarding(onContinue, welcomeSessionRef);
     } catch (error) {
       console.error("Failed to finish onboarding", error);
       setStatus("error");
@@ -101,7 +102,7 @@ export function FinalSection({
       </OnboardingButton>
       {status === "error" && (
         <p className="text-sm text-red-500" role="alert">
-          <Trans>Open Anarlog</Trans>
+          Couldn't open Anarlog. Please try again.
         </p>
       )}
     </div>
@@ -110,12 +111,18 @@ export function FinalSection({
 
 export async function finishOnboarding(
   onContinue?: (sessionId: string) => void,
+  welcomeSessionRef?: { current: string | null },
 ) {
   await sfxCommands.stop("BGM").catch(console.error);
-  const welcomeSessionId = await getOrCreateWelcomeSession().catch((error) => {
-    console.error("Failed to create welcome note", error);
-    return createSession();
-  });
+  const welcomeSessionId =
+    welcomeSessionRef?.current ??
+    (await getOrCreateWelcomeSession().catch((error) => {
+      console.error("Failed to create welcome note", error);
+      return createSession();
+    }));
+  if (welcomeSessionRef) {
+    welcomeSessionRef.current = welcomeSessionId;
+  }
   await new Promise((resolve) => setTimeout(resolve, 100));
   const result = await commands.setOnboardingNeeded(false);
   if (result.status === "error") {

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -101,7 +101,7 @@ export function FinalSection({
       </OnboardingButton>
       {status === "error" && (
         <p className="text-sm text-red-500" role="alert">
-          <Trans>Retry</Trans>
+          <Trans>Open Anarlog</Trans>
         </p>
       )}
     </div>

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -71,6 +71,7 @@ export function FinalSection({
   onContinue: (sessionId: string) => void;
 }) {
   const { i18n } = useLingui();
+  const translate = i18n._.bind(i18n);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const welcomeSessionRef = useRef<string | null>(null);
 
@@ -104,7 +105,7 @@ export function FinalSection({
       </OnboardingButton>
       {status === "error" && (
         <p className="text-sm text-red-500" role="alert">
-          {i18n._({
+          {translate({
             id: "onboarding.finish-error",
             message: "Couldn't open Anarlog. Please try again.",
           })}

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -1,4 +1,5 @@
 import { Icon } from "@iconify-icon/react";
+import { useLingui } from "@lingui/react";
 import { Trans } from "@lingui/react/macro";
 import { Loader2Icon } from "lucide-react";
 import { useRef, useState } from "react";
@@ -69,6 +70,7 @@ export function FinalSection({
 }: {
   onContinue: (sessionId: string) => void;
 }) {
+  const { i18n } = useLingui();
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
   const welcomeSessionRef = useRef<string | null>(null);
 
@@ -102,7 +104,10 @@ export function FinalSection({
       </OnboardingButton>
       {status === "error" && (
         <p className="text-sm text-red-500" role="alert">
-          Couldn't open Anarlog. Please try again.
+          {i18n._({
+            id: "onboarding.finish-error",
+            message: "Couldn't open Anarlog. Please try again.",
+          })}
         </p>
       )}
     </div>

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -1,5 +1,7 @@
 import { Icon } from "@iconify-icon/react";
 import { Trans } from "@lingui/react/macro";
+import { Loader2Icon } from "lucide-react";
+import { useState } from "react";
 
 import { commands as analyticsCommands } from "@hypr/plugin-analytics";
 import { commands as openerCommands } from "@hypr/plugin-opener2";
@@ -11,6 +13,7 @@ import {
   setPendingWelcomeSession,
 } from "./welcome-note";
 
+import { createSession } from "~/session/queries";
 import { flushAutomaticRelaunch } from "~/shared/relaunch";
 import { commands } from "~/types/tauri.gen";
 
@@ -66,13 +69,42 @@ export function FinalSection({
 }: {
   onContinue: (sessionId: string) => void;
 }) {
+  const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+
+  const handleContinue = async () => {
+    if (status === "loading") return;
+
+    setStatus("loading");
+    try {
+      await finishOnboarding(onContinue);
+    } catch (error) {
+      console.error("Failed to finish onboarding", error);
+      setStatus("error");
+    }
+  };
+
   return (
-    <OnboardingButton
-      className="px-6 py-2 text-sm"
-      onClick={() => void finishOnboarding(onContinue)}
-    >
-      <Trans>Open Anarlog</Trans>
-    </OnboardingButton>
+    <div className="flex flex-col items-start gap-2">
+      <OnboardingButton
+        className="px-6 py-2 text-sm disabled:cursor-wait disabled:opacity-70"
+        disabled={status === "loading"}
+        onClick={() => void handleContinue()}
+      >
+        {status === "loading" ? (
+          <span className="flex items-center gap-2">
+            <Loader2Icon className="size-4 animate-spin" />
+            <Trans>Opening Anarlog</Trans>
+          </span>
+        ) : (
+          <Trans>Open Anarlog</Trans>
+        )}
+      </OnboardingButton>
+      {status === "error" && (
+        <p className="text-sm text-red-500" role="alert">
+          <Trans>Couldn't open Anarlog. Please try again.</Trans>
+        </p>
+      )}
+    </div>
   );
 }
 
@@ -80,11 +112,19 @@ export async function finishOnboarding(
   onContinue?: (sessionId: string) => void,
 ) {
   await sfxCommands.stop("BGM").catch(console.error);
-  const welcomeSessionId = await getOrCreateWelcomeSession();
+  const welcomeSessionId = await getOrCreateWelcomeSession().catch((error) => {
+    console.error("Failed to create welcome note", error);
+    return createSession();
+  });
   await new Promise((resolve) => setTimeout(resolve, 100));
-  await commands.setOnboardingNeeded(false).catch(console.error);
+  const result = await commands.setOnboardingNeeded(false);
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
   await new Promise((resolve) => setTimeout(resolve, 100));
-  await analyticsCommands.event({ event: "onboarding_completed" });
+  void analyticsCommands
+    .event({ event: "onboarding_completed" })
+    .catch(console.error);
   setPendingWelcomeSession(welcomeSessionId);
   if (await flushAutomaticRelaunch()) {
     return;

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -93,7 +93,7 @@ export function FinalSection({
         {status === "loading" ? (
           <span className="flex items-center gap-2">
             <Loader2Icon className="size-4 animate-spin" />
-            <Trans>Opening Anarlog</Trans>
+            <Trans>Open Anarlog</Trans>
           </span>
         ) : (
           <Trans>Open Anarlog</Trans>
@@ -101,7 +101,7 @@ export function FinalSection({
       </OnboardingButton>
       {status === "error" && (
         <p className="text-sm text-red-500" role="alert">
-          <Trans>Couldn't open Anarlog. Please try again.</Trans>
+          <Trans>Retry</Trans>
         </p>
       )}
     </div>

--- a/apps/desktop/src/onboarding/final.tsx
+++ b/apps/desktop/src/onboarding/final.tsx
@@ -73,17 +73,22 @@ export function FinalSection({
   const { i18n } = useLingui();
   const translate = i18n._.bind(i18n);
   const [status, setStatus] = useState<"idle" | "loading" | "error">("idle");
+  const finishPromiseRef = useRef<Promise<void> | null>(null);
   const welcomeSessionRef = useRef<string | null>(null);
 
   const handleContinue = async () => {
-    if (status === "loading") return;
+    if (finishPromiseRef.current) return;
 
     setStatus("loading");
+    const finishPromise = finishOnboarding(onContinue, welcomeSessionRef);
+    finishPromiseRef.current = finishPromise;
     try {
-      await finishOnboarding(onContinue, welcomeSessionRef);
+      await finishPromise;
     } catch (error) {
       console.error("Failed to finish onboarding", error);
       setStatus("error");
+    } finally {
+      finishPromiseRef.current = null;
     }
   };
 

--- a/apps/desktop/src/onboarding/welcome-note.test.ts
+++ b/apps/desktop/src/onboarding/welcome-note.test.ts
@@ -54,6 +54,18 @@ it("creates a prerecorded demo note with normal meeting metadata", async () => {
   expect(initial.raw_md).toContain("Join & record");
 });
 
+it("guards empty event metadata before reading its tracking ID", async () => {
+  mocks.execute.mockResolvedValueOnce([]);
+  mocks.createSession.mockResolvedValueOnce("welcome-session");
+
+  await getOrCreateWelcomeSession();
+
+  const [query] = mocks.execute.mock.calls[0];
+  expect(query).toMatch(
+    /CASE\s+WHEN json_valid\(event_json\)\s+THEN json_extract\(event_json, '\$\.tracking_id'\)\s+END = \?/,
+  );
+});
+
 it("carries the welcome note across a one-time onboarding relaunch", () => {
   setPendingWelcomeSession("welcome-session");
 

--- a/apps/desktop/src/onboarding/welcome-note.ts
+++ b/apps/desktop/src/onboarding/welcome-note.ts
@@ -48,7 +48,10 @@ async function findOrCreateWelcomeSession(): Promise<string> {
       SELECT id
       FROM sessions
       WHERE deleted_at IS NULL
-        AND json_extract(event_json, '$.tracking_id') = ?
+        AND CASE
+          WHEN json_valid(event_json)
+          THEN json_extract(event_json, '$.tracking_id')
+        END = ?
       ORDER BY created_at, id
       LIMIT 1
     `,

--- a/apps/desktop/src/test-setup.ts
+++ b/apps/desktop/src/test-setup.ts
@@ -147,7 +147,7 @@ vi.mock("@lingui/react", () => ({
   useLingui: () => ({
     _: translate,
     t: translate,
-    i18n: { locale: "en" },
+    i18n: { _: translate, locale: "en" },
   }),
 }));
 


### PR DESCRIPTION
## Summary

- guard malformed event JSON when locating the welcome session
- fall back to a blank session if welcome-note creation fails
- make onboarding completion retryable and keep analytics non-blocking

## Testing

- pnpm -F desktop typecheck
- pnpm -F desktop test (237 files, 1,684 tests)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches first-run onboarding completion and session selection; failures are mitigated with fallbacks and retries but incorrect behavior could still block new users.
> 
> **Overview**
> Hardens onboarding completion when welcome-note data or settings persistence misbehaves.
> 
> Welcome session lookup now only reads `tracking_id` from `event_json` when `json_valid(event_json)` passes, avoiding query failures on malformed metadata. If welcome-note creation still fails, `finishOnboarding` falls back to a blank `createSession()` and caches that session id across retries so a failed `setOnboardingNeeded` does not create duplicate sessions.
> 
> The final **Open Anarlog** step gains loading UI, a retryable error alert when persisting onboarding state fails, deduplication of concurrent clicks, and non-blocking analytics. Tests cover fallback, persistence retry, concurrency, and the guarded SQL.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e38fc3210db491d763dbf77befcae7e096cbd1fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->