### PR TITLE
fix(desktop): simplify delete toast

### DIFF
--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.test.tsx
@@ -70,18 +70,14 @@ describe("UndoDeleteToast", () => {
     );
 
     expect(mocks.message).toHaveBeenCalledWith(
-      "Deleting Design sync",
+      "Design sync deleted",
       expect.objectContaining({
         id: "undo-delete:session-1",
         duration: Infinity,
-        actionButtonStyle: {
-          background: "hsl(var(--destructive))",
-          color: "hsl(var(--destructive-foreground))",
-        },
-        action: expect.objectContaining({ label: "Delete" }),
-        cancel: expect.objectContaining({ label: "Undo" }),
+        action: expect.objectContaining({ label: "Undo" }),
       }),
     );
+    expect(mocks.message.mock.calls[0][1]).not.toHaveProperty("cancel");
 
     view.unmount();
     expect(mocks.dismiss).toHaveBeenCalledWith("undo-delete:session-1");
@@ -108,7 +104,7 @@ describe("UndoDeleteToast", () => {
     });
 
     expect(mocks.message).toHaveBeenLastCalledWith(
-      "Deleting 1 notes",
+      "1 note deleted",
       expect.objectContaining({ id: "undo-delete:batch-1" }),
     );
 
@@ -125,14 +121,14 @@ describe("UndoDeleteToast", () => {
     });
 
     expect(mocks.message).toHaveBeenLastCalledWith(
-      "Deleting 2 notes",
+      "2 notes deleted",
       expect.objectContaining({ id: "undo-delete:batch-1" }),
     );
 
     const options =
       mocks.message.mock.calls[mocks.message.mock.calls.length - 1][1];
     await act(async () => {
-      options.cancel.onClick();
+      options.action.onClick();
       await Promise.resolve();
     });
 

--- a/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
+++ b/apps/desktop/src/sidebar/toast/undo-delete-toast.tsx
@@ -94,22 +94,6 @@ function useRestoreGroup() {
   );
 }
 
-function useConfirmGroup() {
-  const confirmDeletion = useUndoDelete((state) => state.confirmDeletion);
-  const confirmBatch = useUndoDelete((state) => state.confirmBatch);
-
-  return useCallback(
-    (group: ToastGroup) => {
-      if (group.isBatch) {
-        confirmBatch(group.key);
-      } else {
-        confirmDeletion(group.sessionIds[0]);
-      }
-    },
-    [confirmDeletion, confirmBatch],
-  );
-}
-
 export function UndoDeleteToast() {
   const groups = useToastGroups();
 
@@ -123,14 +107,14 @@ export function UndoDeleteToast() {
 
 function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
   const restoreGroup = useRestoreGroup();
-  const confirmGroup = useConfirmGroup();
   const pendingDeletions = useUndoDelete((state) => state.pendingDeletions);
   const title = group.isBatch
     ? null
     : pendingDeletions[group.sessionIds[0]]?.data.session.title || "Untitled";
+  const noteLabel = group.sessionIds.length === 1 ? "note" : "notes";
   const label = group.isBatch
-    ? `Deleting ${group.sessionIds.length} notes`
-    : `Deleting ${title}`;
+    ? `${group.sessionIds.length} ${noteLabel} deleted`
+    : `${title} deleted`;
 
   useMountEffect(() => {
     const toastId = `undo-delete:${group.key}`;
@@ -138,15 +122,7 @@ function UndoDeleteSonnerToast({ group }: { group: ToastGroup }) {
     sonnerToast.message(label, {
       id: toastId,
       duration: Infinity,
-      actionButtonStyle: {
-        background: "hsl(var(--destructive))",
-        color: "hsl(var(--destructive-foreground))",
-      },
       action: {
-        label: "Delete",
-        onClick: () => confirmGroup(group),
-      },
-      cancel: {
         label: "Undo",
         onClick: () => restoreGroup(group),
       },

--- a/packages/ui/src/components/ui/toast.tsx
+++ b/packages/ui/src/components/ui/toast.tsx
@@ -1,4 +1,4 @@
-import type { ComponentProps } from "react";
+import type { ComponentProps, CSSProperties } from "react";
 import { Toaster as Sonner, toast as sonnerToast } from "sonner";
 
 export { sonnerToast };
@@ -9,6 +9,7 @@ const Toaster = ({
   theme = "system",
   position = "bottom-right",
   richColors = true,
+  style,
   ...props
 }: ToasterProps) => (
   <Sonner
@@ -16,10 +17,11 @@ const Toaster = ({
     position={position}
     richColors={richColors}
     className="toaster group"
+    style={{ "--width": "300px", ...style } as CSSProperties}
     toastOptions={{
       classNames: {
         toast:
-          "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-lg group-[.toaster]:rounded-lg group-[.toaster]:overflow-clip group-[.toaster]:w-[300px]",
+          "group toast group-[.toaster]:bg-background group-[.toaster]:text-foreground group-[.toaster]:border group-[.toaster]:border-border group-[.toaster]:shadow-md group-[.toaster]:rounded-xl group-[.toaster]:overflow-clip group-[.toaster]:w-[300px] group-[.toaster]:p-3.5 group-[.toaster]:gap-3",
         description: "group-[.toast]:text-muted-foreground",
         actionButton:
           "group-[.toast]:bg-primary group-[.toast]:text-primary-foreground",


### PR DESCRIPTION
## Summary

- replace the delete confirmation action with a single Undo action
- update toast copy to describe completed deletion with correct singular and plural labels
- compact the shared toast spacing, radius, shadow, and width handling

## Testing

- pnpm -F desktop exec vitest run src/sidebar/toast/undo-delete-toast.test.tsx
- pnpm -F desktop typecheck
- pnpm -F @hypr/ui typecheck

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI copy and toast interaction only; restore/confirm behavior is unchanged aside from removing the explicit Delete button, with tests updated.
> 
> **Overview**
> **Undo delete toasts** no longer ask users to confirm deletion in the toast. Copy switches from in-progress wording (e.g. “Deleting …”) to past tense (“Design sync deleted”, “2 notes deleted”) with correct singular/plural for batch counts. The destructive **Delete** action and **Undo** cancel button are replaced by one primary **Undo** action; `useConfirmGroup` and per-toast destructive button styling are removed. Finalization still relies on the existing undo-timeout flow in the undo-delete store.
> 
> **Shared `Toaster`** (`@hypr/ui`) accepts an optional `style` prop, sets toast width via `--width: 300px`, and tightens visuals: `rounded-xl`, `shadow-md`, and more compact padding/gap on toasts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a1498ffa63e633cad10585c3791b1109d6e5bae7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->