### PR TITLE
fix(settings): repair Pro AI provider configuration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18970,6 +18970,7 @@ dependencies = [
  "tauri",
  "tauri-plugin",
  "tauri-specta",
+ "tempfile",
  "thiserror 2.0.18",
  "tokio",
 ]

--- a/apps/desktop/src/settings/legacy-snapshots.test.ts
+++ b/apps/desktop/src/settings/legacy-snapshots.test.ts
@@ -81,6 +81,20 @@ describe("legacy settings snapshots", () => {
     expect(statements[0].params[0]).toBe(LEGACY_SETTINGS_ID);
   });
 
+  it("does not replace the settings snapshot with an empty document", async () => {
+    mocks.load.mockResolvedValue({ status: "ok", data: {} });
+    mocks.getTinybaseValues.mockResolvedValue({
+      status: "ok",
+      data: JSON.stringify({ current_llm_provider: "anthropic" }),
+    });
+
+    await refreshLegacySettingsSnapshots();
+
+    const statements = mocks.executeTransaction.mock.calls[0][0];
+    expect(statements).toHaveLength(1);
+    expect(statements[0].params[0]).toBe(LEGACY_MAIN_VALUES_ID);
+  });
+
   it("does not write when neither legacy source is usable", async () => {
     mocks.load.mockRejectedValue(new Error("unavailable"));
     mocks.getTinybaseValues.mockResolvedValue({

--- a/apps/desktop/src/settings/legacy-snapshots.ts
+++ b/apps/desktop/src/settings/legacy-snapshots.ts
@@ -16,7 +16,7 @@ export async function refreshLegacySettingsSnapshots(): Promise<void> {
   if (
     settingsResult.status === "fulfilled" &&
     settingsResult.value.status === "ok" &&
-    isJsonObject(settingsResult.value.data)
+    isNonEmptyJsonObject(settingsResult.value.data)
   ) {
     snapshots.push({
       id: LEGACY_SETTINGS_ID,
@@ -57,6 +57,12 @@ export async function refreshLegacySettingsSnapshots(): Promise<void> {
 
 function isJsonObject(value: unknown): value is Record<string, unknown> {
   return value !== null && typeof value === "object" && !Array.isArray(value);
+}
+
+function isNonEmptyJsonObject(
+  value: unknown,
+): value is Record<string, unknown> {
+  return isJsonObject(value) && Object.keys(value).length > 0;
 }
 
 function parseJsonObject(value: string): Record<string, unknown> | null {

--- a/apps/desktop/src/settings/providers.test.ts
+++ b/apps/desktop/src/settings/providers.test.ts
@@ -44,6 +44,7 @@ vi.mock("~/db/write-queue", () => ({
 }));
 
 import {
+  getStoredAiProvider,
   isKeychainAccessError,
   loadSecureAiProviderApiKeys,
   migratePlaintextAiProviderApiKeys,
@@ -259,6 +260,29 @@ describe("SQLite AI providers", () => {
     );
     expect(mocks.setSecret).not.toHaveBeenCalled();
     expect(mocks.executeTransaction).not.toHaveBeenCalled();
+  });
+
+  it("loads one stored provider with its secure API key", async () => {
+    mocks.execute.mockResolvedValueOnce([
+      {
+        id: "ai_provider:llm:anthropic",
+        value_json: JSON.stringify({
+          type: "llm",
+          base_url: "https://api.anthropic.com/v1",
+          api_key: "",
+        }),
+      },
+    ]);
+    mocks.getSecret.mockResolvedValueOnce({
+      status: "ok",
+      data: "anthropic-key",
+    });
+
+    await expect(getStoredAiProvider("llm", "anthropic")).resolves.toEqual({
+      type: "llm",
+      base_url: "https://api.anthropic.com/v1",
+      api_key: "anthropic-key",
+    });
   });
 
   it("repairs macOS Keychain access through the secure store", async () => {

--- a/apps/desktop/src/settings/providers.ts
+++ b/apps/desktop/src/settings/providers.ts
@@ -71,6 +71,30 @@ export function useAiProvider(
   return providerId ? providers[providerRowId(type, providerId)] : undefined;
 }
 
+export async function getStoredAiProvider(
+  type: AiProviderType,
+  providerId: string,
+): Promise<AiProviderConfig | undefined> {
+  const rows = await liveQueryClient.execute<AppSettingRow>(
+    `
+      SELECT id, value_json
+      FROM app_settings
+      WHERE id IN (?, ?)
+    `,
+    [providerStorageId(type, providerId), LEGACY_SETTINGS_ID],
+  );
+  const provider = parseAiProviders(rows, type)[
+    providerRowId(type, providerId)
+  ];
+  if (!provider) return undefined;
+
+  const secureApiKey = await getProviderApiKey(type, providerId);
+  return {
+    ...provider,
+    api_key: secureApiKey ?? provider.api_key,
+  };
+}
+
 export function setAiProvider(
   type: AiProviderType,
   providerId: string,

--- a/apps/desktop/src/shared/config/configure-paid-settings.test.ts
+++ b/apps/desktop/src/shared/config/configure-paid-settings.test.ts
@@ -1,0 +1,97 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  getStoredAiProvider: vi.fn(),
+  getStoredSettingValues: vi.fn(),
+  setSettingValues: vi.fn(async () => undefined),
+}));
+
+vi.mock("~/settings/providers", () => ({
+  getStoredAiProvider: mocks.getStoredAiProvider,
+}));
+
+vi.mock("~/settings/queries", () => ({
+  getStoredSettingValues: mocks.getStoredSettingValues,
+  setSettingValues: mocks.setSettingValues,
+}));
+
+import { configurePaidSettings } from "./configure-paid-settings";
+
+describe("configurePaidSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getStoredAiProvider.mockResolvedValue(undefined);
+  });
+
+  it("selects hosted AI when no language model is configured", async () => {
+    mocks.getStoredSettingValues.mockResolvedValue({
+      values: {},
+      hasValues: new Set(),
+    });
+
+    await configurePaidSettings();
+
+    expect(mocks.setSettingValues).toHaveBeenCalledWith({
+      current_stt_provider: "hyprnote",
+      current_stt_model: "cloud",
+      current_llm_provider: "hyprnote",
+      current_llm_model: "Auto",
+    });
+  });
+
+  it("repairs a selected provider whose required API key is missing", async () => {
+    mocks.getStoredSettingValues.mockResolvedValue({
+      values: {
+        current_stt_provider: "hyprnote",
+        current_stt_model: "cloud",
+        current_llm_provider: "anthropic",
+        current_llm_model: "claude-opus-4-5-20251101",
+      },
+      hasValues: new Set(),
+    });
+
+    await configurePaidSettings();
+
+    expect(mocks.setSettingValues).toHaveBeenCalledWith({
+      current_llm_provider: "hyprnote",
+      current_llm_model: "Auto",
+    });
+  });
+
+  it("preserves a configured bring-your-own provider", async () => {
+    mocks.getStoredSettingValues.mockResolvedValue({
+      values: {
+        current_stt_provider: "hyprnote",
+        current_stt_model: "cloud",
+        current_llm_provider: "anthropic",
+        current_llm_model: "claude-opus-4-5-20251101",
+      },
+      hasValues: new Set(),
+    });
+    mocks.getStoredAiProvider.mockResolvedValue({
+      type: "llm",
+      base_url: "https://api.anthropic.com/v1",
+      api_key: "anthropic-key",
+    });
+
+    await configurePaidSettings();
+
+    expect(mocks.setSettingValues).toHaveBeenCalledWith({});
+  });
+
+  it("preserves local providers that do not require credentials", async () => {
+    mocks.getStoredSettingValues.mockResolvedValue({
+      values: {
+        current_stt_provider: "hyprnote",
+        current_stt_model: "cloud",
+        current_llm_provider: "ollama",
+        current_llm_model: "llama3.2",
+      },
+      hasValues: new Set(),
+    });
+
+    await configurePaidSettings();
+
+    expect(mocks.setSettingValues).toHaveBeenCalledWith({});
+  });
+});

--- a/apps/desktop/src/shared/config/configure-paid-settings.test.ts
+++ b/apps/desktop/src/shared/config/configure-paid-settings.test.ts
@@ -58,6 +58,28 @@ describe("configurePaidSettings", () => {
     });
   });
 
+  it("repairs hosted defaults when secure provider lookup fails", async () => {
+    mocks.getStoredSettingValues.mockResolvedValue({
+      values: {
+        current_llm_provider: "anthropic",
+        current_llm_model: "claude-opus-4-5-20251101",
+      },
+      hasValues: new Set(),
+    });
+    mocks.getStoredAiProvider.mockRejectedValue(
+      new Error("secure store unavailable"),
+    );
+
+    await configurePaidSettings();
+
+    expect(mocks.setSettingValues).toHaveBeenCalledWith({
+      current_stt_provider: "hyprnote",
+      current_stt_model: "cloud",
+      current_llm_provider: "hyprnote",
+      current_llm_model: "Auto",
+    });
+  });
+
   it("preserves a configured bring-your-own provider", async () => {
     mocks.getStoredSettingValues.mockResolvedValue({
       values: {
@@ -93,5 +115,6 @@ describe("configurePaidSettings", () => {
     await configurePaidSettings();
 
     expect(mocks.setSettingValues).toHaveBeenCalledWith({});
+    expect(mocks.getStoredAiProvider).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/shared/config/configure-paid-settings.ts
+++ b/apps/desktop/src/shared/config/configure-paid-settings.ts
@@ -1,3 +1,6 @@
+import { PROVIDERS } from "~/settings/ai/llm/shared";
+import { getProviderSelectionBlockers } from "~/settings/ai/shared/eligibility";
+import { getStoredAiProvider } from "~/settings/providers";
 import { getStoredSettingValues, setSettingValues } from "~/settings/queries";
 import type { SettingValues } from "~/settings/schema";
 
@@ -10,10 +13,30 @@ export async function configurePaidSettings(): Promise<void> {
     updates.current_stt_model = "cloud";
   }
 
-  if (!values.current_llm_provider) {
+  if (await shouldUseHostedLlm(values)) {
     updates.current_llm_provider = "hyprnote";
     updates.current_llm_model = "Auto";
   }
 
   await setSettingValues(updates);
+}
+
+async function shouldUseHostedLlm(values: SettingValues): Promise<boolean> {
+  const providerId = values.current_llm_provider;
+  if (!providerId || !values.current_llm_model) return true;
+
+  const provider = PROVIDERS.find((candidate) => candidate.id === providerId);
+  if (!provider) return true;
+
+  const config = await getStoredAiProvider("llm", providerId);
+  return (
+    getProviderSelectionBlockers(provider.requirements, {
+      isAuthenticated: true,
+      isPaid: true,
+      config: {
+        base_url: config?.base_url || provider.baseUrl || "",
+        api_key: config?.api_key || "",
+      },
+    }).length > 0
+  );
 }

--- a/apps/desktop/src/shared/config/configure-paid-settings.ts
+++ b/apps/desktop/src/shared/config/configure-paid-settings.ts
@@ -28,13 +28,33 @@ async function shouldUseHostedLlm(values: SettingValues): Promise<boolean> {
   const provider = PROVIDERS.find((candidate) => candidate.id === providerId);
   if (!provider) return true;
 
-  const config = await getStoredAiProvider("llm", providerId);
+  const defaultConfig = {
+    base_url: provider.baseUrl || "",
+    api_key: "",
+  };
+  if (
+    getProviderSelectionBlockers(provider.requirements, {
+      isAuthenticated: true,
+      isPaid: true,
+      config: defaultConfig,
+    }).length === 0
+  ) {
+    return false;
+  }
+
+  let config;
+  try {
+    config = await getStoredAiProvider("llm", providerId);
+  } catch {
+    return true;
+  }
+
   return (
     getProviderSelectionBlockers(provider.requirements, {
       isAuthenticated: true,
       isPaid: true,
       config: {
-        base_url: config?.base_url || provider.baseUrl || "",
+        base_url: config?.base_url || defaultConfig.base_url,
         api_key: config?.api_key || "",
       },
     }).length > 0

--- a/plugins/settings/Cargo.toml
+++ b/plugins/settings/Cargo.toml
@@ -12,6 +12,7 @@ tauri-plugin = { workspace = true, features = ["build"] }
 
 [dev-dependencies]
 specta-typescript = { workspace = true }
+tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros"] }
 
 [dependencies]

--- a/plugins/settings/src/ext.rs
+++ b/plugins/settings/src/ext.rs
@@ -56,7 +56,8 @@ impl<'a, R: tauri::Runtime, M: tauri::Manager<R>> Settings<'a, R, M> {
 
     pub async fn load(&self) -> crate::Result<serde_json::Value> {
         let snapshot = self.manager.state::<crate::state::StartupSnapshot>();
-        snapshot.load().await
+        let legacy_base = self.settings_base_path()?;
+        snapshot.load_with_legacy_fallback(&legacy_base).await
     }
 
     pub async fn save(&self, settings: serde_json::Value) -> crate::Result<()> {

--- a/plugins/settings/src/state.rs
+++ b/plugins/settings/src/state.rs
@@ -1,4 +1,4 @@
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tokio::sync::RwLock;
 
 pub struct StartupSnapshot {
@@ -22,17 +22,42 @@ impl StartupSnapshot {
         &self.startup_vault_base
     }
 
-    async fn read_or_default(&self) -> crate::Result<serde_json::Value> {
-        match tokio::fs::read_to_string(self.settings_path()).await {
+    async fn read_or_default_at(path: &Path) -> crate::Result<serde_json::Value> {
+        match tokio::fs::read_to_string(path).await {
             Ok(content) => Ok(serde_json::from_str(&content)?),
             Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::json!({})),
             Err(e) => Err(e.into()),
         }
     }
 
+    async fn read_or_default(&self) -> crate::Result<serde_json::Value> {
+        Self::read_or_default_at(&self.settings_path()).await
+    }
+
     pub async fn load(&self) -> crate::Result<serde_json::Value> {
         let _guard = self.io_lock.read().await;
         self.read_or_default().await
+    }
+
+    pub async fn load_with_legacy_fallback(
+        &self,
+        legacy_base: &Path,
+    ) -> crate::Result<serde_json::Value> {
+        let _guard = self.io_lock.read().await;
+        let settings = self.read_or_default().await?;
+        if is_non_empty_object(&settings) {
+            return Ok(settings);
+        }
+
+        let legacy_path = hypr_storage::vault::compute_settings_path(legacy_base);
+        if legacy_path == self.settings_path() {
+            return Ok(settings);
+        }
+
+        Ok(match Self::read_or_default_at(&legacy_path).await {
+            Ok(legacy) if is_non_empty_object(&legacy) => legacy,
+            _ => settings,
+        })
     }
 
     pub async fn save(&self, settings: serde_json::Value) -> crate::Result<()> {
@@ -52,6 +77,10 @@ impl StartupSnapshot {
     }
 }
 
+fn is_non_empty_object(value: &serde_json::Value) -> bool {
+    value.as_object().is_some_and(|object| !object.is_empty())
+}
+
 fn merge_settings(existing: serde_json::Value, incoming: serde_json::Value) -> serde_json::Value {
     match (existing, incoming) {
         (serde_json::Value::Object(mut existing_map), serde_json::Value::Object(incoming_map)) => {
@@ -68,6 +97,60 @@ fn merge_settings(existing: serde_json::Value, incoming: serde_json::Value) -> s
 mod tests {
     use super::*;
     use serde_json::json;
+    use tempfile::tempdir;
+
+    #[tokio::test]
+    async fn load_uses_global_legacy_settings_when_custom_vault_is_empty() {
+        let temp = tempdir().unwrap();
+        let vault_base = temp.path().join("vault");
+        let global_base = temp.path().join("global");
+        std::fs::create_dir_all(&vault_base).unwrap();
+        std::fs::create_dir_all(&global_base).unwrap();
+        std::fs::write(
+            hypr_storage::vault::compute_settings_path(&global_base),
+            r#"{"ai":{"current_llm_provider":"hyprnote"}}"#,
+        )
+        .unwrap();
+
+        let snapshot = StartupSnapshot::new(vault_base);
+
+        assert_eq!(
+            snapshot
+                .load_with_legacy_fallback(&global_base)
+                .await
+                .unwrap(),
+            json!({"ai": {"current_llm_provider": "hyprnote"}}),
+        );
+    }
+
+    #[tokio::test]
+    async fn load_prefers_non_empty_custom_vault_settings() {
+        let temp = tempdir().unwrap();
+        let vault_base = temp.path().join("vault");
+        let global_base = temp.path().join("global");
+        std::fs::create_dir_all(&vault_base).unwrap();
+        std::fs::create_dir_all(&global_base).unwrap();
+        std::fs::write(
+            hypr_storage::vault::compute_settings_path(&vault_base),
+            r#"{"general":{"theme":"dark"}}"#,
+        )
+        .unwrap();
+        std::fs::write(
+            hypr_storage::vault::compute_settings_path(&global_base),
+            r#"{"general":{"theme":"light"}}"#,
+        )
+        .unwrap();
+
+        let snapshot = StartupSnapshot::new(vault_base);
+
+        assert_eq!(
+            snapshot
+                .load_with_legacy_fallback(&global_base)
+                .await
+                .unwrap(),
+            json!({"general": {"theme": "dark"}}),
+        );
+    }
 
     #[test]
     fn merge_both_objects() {

--- a/plugins/settings/src/state.rs
+++ b/plugins/settings/src/state.rs
@@ -22,12 +22,18 @@ impl StartupSnapshot {
         &self.startup_vault_base
     }
 
-    async fn read_or_default_at(path: &Path) -> crate::Result<serde_json::Value> {
+    async fn read_at(path: &Path) -> crate::Result<Option<serde_json::Value>> {
         match tokio::fs::read_to_string(path).await {
-            Ok(content) => Ok(serde_json::from_str(&content)?),
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(serde_json::json!({})),
+            Ok(content) => Ok(Some(serde_json::from_str(&content)?)),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
             Err(e) => Err(e.into()),
         }
+    }
+
+    async fn read_or_default_at(path: &Path) -> crate::Result<serde_json::Value> {
+        Ok(Self::read_at(path)
+            .await?
+            .unwrap_or_else(|| serde_json::json!({})))
     }
 
     async fn read_or_default(&self) -> crate::Result<serde_json::Value> {
@@ -44,19 +50,18 @@ impl StartupSnapshot {
         legacy_base: &Path,
     ) -> crate::Result<serde_json::Value> {
         let _guard = self.io_lock.read().await;
-        let settings = self.read_or_default().await?;
-        if is_non_empty_object(&settings) {
+        if let Some(settings) = Self::read_at(&self.settings_path()).await? {
             return Ok(settings);
         }
 
         let legacy_path = hypr_storage::vault::compute_settings_path(legacy_base);
         if legacy_path == self.settings_path() {
-            return Ok(settings);
+            return Ok(serde_json::json!({}));
         }
 
         Ok(match Self::read_or_default_at(&legacy_path).await {
             Ok(legacy) if is_non_empty_object(&legacy) => legacy,
-            _ => settings,
+            _ => serde_json::json!({}),
         })
     }
 
@@ -100,7 +105,7 @@ mod tests {
     use tempfile::tempdir;
 
     #[tokio::test]
-    async fn load_uses_global_legacy_settings_when_custom_vault_is_empty() {
+    async fn load_uses_global_legacy_settings_when_custom_vault_is_missing() {
         let temp = tempdir().unwrap();
         let vault_base = temp.path().join("vault");
         let global_base = temp.path().join("global");
@@ -120,6 +125,35 @@ mod tests {
                 .await
                 .unwrap(),
             json!({"ai": {"current_llm_provider": "hyprnote"}}),
+        );
+    }
+
+    #[tokio::test]
+    async fn load_preserves_an_explicit_custom_vault_reset() {
+        let temp = tempdir().unwrap();
+        let vault_base = temp.path().join("vault");
+        let global_base = temp.path().join("global");
+        std::fs::create_dir_all(&vault_base).unwrap();
+        std::fs::create_dir_all(&global_base).unwrap();
+        std::fs::write(
+            hypr_storage::vault::compute_settings_path(&vault_base),
+            "{}",
+        )
+        .unwrap();
+        std::fs::write(
+            hypr_storage::vault::compute_settings_path(&global_base),
+            r#"{"general":{"theme":"light"}}"#,
+        )
+        .unwrap();
+
+        let snapshot = StartupSnapshot::new(vault_base);
+
+        assert_eq!(
+            snapshot
+                .load_with_legacy_fallback(&global_base)
+                .await
+                .unwrap(),
+            json!({}),
         );
     }
 


### PR DESCRIPTION
## Summary

- Recover legacy settings from the stable data directory only when the selected vault has no settings file.
- Preserve an explicit `{}` reset instead of re-importing legacy global settings.
- Keep usable BYOK and credential-free local LLM providers selected for Pro users.
- Repair to hosted Hyprnote defaults when a selected provider is missing, unusable, or cannot be read from secure storage.
- Load persisted provider configuration from SQLite and API keys from the secure store before deciding whether repair is needed.

## Validation

- `pnpm -F desktop exec vitest run src/shared/config/configure-paid-settings.test.ts`
- `pnpm -F desktop typecheck`
- `cargo test -p tauri-plugin-settings`
- `cargo check -p tauri-plugin-settings`
- `pnpm exec dprint check apps/desktop/src/shared/config/configure-paid-settings.ts apps/desktop/src/shared/config/configure-paid-settings.test.ts plugins/settings/src/state.rs`
