### PR TITLE
refactor/anlg-156-workspace-tenancy

### DIFF
--- a/apps/api/openapi.gen.json
+++ b/apps/api/openapi.gen.json
@@ -956,6 +956,39 @@
             }
           },
           {
+            "name": "num_speakers",
+            "in": "query",
+            "description": "Expected exact number of speakers, when supported by the selected provider",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "min_speakers",
+            "in": "query",
+            "description": "Minimum expected number of speakers, when supported by the selected provider",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "max_speakers",
+            "in": "query",
+            "description": "Maximum expected number of speakers, when supported by the selected provider",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
             "name": "sample_rate",
             "in": "query",
             "description": "Audio sample rate in Hz (default: 16000)",
@@ -1039,6 +1072,39 @@
             "required": false,
             "schema": {
               "type": "string"
+            }
+          },
+          {
+            "name": "num_speakers",
+            "in": "query",
+            "description": "Expected exact number of speakers, when supported by the selected provider",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "min_speakers",
+            "in": "query",
+            "description": "Minimum expected number of speakers, when supported by the selected provider",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
+            }
+          },
+          {
+            "name": "max_speakers",
+            "in": "query",
+            "description": "Maximum expected number of speakers, when supported by the selected provider",
+            "required": false,
+            "schema": {
+              "type": "integer",
+              "format": "int32",
+              "minimum": 0
             }
           },
           {
@@ -2331,19 +2397,81 @@
           "databaseId",
           "token",
           "expiresAt",
-          "workspaceId"
+          "workspaceId",
+          "accountUserId",
+          "personalWorkspaceId",
+          "workspaces"
         ],
         "properties": {
+          "accountUserId": {
+            "type": "string"
+          },
           "databaseId": {
             "type": "string"
           },
           "expiresAt": {
             "type": "string"
           },
+          "personalWorkspaceId": {
+            "type": "string"
+          },
           "token": {
             "type": "string"
           },
           "workspaceId": {
+            "type": "string"
+          },
+          "workspaces": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/CloudsyncWorkspace"
+            }
+          }
+        }
+      },
+      "CloudsyncWorkspace": {
+        "type": "object",
+        "required": [
+          "id",
+          "ownerUserId",
+          "kind",
+          "name",
+          "membershipId",
+          "role",
+          "membershipCreatedAt",
+          "membershipUpdatedAt",
+          "createdAt",
+          "updatedAt"
+        ],
+        "properties": {
+          "createdAt": {
+            "type": "string"
+          },
+          "id": {
+            "type": "string"
+          },
+          "kind": {
+            "type": "string"
+          },
+          "membershipCreatedAt": {
+            "type": "string"
+          },
+          "membershipId": {
+            "type": "string"
+          },
+          "membershipUpdatedAt": {
+            "type": "string"
+          },
+          "name": {
+            "type": "string"
+          },
+          "ownerUserId": {
+            "type": "string"
+          },
+          "role": {
+            "type": "string"
+          },
+          "updatedAt": {
             "type": "string"
           }
         }

--- a/apps/api/src/main.rs
+++ b/apps/api/src/main.rs
@@ -157,8 +157,12 @@ async fn app() -> Router {
         jina_api_key: env.jina_api_key.clone(),
     };
     let pyannote_config = hypr_api_pyannote::PyannoteConfig::new(&env.pyannote);
-    let sync_config = hypr_api_sync::SyncConfig::from_env(&env.sync)
-        .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
+    let sync_config = hypr_api_sync::SyncConfig::from_env(
+        &env.sync,
+        &env.supabase.supabase_url,
+        &env.supabase.supabase_anon_key,
+    )
+    .unwrap_or_else(|error| panic!("Failed to load environment: {error}"));
 
     use hypr_api_nango::NangoIntegrationId;
 

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -4,9 +4,11 @@ import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
 import {
   bindCloudsyncAccount,
   configureCloudsyncToken,
+  execute,
   getCloudsyncStatus,
   suspendCloudsync,
 } from "@hypr/plugin-db";
+import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
 import {
   bindCloudsyncAccountForAuth,
@@ -21,6 +23,14 @@ import {
 vi.mock("./cloudsync-progress", () => ({
   startCloudsyncInitialSyncProgress: vi.fn(),
   stopCloudsyncInitialSyncProgress: vi.fn(),
+}));
+
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: {
+    deleteSessionFolder: vi.fn(() =>
+      Promise.resolve({ status: "ok", data: null }),
+    ),
+  },
 }));
 
 vi.mock("~/env", () => ({
@@ -113,6 +123,11 @@ describe("CloudSync auth lifecycle", () => {
     vi.clearAllMocks();
     vi.mocked(bindCloudsyncAccount).mockResolvedValue(true);
     vi.mocked(configureCloudsyncToken).mockResolvedValue("configured");
+    vi.mocked(execute).mockResolvedValue([]);
+    vi.mocked(fsSyncCommands.deleteSessionFolder).mockResolvedValue({
+      status: "ok",
+      data: null,
+    });
     vi.mocked(getCloudsyncStatus).mockResolvedValue({
       cloudsync_enabled: true,
       extension_loaded: true,
@@ -208,6 +223,62 @@ describe("CloudSync auth lifecycle", () => {
         ],
       },
     );
+  });
+
+  test("deletes queued folders only after native revocation succeeds", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(projectedCredentialsResponse())),
+    );
+    vi.mocked(execute)
+      .mockResolvedValueOnce([
+        { sessionId: "session-shared", workspaceId: "workspace-shared" },
+      ])
+      .mockResolvedValueOnce([]);
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(fsSyncCommands.deleteSessionFolder).toHaveBeenCalledWith(
+      "session-shared",
+    );
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("DELETE FROM cloudsync_session_evictions"),
+      [
+        "session-shared",
+        "workspace-shared",
+        "workspace-shared",
+        "session-shared",
+      ],
+    );
+  });
+
+  test("keeps failed folder evictions queued for retry", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(projectedCredentialsResponse())),
+    );
+    vi.mocked(execute)
+      .mockResolvedValueOnce([
+        { sessionId: "session-shared", workspaceId: "workspace-shared" },
+      ])
+      .mockResolvedValueOnce([]);
+    vi.mocked(fsSyncCommands.deleteSessionFolder).mockResolvedValueOnce({
+      status: "error",
+      error: "folder busy",
+    });
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(execute).toHaveBeenNthCalledWith(
+      2,
+      expect.stringContaining("UPDATE cloudsync_session_evictions"),
+      ["folder busy", "session-shared", "workspace-shared"],
+    );
+    expect(execute).toHaveBeenCalledTimes(2);
+
+    await vi.advanceTimersByTimeAsync(30 * 1000);
+    expect(execute).toHaveBeenCalledTimes(3);
   });
 
   test("rejects partial workspace metadata instead of treating it as legacy", async () => {

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -53,6 +53,58 @@ function credentialsResponse(workspaceId = "user-id") {
   );
 }
 
+function projectedCredentialsPayload() {
+  return {
+    databaseId: "database-id",
+    token: "sqlite-token",
+    expiresAt: new Date(NOW.getTime() + 15 * 60 * 1000).toISOString(),
+    workspaceId: "user-id",
+    accountUserId: "user-id",
+    personalWorkspaceId: "user-id",
+    workspaces: [
+      {
+        id: "user-id",
+        ownerUserId: "user-id",
+        kind: "personal",
+        name: "Personal",
+        membershipId: "membership-personal",
+        role: "owner",
+        membershipCreatedAt: "2026-07-01T01:00:00Z",
+        membershipUpdatedAt: "2026-07-16T01:00:00Z",
+        createdAt: "2026-07-01T00:00:00Z",
+        updatedAt: "2026-07-16T00:00:00Z",
+      },
+      {
+        id: "workspace-shared",
+        ownerUserId: "other-user",
+        kind: "shared",
+        name: "Shared",
+        membershipId: "membership-shared",
+        role: "member",
+        membershipCreatedAt: "2026-07-02T01:00:00Z",
+        membershipUpdatedAt: "2026-07-15T01:00:00Z",
+        createdAt: "2026-07-02T00:00:00Z",
+        updatedAt: "2026-07-15T00:00:00Z",
+      },
+    ],
+  };
+}
+
+type ProjectedCredentialsPayload = ReturnType<
+  typeof projectedCredentialsPayload
+>;
+
+function projectedCredentialsResponse(
+  mutate?: (payload: ProjectedCredentialsPayload) => void,
+) {
+  const payload = projectedCredentialsPayload();
+  mutate?.(payload);
+  return new Response(JSON.stringify(payload), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
 describe("CloudSync auth lifecycle", () => {
   beforeEach(async () => {
     vi.useFakeTimers();
@@ -121,6 +173,122 @@ describe("CloudSync auth lifecycle", () => {
     await vi.advanceTimersByTimeAsync(1);
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
+  });
+
+  test("passes server workspace metadata to the native projection", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(projectedCredentialsResponse())),
+    );
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(configureCloudsyncToken).toHaveBeenCalledWith(
+      "database-id",
+      "sqlite-token",
+      "user-id",
+      {
+        accountUserId: "user-id",
+        personalWorkspaceId: "user-id",
+        workspaces: [
+          expect.objectContaining({
+            id: "user-id",
+            membershipId: "membership-personal",
+            role: "owner",
+            membershipCreatedAt: "2026-07-01T01:00:00Z",
+            membershipUpdatedAt: "2026-07-16T01:00:00Z",
+          }),
+          expect.objectContaining({
+            id: "workspace-shared",
+            membershipId: "membership-shared",
+            role: "member",
+            membershipCreatedAt: "2026-07-02T01:00:00Z",
+            membershipUpdatedAt: "2026-07-15T01:00:00Z",
+          }),
+        ],
+      },
+    );
+  });
+
+  test("rejects partial workspace metadata instead of treating it as legacy", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() =>
+        Promise.resolve(
+          new Response(
+            JSON.stringify({
+              databaseId: "database-id",
+              token: "sqlite-token",
+              expiresAt: new Date(NOW.getTime() + 15 * 60 * 1000).toISOString(),
+              workspaceId: "user-id",
+              accountUserId: "user-id",
+            }),
+            { status: 200 },
+          ),
+        ),
+      ),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+  });
+
+  test.each([
+    [
+      "an unknown role",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[1]!.role = "viewer";
+      },
+    ],
+    [
+      "an unknown workspace kind",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[1]!.kind = "team";
+      },
+    ],
+    [
+      "multiple personal workspaces",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[1]!.kind = "personal";
+      },
+    ],
+    [
+      "zero personal workspaces",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[0]!.kind = "shared";
+      },
+    ],
+    [
+      "duplicate workspace IDs",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[1]!.id = payload.workspaces[0]!.id;
+      },
+    ],
+    [
+      "duplicate membership IDs",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[1]!.membershipId =
+          payload.workspaces[0]!.membershipId;
+      },
+    ],
+    [
+      "an invalid membership timestamp",
+      (payload: ProjectedCredentialsPayload) => {
+        payload.workspaces[1]!.membershipCreatedAt = "not-a-timestamp";
+      },
+    ],
+  ])("rejects projected credentials with %s", async (_label, mutate) => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(projectedCredentialsResponse(mutate))),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
   });
 
   test("suspends sync and ignores an exchange completed after sign-out", async () => {
@@ -500,6 +668,9 @@ describe("CloudSync auth lifecycle", () => {
 
     const activation = handleCloudsyncAuthChange("TOKEN_REFRESHED", session());
     await vi.advanceTimersByTimeAsync(10 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(15 * 1000);
 
     await expect(activation).resolves.toBe("ok");
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -525,6 +696,9 @@ describe("CloudSync auth lifecycle", () => {
 
     const activation = handleCloudsyncAuthChange("TOKEN_REFRESHED", session());
     await vi.advanceTimersByTimeAsync(10 * 1000);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+    await vi.advanceTimersByTimeAsync(15 * 1000);
 
     await expect(activation).resolves.toBe("ok");
     expect(fetchMock).toHaveBeenCalledTimes(1);

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -1,5 +1,6 @@
 import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
 
+import type { CloudsyncWorkspaceProjection } from "@hypr/plugin-db";
 import {
   bindCloudsyncAccount,
   configureCloudsyncToken,
@@ -17,18 +18,31 @@ import { env } from "~/env";
 const REFRESH_LEAD_MS = 2 * 60 * 1000;
 const RETRY_DELAY_MS = 60 * 1000;
 const MIN_REFRESH_DELAY_MS = 1000;
-const EXCHANGE_TIMEOUT_MS = 10 * 1000;
+const EXCHANGE_TIMEOUT_MS = 25 * 1000;
 
 export type CloudsyncAuthChangeResult = "ok" | "account_mismatch";
 
 type CloudsyncAccountMismatchHandler = () => Promise<void>;
 
-type CloudsyncCredentials = {
+type CloudsyncCredentialCore = {
   databaseId: string;
   token: string;
   expiresAt: string;
   workspaceId: string;
 };
+
+type LegacyCloudsyncCredentials = CloudsyncCredentialCore & {
+  accountUserId?: undefined;
+  personalWorkspaceId?: undefined;
+  workspaces?: undefined;
+};
+
+type ProjectedCloudsyncCredentials = CloudsyncCredentialCore &
+  CloudsyncWorkspaceProjection;
+
+type CloudsyncCredentials =
+  | LegacyCloudsyncCredentials
+  | ProjectedCloudsyncCredentials;
 
 let generation = 0;
 let exchangeController: AbortController | null = null;
@@ -108,7 +122,7 @@ function isCredentials(value: unknown): value is CloudsyncCredentials {
   }
 
   const candidate = value as Record<string, unknown>;
-  return (
+  const hasCoreCredentials =
     typeof candidate.databaseId === "string" &&
     candidate.databaseId.length > 0 &&
     typeof candidate.token === "string" &&
@@ -116,8 +130,86 @@ function isCredentials(value: unknown): value is CloudsyncCredentials {
     typeof candidate.expiresAt === "string" &&
     Number.isFinite(Date.parse(candidate.expiresAt)) &&
     typeof candidate.workspaceId === "string" &&
-    candidate.workspaceId.length > 0
+    candidate.workspaceId.length > 0;
+  if (!hasCoreCredentials) {
+    return false;
+  }
+
+  const projectionKeys = ["accountUserId", "personalWorkspaceId", "workspaces"];
+  if (!projectionKeys.some((key) => key in candidate)) {
+    return true;
+  }
+
+  if (
+    typeof candidate.accountUserId !== "string" ||
+    candidate.accountUserId.length === 0 ||
+    typeof candidate.personalWorkspaceId !== "string" ||
+    candidate.personalWorkspaceId.length === 0 ||
+    candidate.personalWorkspaceId !== candidate.workspaceId ||
+    candidate.accountUserId !== candidate.personalWorkspaceId ||
+    !Array.isArray(candidate.workspaces) ||
+    candidate.workspaces.length === 0
+  ) {
+    return false;
+  }
+
+  const workspaceIds = new Set<string>();
+  const membershipIds = new Set<string>();
+  for (const value of candidate.workspaces) {
+    if (!value || typeof value !== "object") {
+      return false;
+    }
+
+    const workspace = value as Record<string, unknown>;
+    if (
+      typeof workspace.id !== "string" ||
+      workspace.id.length === 0 ||
+      typeof workspace.ownerUserId !== "string" ||
+      workspace.ownerUserId.length === 0 ||
+      typeof workspace.kind !== "string" ||
+      !["personal", "shared"].includes(workspace.kind) ||
+      typeof workspace.name !== "string" ||
+      typeof workspace.membershipId !== "string" ||
+      workspace.membershipId.length === 0 ||
+      typeof workspace.role !== "string" ||
+      !["owner", "admin", "member"].includes(workspace.role) ||
+      typeof workspace.membershipCreatedAt !== "string" ||
+      !Number.isFinite(Date.parse(workspace.membershipCreatedAt)) ||
+      typeof workspace.membershipUpdatedAt !== "string" ||
+      !Number.isFinite(Date.parse(workspace.membershipUpdatedAt)) ||
+      typeof workspace.createdAt !== "string" ||
+      !Number.isFinite(Date.parse(workspace.createdAt)) ||
+      typeof workspace.updatedAt !== "string" ||
+      !Number.isFinite(Date.parse(workspace.updatedAt)) ||
+      workspaceIds.has(workspace.id) ||
+      membershipIds.has(workspace.membershipId)
+    ) {
+      return false;
+    }
+
+    workspaceIds.add(workspace.id);
+    membershipIds.add(workspace.membershipId);
+  }
+
+  const personalWorkspaces = candidate.workspaces.filter(
+    (workspace) => workspace.kind === "personal",
   );
+  if (personalWorkspaces.length !== 1) {
+    return false;
+  }
+
+  const personalWorkspace = personalWorkspaces[0]!;
+  return (
+    personalWorkspace.id === candidate.personalWorkspaceId &&
+    personalWorkspace.ownerUserId === candidate.accountUserId &&
+    personalWorkspace.role === "owner"
+  );
+}
+
+function hasWorkspaceProjection(
+  credentials: CloudsyncCredentials,
+): credentials is ProjectedCloudsyncCredentials {
+  return credentials.accountUserId !== undefined;
 }
 
 function scheduleExchange(
@@ -311,7 +403,10 @@ async function activateCloudsync(
     return "ok";
   }
 
-  if (credentials.workspaceId !== session.user.id) {
+  const accountUserId = hasWorkspaceProjection(credentials)
+    ? credentials.accountUserId
+    : credentials.workspaceId;
+  if (accountUserId !== session.user.id) {
     if (!suspendBeforeExchange) {
       await suspendCloudsyncAfterCredentialRejection(activeGeneration);
     }
@@ -339,11 +434,22 @@ async function activateCloudsync(
         return "configured" as const;
       }
 
-      const configuration = await configureCloudsyncToken(
-        credentials.databaseId,
-        credentials.token,
-        credentials.workspaceId,
-      );
+      const configuration = hasWorkspaceProjection(credentials)
+        ? await configureCloudsyncToken(
+            credentials.databaseId,
+            credentials.token,
+            accountUserId,
+            {
+              accountUserId: credentials.accountUserId,
+              personalWorkspaceId: credentials.personalWorkspaceId,
+              workspaces: credentials.workspaces,
+            },
+          )
+        : await configureCloudsyncToken(
+            credentials.databaseId,
+            credentials.token,
+            accountUserId,
+          );
 
       if (activeGeneration !== generation) {
         if (configuration === "configured") {

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -4,9 +4,11 @@ import type { CloudsyncWorkspaceProjection } from "@hypr/plugin-db";
 import {
   bindCloudsyncAccount,
   configureCloudsyncToken,
+  execute,
   getCloudsyncStatus,
   suspendCloudsync,
 } from "@hypr/plugin-db";
+import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
 import {
   startCloudsyncInitialSyncProgress,
@@ -19,6 +21,7 @@ const REFRESH_LEAD_MS = 2 * 60 * 1000;
 const RETRY_DELAY_MS = 60 * 1000;
 const MIN_REFRESH_DELAY_MS = 1000;
 const EXCHANGE_TIMEOUT_MS = 25 * 1000;
+const EVICTION_RETRY_DELAY_MS = 30 * 1000;
 
 export type CloudsyncAuthChangeResult = "ok" | "account_mismatch";
 
@@ -47,6 +50,7 @@ type CloudsyncCredentials =
 let generation = 0;
 let exchangeController: AbortController | null = null;
 let refreshTimer: ReturnType<typeof setTimeout> | null = null;
+let evictionRetryTimer: ReturnType<typeof setTimeout> | null = null;
 let pluginOperation = Promise.resolve();
 
 function beginTransition() {
@@ -57,6 +61,10 @@ function beginTransition() {
   if (refreshTimer) {
     clearTimeout(refreshTimer);
     refreshTimer = null;
+  }
+  if (evictionRetryTimer) {
+    clearTimeout(evictionRetryTimer);
+    evictionRetryTimer = null;
   }
 
   return generation;
@@ -69,6 +77,116 @@ function enqueuePluginOperation<T>(operation: () => Promise<T>) {
     () => {},
   );
   return next;
+}
+
+async function flushCloudsyncSessionEvictions(): Promise<boolean> {
+  const batchSize = 128;
+
+  while (true) {
+    let rows: { sessionId: string; workspaceId: string }[];
+    try {
+      rows = await execute(
+        `
+          SELECT
+            eviction.session_id AS sessionId,
+            eviction.workspace_id AS workspaceId
+          FROM cloudsync_session_evictions AS eviction
+          WHERE NOT EXISTS (
+            SELECT 1
+            FROM workspace_memberships AS membership
+            WHERE membership.workspace_id = eviction.workspace_id
+              AND membership.deleted_at IS NULL
+          )
+          AND NOT EXISTS (
+            SELECT 1
+            FROM sessions
+            WHERE sessions.id = eviction.session_id
+          )
+          ORDER BY eviction.queued_at, eviction.session_id
+          LIMIT ?
+        `,
+        [batchSize],
+      );
+    } catch (error) {
+      console.warn("[cloudsync] session eviction queue unavailable", error);
+      return true;
+    }
+
+    if (rows.length === 0) return false;
+
+    let failed = false;
+    for (const row of rows) {
+      let deletionError = "";
+      try {
+        const result = await fsSyncCommands.deleteSessionFolder(row.sessionId);
+        if (result.status === "error") {
+          deletionError = String(result.error);
+        }
+      } catch (error) {
+        deletionError = error instanceof Error ? error.message : String(error);
+      }
+
+      try {
+        if (deletionError) {
+          failed = true;
+          await execute(
+            `
+              UPDATE cloudsync_session_evictions
+              SET attempt_count = attempt_count + 1,
+                  last_attempt_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+                  last_error = ?
+              WHERE session_id = ? AND workspace_id = ?
+            `,
+            [deletionError.slice(0, 512), row.sessionId, row.workspaceId],
+          );
+          continue;
+        }
+
+        await execute(
+          `
+            DELETE FROM cloudsync_session_evictions
+            WHERE session_id = ? AND workspace_id = ?
+              AND NOT EXISTS (
+                SELECT 1
+                FROM workspace_memberships
+                WHERE workspace_id = ? AND deleted_at IS NULL
+              )
+              AND NOT EXISTS (
+                SELECT 1 FROM sessions WHERE id = ?
+              )
+          `,
+          [row.sessionId, row.workspaceId, row.workspaceId, row.sessionId],
+        );
+      } catch (error) {
+        failed = true;
+        console.warn(
+          "[cloudsync] failed to update session eviction queue",
+          error,
+        );
+      }
+    }
+
+    if (failed) return true;
+    if (rows.length < batchSize) return false;
+  }
+}
+
+function scheduleCloudsyncSessionEvictionRetry(activeGeneration: number) {
+  if (evictionRetryTimer) {
+    clearTimeout(evictionRetryTimer);
+  }
+  evictionRetryTimer = setTimeout(() => {
+    evictionRetryTimer = null;
+    if (activeGeneration !== generation) return;
+
+    void enqueuePluginOperation(async () => {
+      if (activeGeneration !== generation) return;
+      const retry = await flushCloudsyncSessionEvictions();
+      if (retry && activeGeneration === generation) {
+        scheduleCloudsyncSessionEvictionRetry(activeGeneration);
+      }
+    });
+  }, EVICTION_RETRY_DELAY_MS);
 }
 
 export async function bindCloudsyncAccountForAuth(
@@ -450,6 +568,13 @@ async function activateCloudsync(
             credentials.token,
             accountUserId,
           );
+
+      if (configuration === "configured" && activeGeneration === generation) {
+        const retryEvictions = await flushCloudsyncSessionEvictions();
+        if (retryEvictions) {
+          scheduleCloudsyncSessionEvictionRetry(activeGeneration);
+        }
+      }
 
       if (activeGeneration !== generation) {
         if (configuration === "configured") {

--- a/crates/api-sync/Cargo.toml
+++ b/crates/api-sync/Cargo.toml
@@ -11,7 +11,7 @@ utoipa = { workspace = true }
 
 axum = { workspace = true }
 chrono = { workspace = true }
-reqwest = { workspace = true, features = ["json"] }
+reqwest = { workspace = true, features = ["json", "query"] }
 sentry = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }

--- a/crates/api-sync/src/config.rs
+++ b/crates/api-sync/src/config.rs
@@ -31,6 +31,8 @@ pub struct SyncConfig {
     pub(crate) token_issuer_api_key: String,
     pub(crate) database_id: String,
     pub(crate) token_ttl_seconds: u64,
+    pub(crate) supabase_url: String,
+    pub(crate) supabase_anon_key: String,
 }
 
 impl SyncConfig {
@@ -38,12 +40,23 @@ impl SyncConfig {
         project_url: impl Into<String>,
         token_issuer_api_key: impl Into<String>,
         database_id: impl Into<String>,
+        supabase_url: impl Into<String>,
+        supabase_anon_key: impl Into<String>,
     ) -> Result<Self, String> {
+        let supabase_anon_key = supabase_anon_key.into();
+        if supabase_anon_key.trim().is_empty() {
+            return Err(
+                "SUPABASE_ANON_KEY is required for CloudSync workspace projection".to_string(),
+            );
+        }
+
         Ok(Self {
             project_url: validate_project_url(project_url.into())?,
             token_issuer_api_key: token_issuer_api_key.into(),
             database_id: database_id.into(),
             token_ttl_seconds: DEFAULT_TOKEN_TTL_SECONDS,
+            supabase_url: validate_supabase_url(supabase_url.into())?,
+            supabase_anon_key,
         })
     }
 
@@ -53,7 +66,11 @@ impl SyncConfig {
         Ok(self)
     }
 
-    pub fn from_env(env: &SyncEnv) -> Result<Option<Self>, String> {
+    pub fn from_env(
+        env: &SyncEnv,
+        supabase_url: &str,
+        supabase_anon_key: &str,
+    ) -> Result<Option<Self>, String> {
         let project_url = nonempty(env.sqlitecloud_project_url.as_deref());
         let token_issuer_api_key = nonempty(env.sqlitecloud_token_issuer_api_key.as_deref());
         let database_id = nonempty(env.anarlog_cloudsync_database_id.as_deref());
@@ -79,8 +96,14 @@ impl SyncConfig {
         validate_token_ttl(token_ttl_seconds)?;
 
         Ok(Some(
-            Self::new(project_url, token_issuer_api_key, database_id)?
-                .with_token_ttl_seconds(token_ttl_seconds)?,
+            Self::new(
+                project_url,
+                token_issuer_api_key,
+                database_id,
+                supabase_url,
+                supabase_anon_key,
+            )?
+            .with_token_ttl_seconds(token_ttl_seconds)?,
         ))
     }
 }
@@ -103,6 +126,35 @@ fn validate_project_url(value: String) -> Result<String, String> {
         || url.fragment().is_some()
     {
         return Err("SQLITECLOUD_PROJECT_URL must contain only the project origin".to_string());
+    }
+
+    Ok(url.origin().ascii_serialization())
+}
+
+fn validate_supabase_url(value: String) -> Result<String, String> {
+    let url =
+        reqwest::Url::parse(&value).map_err(|_| "SUPABASE_URL must be a valid URL".to_string())?;
+    let host = url
+        .host_str()
+        .ok_or_else(|| "SUPABASE_URL must include a host".to_string())?;
+    let address_host = host
+        .strip_prefix('[')
+        .and_then(|host| host.strip_suffix(']'))
+        .unwrap_or(host);
+    let is_loopback = host.eq_ignore_ascii_case("localhost")
+        || address_host
+            .parse::<std::net::IpAddr>()
+            .is_ok_and(|address| address.is_loopback());
+    if (url.scheme() != "https" && !(url.scheme() == "http" && is_loopback))
+        || !url.username().is_empty()
+        || url.password().is_some()
+        || url.path() != "/"
+        || url.query().is_some()
+        || url.fragment().is_some()
+    {
+        return Err(
+            "SUPABASE_URL must use HTTPS, except for HTTP loopback development origins".to_string(),
+        );
     }
 
     Ok(url.origin().ascii_serialization())
@@ -137,12 +189,15 @@ mod tests {
         }
     }
 
+    fn config(env: &SyncEnv) -> Result<Option<SyncConfig>, String> {
+        SyncConfig::from_env(env, "https://project.supabase.co", "anon-key")
+    }
+
     #[test]
     fn accepts_https_sqlite_cloud_project_url() {
-        let config =
-            SyncConfig::from_env(&env("https://project.region.gateway.sqlite.cloud/", None))
-                .unwrap()
-                .unwrap();
+        let config = config(&env("https://project.region.gateway.sqlite.cloud/", None))
+            .unwrap()
+            .unwrap();
 
         assert_eq!(
             config.project_url,
@@ -153,25 +208,41 @@ mod tests {
 
     #[test]
     fn rejects_non_https_or_non_sqlite_cloud_project_url() {
-        assert!(SyncConfig::from_env(&env("http://project.gateway.sqlite.cloud", None)).is_err());
-        assert!(SyncConfig::from_env(&env("https://example.com", None)).is_err());
+        assert!(config(&env("http://project.gateway.sqlite.cloud", None)).is_err());
+        assert!(config(&env("https://example.com", None)).is_err());
     }
 
     #[test]
     fn bounds_token_ttl() {
         assert!(
-            SyncConfig::from_env(&env(
+            config(&env(
                 "https://project.gateway.sqlite.cloud",
                 Some(MIN_TOKEN_TTL_SECONDS - 1),
             ))
             .is_err()
         );
         assert!(
-            SyncConfig::from_env(&env(
+            config(&env(
                 "https://project.gateway.sqlite.cloud",
                 Some(MAX_TOKEN_TTL_SECONDS + 1),
             ))
             .is_err()
         );
+    }
+
+    #[test]
+    fn validates_supabase_workspace_projection_config() {
+        let sync_env = env("https://project.gateway.sqlite.cloud", None);
+
+        assert!(SyncConfig::from_env(&sync_env, "not-a-url", "anon-key").is_err());
+        assert!(SyncConfig::from_env(&sync_env, "http://project.supabase.co", "anon-key").is_err());
+        assert!(SyncConfig::from_env(&sync_env, "http://localhost:54321", "anon-key").is_ok());
+        assert!(SyncConfig::from_env(&sync_env, "http://127.0.0.1:54321", "anon-key").is_ok());
+        assert!(SyncConfig::from_env(&sync_env, "http://[::1]:54321", "anon-key").is_ok());
+        assert!(
+            SyncConfig::from_env(&sync_env, "https://project.supabase.co/path", "anon-key")
+                .is_err()
+        );
+        assert!(SyncConfig::from_env(&sync_env, "https://project.supabase.co", "   ").is_err());
     }
 }

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -1,3 +1,5 @@
+use std::collections::HashSet;
+
 use axum::{
     Extension, Json, Router,
     extract::State,
@@ -12,6 +14,9 @@ use utoipa::OpenApi;
 use crate::error::{Result, SyncError};
 use crate::state::AppState;
 
+const WORKSPACE_PROJECTION_SELECT: &str = "id,user_id,role,created_at,updated_at,workspace:workspaces!inner(id,owner_user_id,kind,name,created_at,updated_at)";
+const WORKSPACE_PROJECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
 #[derive(Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
 pub struct CloudsyncCredentials {
@@ -19,6 +24,24 @@ pub struct CloudsyncCredentials {
     token: String,
     expires_at: String,
     workspace_id: String,
+    account_user_id: String,
+    personal_workspace_id: String,
+    workspaces: Vec<CloudsyncWorkspace>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudsyncWorkspace {
+    id: String,
+    owner_user_id: String,
+    kind: String,
+    name: String,
+    membership_id: String,
+    role: String,
+    membership_created_at: String,
+    membership_updated_at: String,
+    created_at: String,
+    updated_at: String,
 }
 
 #[derive(Serialize)]
@@ -39,8 +62,31 @@ struct CreateTokenResponse {
     token: String,
 }
 
+#[derive(Deserialize)]
+struct WorkspaceMembershipRow {
+    id: String,
+    user_id: String,
+    role: String,
+    created_at: String,
+    updated_at: String,
+    workspace: WorkspaceRow,
+}
+
+#[derive(Deserialize)]
+struct WorkspaceRow {
+    id: String,
+    owner_user_id: String,
+    kind: String,
+    name: String,
+    created_at: String,
+    updated_at: String,
+}
+
 #[derive(OpenApi)]
-#[openapi(paths(create_credentials), components(schemas(CloudsyncCredentials)))]
+#[openapi(
+    paths(create_credentials),
+    components(schemas(CloudsyncCredentials, CloudsyncWorkspace))
+)]
 pub struct ApiDoc;
 
 pub fn openapi() -> utoipa::openapi::OpenApi {
@@ -74,6 +120,10 @@ async fn create_credentials(
     if !auth.claims.is_pro() {
         return Err(SyncError::ProPlanRequired);
     }
+
+    let workspace_rows = fetch_workspace_projection(&state, &auth).await?;
+    let (personal_workspace_id, workspaces) =
+        validate_workspace_projection(workspace_rows, &auth.claims.sub)?;
 
     let ttl = i64::try_from(state.config.token_ttl_seconds)
         .map_err(|_| SyncError::Internal("CloudSync token TTL is too large".to_string()))?;
@@ -116,9 +166,142 @@ async fn create_credentials(
             database_id: state.config.database_id,
             token: response.data.token,
             expires_at,
-            workspace_id: auth.claims.sub,
+            workspace_id: personal_workspace_id.clone(),
+            account_user_id: auth.claims.sub,
+            personal_workspace_id,
+            workspaces,
         }),
     ))
+}
+
+async fn fetch_workspace_projection(
+    state: &AppState,
+    auth: &AuthContext,
+) -> Result<Vec<WorkspaceMembershipRow>> {
+    let user_filter = format!("eq.{}", auth.claims.sub);
+    let response = state
+        .client
+        .get(format!(
+            "{}/rest/v1/workspace_memberships",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_anon_key)
+        .bearer_auth(&auth.token)
+        .timeout(WORKSPACE_PROJECTION_TIMEOUT)
+        .query(&[
+            ("select", WORKSPACE_PROJECTION_SELECT),
+            ("user_id", user_filter.as_str()),
+            ("deleted_at", "is.null"),
+            ("workspace.deleted_at", "is.null"),
+        ])
+        .send()
+        .await
+        .map_err(|error| {
+            tracing::warn!(%error, "Supabase workspace projection request failed");
+            SyncError::Upstream
+        })?;
+    if !response.status().is_success() {
+        tracing::warn!(
+            status = %response.status(),
+            "Supabase workspace projection request was rejected"
+        );
+        return Err(SyncError::Upstream);
+    }
+
+    response.json().await.map_err(|error| {
+        tracing::warn!(%error, "Supabase workspace projection response was invalid");
+        SyncError::Upstream
+    })
+}
+
+fn validate_workspace_projection(
+    mut rows: Vec<WorkspaceMembershipRow>,
+    account_user_id: &str,
+) -> Result<(String, Vec<CloudsyncWorkspace>)> {
+    let mut membership_ids = HashSet::with_capacity(rows.len());
+    let mut workspace_ids = HashSet::with_capacity(rows.len());
+
+    for row in &rows {
+        if row.user_id != account_user_id {
+            return invalid_workspace_projection("membership user does not match account");
+        }
+        if row.id.trim().is_empty()
+            || row.workspace.id.trim().is_empty()
+            || row.workspace.owner_user_id.trim().is_empty()
+        {
+            return invalid_workspace_projection("workspace projection contains a blank identity");
+        }
+        if !matches!(row.role.as_str(), "owner" | "admin" | "member") {
+            return invalid_workspace_projection("workspace membership has an invalid role");
+        }
+        if !matches!(row.workspace.kind.as_str(), "personal" | "shared") {
+            return invalid_workspace_projection("workspace has an invalid kind");
+        }
+        if chrono::DateTime::parse_from_rfc3339(&row.workspace.created_at).is_err()
+            || chrono::DateTime::parse_from_rfc3339(&row.workspace.updated_at).is_err()
+        {
+            return invalid_workspace_projection("workspace has an invalid timestamp");
+        }
+        if chrono::DateTime::parse_from_rfc3339(&row.created_at).is_err()
+            || chrono::DateTime::parse_from_rfc3339(&row.updated_at).is_err()
+        {
+            return invalid_workspace_projection("workspace membership has an invalid timestamp");
+        }
+        if !membership_ids.insert(&row.id) || !workspace_ids.insert(&row.workspace.id) {
+            return invalid_workspace_projection("workspace projection contains duplicate rows");
+        }
+    }
+
+    let personal_workspaces = rows
+        .iter()
+        .filter(|row| row.workspace.kind == "personal")
+        .collect::<Vec<_>>();
+    if personal_workspaces.len() != 1 {
+        return invalid_workspace_projection(
+            "account must have exactly one personal owner workspace",
+        );
+    }
+
+    let personal_workspace = personal_workspaces[0];
+    if personal_workspace.role != "owner"
+        || personal_workspace.workspace.id != account_user_id
+        || personal_workspace.workspace.owner_user_id != account_user_id
+    {
+        return invalid_workspace_projection("personal workspace identity does not match account");
+    }
+
+    let personal_workspace_id = personal_workspace.workspace.id.clone();
+    rows.sort_by(|left, right| {
+        let left_is_personal = left.workspace.id == personal_workspace_id;
+        let right_is_personal = right.workspace.id == personal_workspace_id;
+        right_is_personal
+            .cmp(&left_is_personal)
+            .then_with(|| left.workspace.created_at.cmp(&right.workspace.created_at))
+            .then_with(|| left.workspace.id.cmp(&right.workspace.id))
+    });
+
+    Ok((
+        personal_workspace_id,
+        rows.into_iter()
+            .map(|row| CloudsyncWorkspace {
+                id: row.workspace.id,
+                owner_user_id: row.workspace.owner_user_id,
+                kind: row.workspace.kind,
+                name: row.workspace.name,
+                membership_id: row.id,
+                role: row.role,
+                membership_created_at: row.created_at,
+                membership_updated_at: row.updated_at,
+                created_at: row.workspace.created_at,
+                updated_at: row.workspace.updated_at,
+            })
+            .collect(),
+    ))
+}
+
+fn invalid_workspace_projection<T>(reason: &'static str) -> Result<T> {
+    tracing::warn!(reason, "Supabase workspace projection failed validation");
+    Err(SyncError::Upstream)
 }
 
 #[cfg(test)]
@@ -129,7 +312,7 @@ mod tests {
     use tower::ServiceExt;
     use wiremock::{
         Mock, MockServer, ResponseTemplate,
-        matchers::{body_partial_json, header, method, path},
+        matchers::{body_partial_json, header, method, path, query_param},
     };
 
     use super::*;
@@ -141,6 +324,8 @@ mod tests {
             token_issuer_api_key: api_key.to_string(),
             database_id: "database-id".to_string(),
             token_ttl_seconds: 60,
+            supabase_url: server.uri(),
+            supabase_anon_key: "anon-key".to_string(),
         }))
         .layer(Extension(AuthContext {
             token: "supabase-token".to_string(),
@@ -158,6 +343,38 @@ mod tests {
         }))
     }
 
+    fn personal_workspace(id: &str) -> Value {
+        json!({
+            "id": id,
+            "user_id": "user-123",
+            "role": "owner",
+            "created_at": "2026-07-16T08:01:00Z",
+            "updated_at": "2026-07-16T08:02:00Z",
+            "workspace": {
+                "id": id,
+                "owner_user_id": id,
+                "kind": "personal",
+                "name": "Personal",
+                "created_at": "2026-07-16T08:00:00Z",
+                "updated_at": "2026-07-16T08:00:00Z"
+            }
+        })
+    }
+
+    async fn mock_workspace_projection(server: &MockServer, body: Value) {
+        Mock::given(method("GET"))
+            .and(path("/rest/v1/workspace_memberships"))
+            .and(header("apikey", "anon-key"))
+            .and(header("authorization", "Bearer supabase-token"))
+            .and(query_param("select", WORKSPACE_PROJECTION_SELECT))
+            .and(query_param("user_id", "eq.user-123"))
+            .and(query_param("deleted_at", "is.null"))
+            .and(query_param("workspace.deleted_at", "is.null"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(body))
+            .mount(server)
+            .await;
+    }
+
     async fn response_json(response: axum::response::Response) -> Value {
         let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         serde_json::from_slice(&bytes).unwrap()
@@ -166,6 +383,28 @@ mod tests {
     #[tokio::test]
     async fn mints_token_for_verified_supabase_subject() {
         let server = MockServer::start().await;
+        mock_workspace_projection(
+            &server,
+            json!([
+                {
+                    "id": "membership-team",
+                    "user_id": "user-123",
+                    "role": "member",
+                    "created_at": "2026-07-16T09:01:00Z",
+                    "updated_at": "2026-07-16T10:01:00Z",
+                    "workspace": {
+                        "id": "workspace-team",
+                        "owner_user_id": "user-456",
+                        "kind": "shared",
+                        "name": "Acme",
+                        "created_at": "2026-07-16T09:00:00Z",
+                        "updated_at": "2026-07-16T10:00:00Z"
+                    }
+                },
+                personal_workspace("user-123")
+            ]),
+        )
+        .await;
         Mock::given(method("POST"))
             .and(path("/v2/tokens"))
             .and(header("authorization", "Bearer issuer-key"))
@@ -189,7 +428,35 @@ mod tests {
         assert_eq!(body["databaseId"], "database-id");
         assert_eq!(body["token"], "sqlite-token");
         assert_eq!(body["workspaceId"], "user-123");
+        assert_eq!(body["accountUserId"], "user-123");
+        assert_eq!(body["personalWorkspaceId"], "user-123");
+        assert_eq!(body["workspaces"][0]["id"], "user-123");
+        assert_eq!(body["workspaces"][0]["membershipId"], "user-123");
+        assert_eq!(body["workspaces"][0]["role"], "owner");
+        assert_eq!(body["workspaces"][1]["id"], "workspace-team");
+        assert_eq!(body["workspaces"][1]["ownerUserId"], "user-456");
+        assert_eq!(body["workspaces"][1]["kind"], "shared");
+        assert_eq!(body["workspaces"][1]["name"], "Acme");
+        assert_eq!(
+            body["workspaces"][1]["membershipCreatedAt"],
+            "2026-07-16T09:01:00Z"
+        );
+        assert_eq!(
+            body["workspaces"][1]["membershipUpdatedAt"],
+            "2026-07-16T10:01:00Z"
+        );
+        assert_eq!(body["workspaces"][1]["createdAt"], "2026-07-16T09:00:00Z");
+        assert_eq!(body["workspaces"][1]["updatedAt"], "2026-07-16T10:00:00Z");
         assert!(body["expiresAt"].as_str().unwrap().ends_with('Z'));
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests[0].url.path(), "/rest/v1/workspace_memberships");
+        assert_eq!(requests[1].url.path(), "/v2/tokens");
+        let token_request: Value = serde_json::from_slice(&requests[1].body).unwrap();
+        assert_eq!(token_request.as_object().unwrap().len(), 3);
+        assert_eq!(token_request["userId"], "user-123");
+        assert!(token_request.get("workspaceId").is_none());
+        assert!(token_request.get("workspaceIds").is_none());
     }
 
     #[tokio::test]
@@ -211,8 +478,175 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn upstream_failure_is_redacted() {
+    async fn refuses_token_when_workspace_projection_is_invalid() {
+        let invalid_projections = [
+            json!([]),
+            json!([personal_workspace("different-user")]),
+            json!([
+                personal_workspace("user-123"),
+                {
+                    "id": "other-owner-membership",
+                    "user_id": "user-123",
+                    "role": "owner",
+                    "created_at": "2026-07-16T09:00:00Z",
+                    "updated_at": "2026-07-16T09:00:00Z",
+                    "workspace": {
+                        "id": "other-personal",
+                        "owner_user_id": "other-personal",
+                        "kind": "personal",
+                        "name": "Other",
+                        "created_at": "2026-07-16T09:00:00Z",
+                        "updated_at": "2026-07-16T09:00:00Z"
+                    }
+                }
+            ]),
+            json!([{
+                "id": "user-123",
+                "user_id": "user-123",
+                "role": "admin",
+                "created_at": "2026-07-16T08:00:00Z",
+                "updated_at": "2026-07-16T08:00:00Z",
+                "workspace": {
+                    "id": "user-123",
+                    "owner_user_id": "user-123",
+                    "kind": "personal",
+                    "name": "Personal",
+                    "created_at": "2026-07-16T08:00:00Z",
+                    "updated_at": "2026-07-16T08:00:00Z"
+                }
+            }]),
+            json!([
+                personal_workspace("user-123"),
+                {
+                    "id": "",
+                    "user_id": "user-123",
+                    "role": "member",
+                    "created_at": "2026-07-16T09:00:00Z",
+                    "updated_at": "2026-07-16T09:00:00Z",
+                    "workspace": {
+                        "id": "workspace-team",
+                        "owner_user_id": "user-456",
+                        "kind": "shared",
+                        "name": "Acme",
+                        "created_at": "2026-07-16T09:00:00Z",
+                        "updated_at": "2026-07-16T09:00:00Z"
+                    }
+                }
+            ]),
+            json!([
+                personal_workspace("user-123"),
+                {
+                    "id": "membership-team",
+                    "user_id": "user-123",
+                    "role": "editor",
+                    "created_at": "2026-07-16T09:00:00Z",
+                    "updated_at": "2026-07-16T09:00:00Z",
+                    "workspace": {
+                        "id": "workspace-team",
+                        "owner_user_id": "user-456",
+                        "kind": "shared",
+                        "name": "Acme",
+                        "created_at": "2026-07-16T09:00:00Z",
+                        "updated_at": "2026-07-16T09:00:00Z"
+                    }
+                }
+            ]),
+            json!([
+                personal_workspace("user-123"),
+                {
+                    "id": "membership-team",
+                    "user_id": "user-123",
+                    "role": "member",
+                    "created_at": "2026-07-16T09:00:00Z",
+                    "updated_at": "2026-07-16T09:00:00Z",
+                    "workspace": {
+                        "id": "workspace-team",
+                        "owner_user_id": "user-456",
+                        "kind": "team",
+                        "name": "Acme",
+                        "created_at": "2026-07-16T09:00:00Z",
+                        "updated_at": "2026-07-16T09:00:00Z"
+                    }
+                }
+            ]),
+            json!([
+                personal_workspace("user-123"),
+                {
+                    "id": "membership-team",
+                    "user_id": "user-123",
+                    "role": "member",
+                    "created_at": "2026-07-16T09:00:00Z",
+                    "updated_at": "2026-07-16T09:00:00Z",
+                    "workspace": {
+                        "id": "workspace-team",
+                        "owner_user_id": "user-456",
+                        "kind": "shared",
+                        "name": "Acme",
+                        "created_at": "not-a-timestamp",
+                        "updated_at": "2026-07-16T09:00:00Z"
+                    }
+                }
+            ]),
+            json!([
+                personal_workspace("user-123"),
+                {
+                    "id": "membership-team",
+                    "user_id": "user-123",
+                    "role": "member",
+                    "created_at": "not-a-timestamp",
+                    "updated_at": "2026-07-16T09:00:00Z",
+                    "workspace": {
+                        "id": "workspace-team",
+                        "owner_user_id": "user-456",
+                        "kind": "shared",
+                        "name": "Acme",
+                        "created_at": "2026-07-16T09:00:00Z",
+                        "updated_at": "2026-07-16T09:00:00Z"
+                    }
+                }
+            ]),
+        ];
+
+        for projection in invalid_projections {
+            let server = MockServer::start().await;
+            mock_workspace_projection(&server, projection).await;
+
+            let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+                .oneshot(Request::post("/token").body(Body::empty()).unwrap())
+                .await
+                .unwrap();
+
+            assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+            let requests = server.received_requests().await.unwrap();
+            assert_eq!(requests.len(), 1);
+            assert_eq!(requests[0].url.path(), "/rest/v1/workspace_memberships");
+        }
+    }
+
+    #[tokio::test]
+    async fn workspace_projection_failure_is_redacted() {
         let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path("/rest/v1/workspace_memberships"))
+            .respond_with(ResponseTemplate::new(403).set_body_string("secret supabase detail"))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, "issuer-key", &["hyprnote_pro"])
+            .oneshot(Request::post("/token").body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let body = response_json(response).await.to_string();
+        assert!(!body.contains("anon-key"));
+        assert!(!body.contains("supabase-token"));
+        assert!(!body.contains("supabase detail"));
+    }
+
+    #[tokio::test]
+    async fn sqlite_cloud_failure_is_redacted() {
+        let server = MockServer::start().await;
+        mock_workspace_projection(&server, json!([personal_workspace("user-123")])).await;
         Mock::given(method("POST"))
             .and(path("/v2/tokens"))
             .respond_with(ResponseTemplate::new(403).set_body_string("secret upstream detail"))

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -16,6 +16,8 @@ use crate::state::AppState;
 
 const WORKSPACE_PROJECTION_SELECT: &str = "id,user_id,role,created_at,updated_at,workspace:workspaces!inner(id,owner_user_id,kind,name,created_at,updated_at)";
 const WORKSPACE_PROJECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+const MAX_TOKEN_WORKSPACES: usize = 128;
+const MAX_TOKEN_ATTRIBUTES_BYTES: usize = 8 * 1024;
 
 #[derive(Serialize, utoipa::ToSchema)]
 #[serde(rename_all = "camelCase")]
@@ -50,6 +52,7 @@ struct CreateTokenRequest<'a> {
     name: &'static str,
     user_id: &'a str,
     expires_at: &'a str,
+    attributes: &'a str,
 }
 
 #[derive(Deserialize)]
@@ -124,6 +127,7 @@ async fn create_credentials(
     let workspace_rows = fetch_workspace_projection(&state, &auth).await?;
     let (personal_workspace_id, workspaces) =
         validate_workspace_projection(workspace_rows, &auth.claims.sub)?;
+    let token_attributes = encode_workspace_token_attributes(&workspaces)?;
 
     let ttl = i64::try_from(state.config.token_ttl_seconds)
         .map_err(|_| SyncError::Internal("CloudSync token TTL is too large".to_string()))?;
@@ -141,6 +145,7 @@ async fn create_credentials(
             name: "anarlog-cloudsync",
             user_id: &auth.claims.sub,
             expires_at: &expires_at,
+            attributes: &token_attributes,
         })
         .send()
         .await
@@ -304,6 +309,35 @@ fn invalid_workspace_projection<T>(reason: &'static str) -> Result<T> {
     Err(SyncError::Upstream)
 }
 
+fn encode_workspace_token_attributes(workspaces: &[CloudsyncWorkspace]) -> Result<String> {
+    if workspaces.len() > MAX_TOKEN_WORKSPACES {
+        tracing::warn!(
+            workspace_count = workspaces.len(),
+            "CloudSync workspace projection exceeds token limit"
+        );
+        return Err(SyncError::Upstream);
+    }
+
+    let attributes = serde_json::to_string(&serde_json::json!({
+        "workspace_ids": workspaces
+            .iter()
+            .map(|workspace| workspace.id.as_str())
+            .collect::<Vec<_>>(),
+    }))
+    .map_err(|error| {
+        SyncError::Internal(format!("CloudSync token attributes are invalid: {error}"))
+    })?;
+    if attributes.len() > MAX_TOKEN_ATTRIBUTES_BYTES {
+        tracing::warn!(
+            attribute_bytes = attributes.len(),
+            "CloudSync workspace projection exceeds token size limit"
+        );
+        return Err(SyncError::Upstream);
+    }
+
+    Ok(attributes)
+}
+
 #[cfg(test)]
 mod tests {
     use axum::{Extension, body::Body, body::to_bytes, http::Request, http::StatusCode};
@@ -453,10 +487,46 @@ mod tests {
         assert_eq!(requests[0].url.path(), "/rest/v1/workspace_memberships");
         assert_eq!(requests[1].url.path(), "/v2/tokens");
         let token_request: Value = serde_json::from_slice(&requests[1].body).unwrap();
-        assert_eq!(token_request.as_object().unwrap().len(), 3);
+        assert_eq!(token_request.as_object().unwrap().len(), 4);
         assert_eq!(token_request["userId"], "user-123");
+        let attributes: Value =
+            serde_json::from_str(token_request["attributes"].as_str().unwrap()).unwrap();
+        assert_eq!(
+            attributes,
+            json!({ "workspace_ids": ["user-123", "workspace-team"] })
+        );
         assert!(token_request.get("workspaceId").is_none());
         assert!(token_request.get("workspaceIds").is_none());
+    }
+
+    #[test]
+    fn bounds_workspace_token_attributes() {
+        let workspace = |id: String| CloudsyncWorkspace {
+            id,
+            owner_user_id: "user-123".to_string(),
+            kind: "shared".to_string(),
+            name: "Shared".to_string(),
+            membership_id: "membership".to_string(),
+            role: "member".to_string(),
+            membership_created_at: "2026-07-16T08:00:00Z".to_string(),
+            membership_updated_at: "2026-07-16T08:00:00Z".to_string(),
+            created_at: "2026-07-16T08:00:00Z".to_string(),
+            updated_at: "2026-07-16T08:00:00Z".to_string(),
+        };
+
+        let too_many = (0..=MAX_TOKEN_WORKSPACES)
+            .map(|index| workspace(format!("workspace-{index}")))
+            .collect::<Vec<_>>();
+        assert!(matches!(
+            encode_workspace_token_attributes(&too_many),
+            Err(SyncError::Upstream)
+        ));
+
+        let oversized = [workspace("x".repeat(MAX_TOKEN_ATTRIBUTES_BYTES))];
+        assert!(matches!(
+            encode_workspace_token_attributes(&oversized),
+            Err(SyncError::Upstream)
+        ));
     }
 
     #[tokio::test]

--- a/crates/api-sync/src/state.rs
+++ b/crates/api-sync/src/state.rs
@@ -1,6 +1,6 @@
 use crate::config::SyncConfig;
 
-const SQLITE_CLOUD_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const UPSTREAM_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
 
 #[derive(Clone)]
 pub struct AppState {
@@ -13,9 +13,9 @@ impl AppState {
         Self {
             config,
             client: reqwest::Client::builder()
-                .timeout(SQLITE_CLOUD_REQUEST_TIMEOUT)
+                .timeout(UPSTREAM_REQUEST_TIMEOUT)
                 .build()
-                .expect("SQLite Cloud HTTP client must build"),
+                .expect("CloudSync HTTP client must build"),
         }
     }
 }

--- a/crates/cloudsync/src/api.rs
+++ b/crates/cloudsync/src/api.rs
@@ -147,6 +147,23 @@ where
         .await?)
 }
 
+/// https://docs.sqlitecloud.io/docs/sqlite-sync-api-cloudsync-set-filter
+pub async fn set_filter<'e, E>(
+    executor: E,
+    table_name: &str,
+    filter_expression: &str,
+) -> Result<(), Error>
+where
+    E: Executor<'e, Database = Sqlite>,
+{
+    sqlx::query("SELECT cloudsync_set_filter(?, ?)")
+        .bind(table_name)
+        .bind(filter_expression)
+        .fetch_optional(executor)
+        .await?;
+    Ok(())
+}
+
 /// https://docs.sqlitecloud.io/docs/sqlite-sync-api-cloudsync-commit-alter
 pub async fn commit_alter<'e, E>(executor: E, table_name: &str) -> Result<(), Error>
 where

--- a/crates/cloudsync/src/lib.rs
+++ b/crates/cloudsync/src/lib.rs
@@ -12,7 +12,7 @@ use sqlx::sqlite::SqliteConnectOptions;
 
 pub use api::{
     CloudsyncConnectionInitializer, CloudsyncTableSpec, begin_alter, cleanup, commit_alter,
-    db_version, disable, enable, init, is_enabled, siteid, terminate, uuid, version,
+    db_version, disable, enable, init, is_enabled, set_filter, siteid, terminate, uuid, version,
 };
 pub use bundle::bundled_extension_path;
 pub use close::install_transaction_observer;
@@ -110,6 +110,80 @@ mod tests {
         assert!(chunks >= 3);
         assert!(total_bytes > 0);
         assert!(max_chunk_bytes <= 5 * 1024 * 1024);
+        pool.close().await;
+    }
+
+    #[tokio::test]
+    async fn write_filter_can_use_a_local_workspace_scope_table() {
+        let options = SqliteConnectOptions::from_str("sqlite::memory:").unwrap();
+        let (options, _) = apply(options).unwrap();
+        let pool = SqlitePoolOptions::new()
+            .max_connections(1)
+            .connect_with(options)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE writable_workspaces (
+               allowed_workspace_id TEXT PRIMARY KEY NOT NULL
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        sqlx::query("INSERT INTO writable_workspaces (allowed_workspace_id) VALUES ('personal')")
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query(
+            "CREATE TABLE items (
+               id TEXT PRIMARY KEY NOT NULL,
+               workspace_id TEXT NOT NULL DEFAULT '',
+               title TEXT NOT NULL DEFAULT ''
+             )",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        init(&pool, "items", None, None).await.unwrap();
+        set_filter(
+            &pool,
+            "items",
+            "workspace_id IN (SELECT allowed_workspace_id FROM writable_workspaces)",
+        )
+        .await
+        .unwrap();
+        let baseline_metadata_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM items_cloudsync")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+
+        sqlx::query(
+            "INSERT INTO items (id, workspace_id, title)
+             VALUES ('shared', 'shared', 'Shared')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let shared_metadata_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM items_cloudsync")
+            .fetch_one(&pool)
+            .await
+            .unwrap();
+        assert_eq!(shared_metadata_count, baseline_metadata_count);
+
+        sqlx::query(
+            "INSERT INTO items (id, workspace_id, title)
+             VALUES ('personal', 'personal', 'Personal')",
+        )
+        .execute(&pool)
+        .await
+        .unwrap();
+        let personal_metadata_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM items_cloudsync")
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert!(personal_metadata_count > baseline_metadata_count);
         pool.close().await;
     }
 

--- a/crates/db-app/migrations/20260716120000_personal_workspaces.sql
+++ b/crates/db-app/migrations/20260716120000_personal_workspaces.sql
@@ -1,0 +1,26 @@
+CREATE TABLE IF NOT EXISTS workspaces (
+  id             TEXT PRIMARY KEY NOT NULL,
+  owner_user_id  TEXT NOT NULL DEFAULT '',
+  kind           TEXT NOT NULL DEFAULT 'personal',
+  name           TEXT NOT NULL DEFAULT '',
+  created_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  deleted_at     TEXT
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS workspace_memberships (
+  id            TEXT PRIMARY KEY NOT NULL,
+  workspace_id  TEXT NOT NULL DEFAULT '',
+  user_id       TEXT NOT NULL DEFAULT '',
+  role          TEXT NOT NULL DEFAULT 'member',
+  created_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at    TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  deleted_at    TEXT,
+  UNIQUE (workspace_id, user_id)
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_workspaces_owner_user_id
+ON workspaces(owner_user_id);
+
+CREATE INDEX IF NOT EXISTS idx_workspace_memberships_user_id
+ON workspace_memberships(user_id);

--- a/crates/db-app/migrations/20260716130000_cloudsync_session_evictions.sql
+++ b/crates/db-app/migrations/20260716130000_cloudsync_session_evictions.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS cloudsync_session_evictions (
+  session_id      TEXT PRIMARY KEY NOT NULL,
+  workspace_id    TEXT NOT NULL,
+  queued_at       TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  attempt_count   INTEGER NOT NULL DEFAULT 0,
+  last_attempt_at TEXT,
+  last_error      TEXT NOT NULL DEFAULT ''
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_cloudsync_session_evictions_workspace_id
+ON cloudsync_session_evictions(workspace_id);
+
+CREATE TABLE IF NOT EXISTS cloudsync_writable_workspaces (
+  allowed_workspace_id TEXT PRIMARY KEY NOT NULL
+) STRICT;

--- a/crates/db-app/src/cloudsync.rs
+++ b/crates/db-app/src/cloudsync.rs
@@ -32,6 +32,7 @@ pub enum CloudsyncWorkspaceError {
     Sqlx(sqlx::Error),
     InvalidWorkspaceId,
     InvalidBinding,
+    InvalidWorkspaceProjection,
     AccountMismatch,
     ForeignWorkspace { table: String },
 }
@@ -42,6 +43,9 @@ impl std::fmt::Display for CloudsyncWorkspaceError {
             Self::Sqlx(error) => write!(f, "{error}"),
             Self::InvalidWorkspaceId => write!(f, "workspace ID is invalid"),
             Self::InvalidBinding => write!(f, "local CloudSync workspace binding is invalid"),
+            Self::InvalidWorkspaceProjection => {
+                write!(f, "CloudSync workspace projection is invalid")
+            }
             Self::AccountMismatch => write!(
                 f,
                 "this local database is already bound to a different account"
@@ -66,6 +70,27 @@ impl From<sqlx::Error> for CloudsyncWorkspaceError {
 struct CloudsyncWorkspaceBinding {
     workspace_id: String,
     account_user_id: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudsyncWorkspaceProjection {
+    pub account_user_id: String,
+    pub personal_workspace_id: String,
+    pub workspaces: Vec<CloudsyncWorkspaceProjectionEntry>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudsyncWorkspaceProjectionEntry {
+    pub id: String,
+    pub owner_user_id: String,
+    pub kind: String,
+    pub name: String,
+    pub membership_id: String,
+    pub role: String,
+    pub membership_created_at: String,
+    pub membership_updated_at: String,
+    pub created_at: String,
+    pub updated_at: String,
 }
 
 static CLOUDSYNC_TABLE_REGISTRY: LazyLock<Vec<CloudsyncTableSpec>> = LazyLock::new(|| {
@@ -257,6 +282,98 @@ pub async fn claim_cloudsync_workspace(
     Ok(())
 }
 
+pub async fn replace_cloudsync_workspace_projection(
+    pool: &SqlitePool,
+    projection: &CloudsyncWorkspaceProjection,
+) -> Result<(), CloudsyncWorkspaceError> {
+    validate_cloudsync_workspace_projection(projection)?;
+
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    sqlx::query("DELETE FROM workspace_memberships")
+        .execute(&mut *transaction)
+        .await?;
+    sqlx::query("DELETE FROM workspaces")
+        .execute(&mut *transaction)
+        .await?;
+
+    for workspace in &projection.workspaces {
+        sqlx::query(
+            "INSERT INTO workspaces (
+               id, owner_user_id, kind, name, created_at, updated_at, deleted_at
+             ) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(&workspace.id)
+        .bind(&workspace.owner_user_id)
+        .bind(&workspace.kind)
+        .bind(&workspace.name)
+        .bind(&workspace.created_at)
+        .bind(&workspace.updated_at)
+        .execute(&mut *transaction)
+        .await?;
+        sqlx::query(
+            "INSERT INTO workspace_memberships (
+               id, workspace_id, user_id, role, created_at, updated_at, deleted_at
+             ) VALUES (?, ?, ?, ?, ?, ?, NULL)",
+        )
+        .bind(&workspace.membership_id)
+        .bind(&workspace.id)
+        .bind(&projection.account_user_id)
+        .bind(&workspace.role)
+        .bind(&workspace.membership_created_at)
+        .bind(&workspace.membership_updated_at)
+        .execute(&mut *transaction)
+        .await?;
+    }
+
+    transaction.commit().await?;
+    Ok(())
+}
+
+pub fn validate_cloudsync_workspace_projection(
+    projection: &CloudsyncWorkspaceProjection,
+) -> Result<(), CloudsyncWorkspaceError> {
+    let account_user_id = validated_account_user_id(&projection.account_user_id)?;
+    if projection.personal_workspace_id != account_user_id || projection.workspaces.is_empty() {
+        return Err(CloudsyncWorkspaceError::InvalidWorkspaceProjection);
+    }
+
+    let mut workspace_ids = std::collections::HashSet::new();
+    let mut membership_ids = std::collections::HashSet::new();
+    for workspace in &projection.workspaces {
+        if workspace.id.trim().is_empty()
+            || workspace.owner_user_id.trim().is_empty()
+            || !matches!(workspace.kind.as_str(), "personal" | "shared")
+            || workspace.membership_id.trim().is_empty()
+            || !matches!(workspace.role.as_str(), "owner" | "admin" | "member")
+            || workspace.membership_created_at.trim().is_empty()
+            || workspace.membership_updated_at.trim().is_empty()
+            || workspace.created_at.trim().is_empty()
+            || workspace.updated_at.trim().is_empty()
+            || !workspace_ids.insert(workspace.id.as_str())
+            || !membership_ids.insert(workspace.membership_id.as_str())
+        {
+            return Err(CloudsyncWorkspaceError::InvalidWorkspaceProjection);
+        }
+    }
+
+    let mut personal_workspaces = projection
+        .workspaces
+        .iter()
+        .filter(|workspace| workspace.kind == "personal");
+    let Some(personal_workspace) = personal_workspaces.next() else {
+        return Err(CloudsyncWorkspaceError::InvalidWorkspaceProjection);
+    };
+    if personal_workspaces.next().is_some()
+        || personal_workspace.id != projection.personal_workspace_id
+        || personal_workspace.owner_user_id != account_user_id
+        || personal_workspace.role != "owner"
+    {
+        return Err(CloudsyncWorkspaceError::InvalidWorkspaceProjection);
+    }
+
+    Ok(())
+}
+
 fn validated_account_user_id(account_user_id: &str) -> Result<&str, CloudsyncWorkspaceError> {
     let account_user_id = account_user_id.trim();
     if account_user_id.is_empty() || account_user_id == LEGACY_DEFAULT_USER_ID {
@@ -414,6 +531,215 @@ mod tests {
         let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
         crate::prepare_schema(&db).await.unwrap();
         db
+    }
+
+    fn projection(
+        account_user_id: &str,
+        workspaces: Vec<CloudsyncWorkspaceProjectionEntry>,
+    ) -> CloudsyncWorkspaceProjection {
+        CloudsyncWorkspaceProjection {
+            account_user_id: account_user_id.to_string(),
+            personal_workspace_id: account_user_id.to_string(),
+            workspaces,
+        }
+    }
+
+    fn projected_workspace(
+        id: &str,
+        owner_user_id: &str,
+        kind: &str,
+        membership_id: &str,
+        role: &str,
+        name: &str,
+    ) -> CloudsyncWorkspaceProjectionEntry {
+        CloudsyncWorkspaceProjectionEntry {
+            id: id.to_string(),
+            owner_user_id: owner_user_id.to_string(),
+            kind: kind.to_string(),
+            name: name.to_string(),
+            membership_id: membership_id.to_string(),
+            role: role.to_string(),
+            membership_created_at: "2026-07-16T00:01:00Z".to_string(),
+            membership_updated_at: "2026-07-16T00:02:00Z".to_string(),
+            created_at: "2026-07-16T00:00:00Z".to_string(),
+            updated_at: "2026-07-16T00:00:00Z".to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn workspace_projection_replaces_stale_server_rows() {
+        let db = test_db().await;
+        replace_cloudsync_workspace_projection(
+            db.pool(),
+            &projection(
+                "user-a",
+                vec![
+                    projected_workspace(
+                        "user-a",
+                        "user-a",
+                        "personal",
+                        "membership-personal",
+                        "owner",
+                        "Personal",
+                    ),
+                    projected_workspace(
+                        "workspace-shared",
+                        "user-b",
+                        "shared",
+                        "membership-shared",
+                        "member",
+                        "Shared",
+                    ),
+                ],
+            ),
+        )
+        .await
+        .unwrap();
+
+        replace_cloudsync_workspace_projection(
+            db.pool(),
+            &projection(
+                "user-a",
+                vec![projected_workspace(
+                    "user-a",
+                    "user-a",
+                    "personal",
+                    "membership-personal",
+                    "owner",
+                    "My notes",
+                )],
+            ),
+        )
+        .await
+        .unwrap();
+
+        let workspaces: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, name FROM workspaces ORDER BY id")
+                .fetch_all(db.pool())
+                .await
+                .unwrap();
+        let memberships: Vec<(String, String, String, String, String, String)> = sqlx::query_as(
+            "SELECT id, workspace_id, user_id, role, created_at, updated_at
+                 FROM workspace_memberships ORDER BY id",
+        )
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(
+            workspaces,
+            vec![("user-a".to_string(), "My notes".to_string())]
+        );
+        assert_eq!(
+            memberships,
+            vec![(
+                "membership-personal".to_string(),
+                "user-a".to_string(),
+                "user-a".to_string(),
+                "owner".to_string(),
+                "2026-07-16T00:01:00Z".to_string(),
+                "2026-07-16T00:02:00Z".to_string(),
+            )]
+        );
+    }
+
+    #[tokio::test]
+    async fn invalid_workspace_projections_preserve_existing_rows() {
+        let db = test_db().await;
+        let valid = projection(
+            "user-a",
+            vec![projected_workspace(
+                "user-a",
+                "user-a",
+                "personal",
+                "membership-personal",
+                "owner",
+                "Personal",
+            )],
+        );
+        replace_cloudsync_workspace_projection(db.pool(), &valid)
+            .await
+            .unwrap();
+
+        let mut missing_personal = valid.clone();
+        missing_personal.personal_workspace_id = "workspace-missing".to_string();
+        let mut invalid_role = valid.clone();
+        invalid_role.workspaces[0].role = "viewer".to_string();
+        let mut invalid_membership_timestamp = valid.clone();
+        invalid_membership_timestamp.workspaces[0].membership_created_at = String::new();
+        let mut invalid_kind = valid.clone();
+        invalid_kind.workspaces.push(projected_workspace(
+            "workspace-shared",
+            "user-b",
+            "team",
+            "membership-shared",
+            "member",
+            "Shared",
+        ));
+        let mut duplicate_personal = valid.clone();
+        duplicate_personal.workspaces.push(projected_workspace(
+            "workspace-personal-2",
+            "user-b",
+            "personal",
+            "membership-personal-2",
+            "owner",
+            "Other personal",
+        ));
+        let mut duplicate_workspace = valid.clone();
+        duplicate_workspace.workspaces.push(projected_workspace(
+            "user-a",
+            "user-b",
+            "shared",
+            "membership-shared",
+            "member",
+            "Shared",
+        ));
+        let mut duplicate_membership = valid.clone();
+        duplicate_membership.workspaces.push(projected_workspace(
+            "workspace-shared",
+            "user-b",
+            "shared",
+            "membership-personal",
+            "member",
+            "Shared",
+        ));
+
+        for invalid in [
+            missing_personal,
+            invalid_role,
+            invalid_membership_timestamp,
+            invalid_kind,
+            duplicate_personal,
+            duplicate_workspace,
+            duplicate_membership,
+        ] {
+            let error = replace_cloudsync_workspace_projection(db.pool(), &invalid)
+                .await
+                .unwrap_err();
+            assert!(matches!(
+                error,
+                CloudsyncWorkspaceError::InvalidWorkspaceProjection
+            ));
+        }
+
+        let workspaces: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, name FROM workspaces ORDER BY id")
+                .fetch_all(db.pool())
+                .await
+                .unwrap();
+        let memberships: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, workspace_id FROM workspace_memberships ORDER BY id")
+                .fetch_all(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(
+            workspaces,
+            vec![("user-a".to_string(), "Personal".to_string())]
+        );
+        assert_eq!(
+            memberships,
+            vec![("membership-personal".to_string(), "user-a".to_string(),)]
+        );
     }
 
     #[tokio::test]

--- a/crates/db-app/src/cloudsync.rs
+++ b/crates/db-app/src/cloudsync.rs
@@ -5,6 +5,9 @@ use serde::{Deserialize, Serialize};
 use sqlx::{Sqlite, SqlitePool, Transaction};
 
 pub const CLOUDSYNC_WORKSPACE_BINDING_ID: &str = "cloudsync_workspace_binding";
+const CLOUDSYNC_FULL_RESYNC_PENDING_ID: &str = "cloudsync_full_resync_pending";
+const CLOUDSYNC_WRITE_FILTER_VERSION_ID: &str = "cloudsync_write_filter_version";
+const CLOUDSYNC_WRITE_FILTER_VERSION: &str = "writable-workspaces-v1";
 const LEGACY_DEFAULT_USER_ID: &str = "00000000-0000-0000-0000-000000000000";
 
 const USER_ID_REFERENCES: &[(&str, &str)] = &[
@@ -91,6 +94,22 @@ pub struct CloudsyncWorkspaceProjectionEntry {
     pub membership_updated_at: String,
     pub created_at: String,
     pub updated_at: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CloudsyncWorkspaceReconciliationPlan {
+    pub granted_workspace_ids: Vec<String>,
+    pub revoked_workspace_ids: Vec<String>,
+}
+
+impl CloudsyncWorkspaceReconciliationPlan {
+    pub fn requires_replica_reset(&self) -> bool {
+        !self.revoked_workspace_ids.is_empty()
+    }
+
+    pub fn requires_full_resync(&self) -> bool {
+        !self.granted_workspace_ids.is_empty() || !self.revoked_workspace_ids.is_empty()
+    }
 }
 
 static CLOUDSYNC_TABLE_REGISTRY: LazyLock<Vec<CloudsyncTableSpec>> = LazyLock::new(|| {
@@ -286,9 +305,192 @@ pub async fn replace_cloudsync_workspace_projection(
     pool: &SqlitePool,
     projection: &CloudsyncWorkspaceProjection,
 ) -> Result<(), CloudsyncWorkspaceError> {
+    write_cloudsync_workspace_projection(pool, projection, false, false)
+        .await
+        .map(|_| ())
+}
+
+pub async fn stage_cloudsync_workspace_reconciliation(
+    pool: &SqlitePool,
+    projection: &CloudsyncWorkspaceProjection,
+) -> Result<CloudsyncWorkspaceReconciliationPlan, CloudsyncWorkspaceError> {
     validate_cloudsync_workspace_projection(projection)?;
 
     let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    require_claimed_binding(&mut transaction, &projection.account_user_id).await?;
+
+    let existing_workspace_ids: Vec<String> = sqlx::query_scalar(
+        "SELECT workspace_id
+         FROM workspace_memberships
+         WHERE user_id = ? AND deleted_at IS NULL",
+    )
+    .bind(&projection.account_user_id)
+    .fetch_all(&mut *transaction)
+    .await?;
+    let existing_workspace_ids = existing_workspace_ids
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+    let projected_workspace_ids = projection
+        .workspaces
+        .iter()
+        .map(|workspace| workspace.id.clone())
+        .collect::<std::collections::HashSet<_>>();
+
+    let mut granted_workspace_ids = projected_workspace_ids
+        .difference(&existing_workspace_ids)
+        .cloned()
+        .collect::<Vec<_>>();
+    let mut revoked_workspace_ids = existing_workspace_ids
+        .difference(&projected_workspace_ids)
+        .cloned()
+        .collect::<Vec<_>>();
+    granted_workspace_ids.sort();
+    revoked_workspace_ids.sort();
+
+    for workspace_id in &revoked_workspace_ids {
+        sqlx::query(
+            "INSERT INTO cloudsync_session_evictions (session_id, workspace_id)
+             SELECT id, workspace_id
+             FROM sessions
+             WHERE workspace_id = ?
+             ON CONFLICT(session_id) DO UPDATE SET
+               workspace_id = excluded.workspace_id,
+               queued_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+               attempt_count = 0,
+               last_attempt_at = NULL,
+               last_error = ''",
+        )
+        .bind(workspace_id)
+        .execute(&mut *transaction)
+        .await?;
+    }
+
+    transaction.commit().await?;
+    Ok(CloudsyncWorkspaceReconciliationPlan {
+        granted_workspace_ids,
+        revoked_workspace_ids,
+    })
+}
+
+pub async fn commit_cloudsync_workspace_projection(
+    pool: &SqlitePool,
+    projection: &CloudsyncWorkspaceProjection,
+    require_full_resync: bool,
+) -> Result<Option<String>, CloudsyncWorkspaceError> {
+    write_cloudsync_workspace_projection(pool, projection, require_full_resync, true).await
+}
+
+pub async fn cloudsync_full_resync_generation(
+    pool: &SqlitePool,
+) -> Result<Option<String>, CloudsyncWorkspaceError> {
+    let value_json: Option<String> =
+        sqlx::query_scalar("SELECT value_json FROM app_settings WHERE id = ?")
+            .bind(CLOUDSYNC_FULL_RESYNC_PENDING_ID)
+            .fetch_optional(pool)
+            .await?;
+    value_json
+        .map(|value_json| {
+            serde_json::from_str(&value_json)
+                .map_err(|_| CloudsyncWorkspaceError::InvalidWorkspaceProjection)
+        })
+        .transpose()
+}
+
+pub async fn clear_cloudsync_full_resync_pending(
+    pool: &SqlitePool,
+    generation: &str,
+) -> Result<(), CloudsyncWorkspaceError> {
+    let value_json = serde_json::to_string(generation)
+        .map_err(|_| CloudsyncWorkspaceError::InvalidWorkspaceProjection)?;
+    sqlx::query("DELETE FROM app_settings WHERE id = ? AND value_json = ?")
+        .bind(CLOUDSYNC_FULL_RESYNC_PENDING_ID)
+        .bind(value_json)
+        .execute(pool)
+        .await?;
+    Ok(())
+}
+
+pub async fn cloudsync_write_filter_installed(
+    pool: &SqlitePool,
+    personal_workspace_id: &str,
+) -> Result<bool, CloudsyncWorkspaceError> {
+    let personal_workspace_id = validated_account_user_id(personal_workspace_id)?;
+    if !cloudsync_write_filter_version_current(pool).await? {
+        return Ok(false);
+    }
+    let writable_scope_matches: bool = sqlx::query_scalar(
+        "SELECT COUNT(*) = 1 AND MAX(allowed_workspace_id) = ?
+         FROM cloudsync_writable_workspaces",
+    )
+    .bind(personal_workspace_id)
+    .fetch_one(pool)
+    .await?;
+    Ok(writable_scope_matches)
+}
+
+pub async fn cloudsync_write_filter_version_current(
+    pool: &SqlitePool,
+) -> Result<bool, CloudsyncWorkspaceError> {
+    let value_json: Option<String> =
+        sqlx::query_scalar("SELECT value_json FROM app_settings WHERE id = ?")
+            .bind(CLOUDSYNC_WRITE_FILTER_VERSION_ID)
+            .fetch_optional(pool)
+            .await?;
+    let current_version = value_json
+        .and_then(|value_json| serde_json::from_str::<String>(&value_json).ok())
+        .is_some_and(|version| version == CLOUDSYNC_WRITE_FILTER_VERSION);
+    Ok(current_version)
+}
+
+pub async fn set_cloudsync_personal_write_scope(
+    pool: &SqlitePool,
+    personal_workspace_id: &str,
+) -> Result<(), CloudsyncWorkspaceError> {
+    let personal_workspace_id = validated_account_user_id(personal_workspace_id)?;
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    sqlx::query("DELETE FROM cloudsync_writable_workspaces")
+        .execute(&mut *transaction)
+        .await?;
+    sqlx::query("INSERT INTO cloudsync_writable_workspaces (allowed_workspace_id) VALUES (?)")
+        .bind(personal_workspace_id)
+        .execute(&mut *transaction)
+        .await?;
+    transaction.commit().await?;
+    Ok(())
+}
+
+pub async fn mark_cloudsync_write_filter_installed(
+    pool: &SqlitePool,
+) -> Result<(), CloudsyncWorkspaceError> {
+    let value_json = serde_json::to_string(CLOUDSYNC_WRITE_FILTER_VERSION)
+        .map_err(|_| CloudsyncWorkspaceError::InvalidWorkspaceProjection)?;
+    sqlx::query(
+        "INSERT INTO app_settings (id, value_json)
+         VALUES (?, ?)
+         ON CONFLICT(id) DO UPDATE SET
+           value_json = excluded.value_json,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+    )
+    .bind(CLOUDSYNC_WRITE_FILTER_VERSION_ID)
+    .bind(value_json)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn write_cloudsync_workspace_projection(
+    pool: &SqlitePool,
+    projection: &CloudsyncWorkspaceProjection,
+    require_full_resync: bool,
+    require_claimed_account: bool,
+) -> Result<Option<String>, CloudsyncWorkspaceError> {
+    validate_cloudsync_workspace_projection(projection)?;
+
+    let full_resync_generation = require_full_resync.then(|| uuid::Uuid::new_v4().to_string());
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    if require_claimed_account {
+        require_claimed_binding(&mut transaction, &projection.account_user_id).await?;
+    }
     sqlx::query("DELETE FROM workspace_memberships")
         .execute(&mut *transaction)
         .await?;
@@ -323,10 +525,31 @@ pub async fn replace_cloudsync_workspace_projection(
         .bind(&workspace.membership_updated_at)
         .execute(&mut *transaction)
         .await?;
+
+        sqlx::query("DELETE FROM cloudsync_session_evictions WHERE workspace_id = ?")
+            .bind(&workspace.id)
+            .execute(&mut *transaction)
+            .await?;
+    }
+
+    if let Some(generation) = full_resync_generation.as_ref() {
+        let value_json = serde_json::to_string(generation)
+            .map_err(|_| CloudsyncWorkspaceError::InvalidWorkspaceProjection)?;
+        sqlx::query(
+            "INSERT INTO app_settings (id, value_json)
+             VALUES (?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               value_json = excluded.value_json,
+               updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
+        )
+        .bind(CLOUDSYNC_FULL_RESYNC_PENDING_ID)
+        .bind(value_json)
+        .execute(&mut *transaction)
+        .await?;
     }
 
     transaction.commit().await?;
-    Ok(())
+    Ok(full_resync_generation)
 }
 
 pub fn validate_cloudsync_workspace_projection(
@@ -498,6 +721,27 @@ async fn load_or_create_binding(
     Ok(binding)
 }
 
+async fn require_claimed_binding(
+    transaction: &mut Transaction<'_, Sqlite>,
+    account_user_id: &str,
+) -> Result<(), CloudsyncWorkspaceError> {
+    let value_json: Option<String> =
+        sqlx::query_scalar("SELECT value_json FROM app_settings WHERE id = ?")
+            .bind(CLOUDSYNC_WORKSPACE_BINDING_ID)
+            .fetch_optional(&mut **transaction)
+            .await?;
+    let Some(value_json) = value_json else {
+        return Err(CloudsyncWorkspaceError::InvalidBinding);
+    };
+    let binding = parse_binding(&value_json)?;
+    if binding.workspace_id != account_user_id
+        || binding.account_user_id.as_deref() != Some(account_user_id)
+    {
+        return Err(CloudsyncWorkspaceError::AccountMismatch);
+    }
+    Ok(())
+}
+
 fn parse_binding(value_json: &str) -> Result<CloudsyncWorkspaceBinding, CloudsyncWorkspaceError> {
     let binding: CloudsyncWorkspaceBinding =
         serde_json::from_str(value_json).map_err(|_| CloudsyncWorkspaceError::InvalidBinding)?;
@@ -640,6 +884,262 @@ mod tests {
                 "2026-07-16T00:01:00Z".to_string(),
                 "2026-07-16T00:02:00Z".to_string(),
             )]
+        );
+    }
+
+    #[tokio::test]
+    async fn workspace_reconciliation_stages_revoked_sessions_before_projection_commit() {
+        let db = test_db().await;
+        claim_cloudsync_workspace(db.pool(), "user-a")
+            .await
+            .unwrap();
+        let current = projection(
+            "user-a",
+            vec![
+                projected_workspace(
+                    "user-a",
+                    "user-a",
+                    "personal",
+                    "membership-personal",
+                    "owner",
+                    "Personal",
+                ),
+                projected_workspace(
+                    "workspace-shared",
+                    "user-b",
+                    "shared",
+                    "membership-shared",
+                    "member",
+                    "Shared",
+                ),
+            ],
+        );
+        replace_cloudsync_workspace_projection(db.pool(), &current)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session-personal', 'user-a', 'user-a', 'Personal'),
+                    ('session-shared', 'workspace-shared', 'user-b', 'Shared')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let personal_only = projection(
+            "user-a",
+            vec![projected_workspace(
+                "user-a",
+                "user-a",
+                "personal",
+                "membership-personal",
+                "owner",
+                "Personal",
+            )],
+        );
+        let plan = stage_cloudsync_workspace_reconciliation(db.pool(), &personal_only)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            plan,
+            CloudsyncWorkspaceReconciliationPlan {
+                granted_workspace_ids: vec![],
+                revoked_workspace_ids: vec!["workspace-shared".to_string()],
+            }
+        );
+        assert!(plan.requires_replica_reset());
+        assert!(plan.requires_full_resync());
+        let memberships_before_commit: Vec<String> = sqlx::query_scalar(
+            "SELECT workspace_id FROM workspace_memberships ORDER BY workspace_id",
+        )
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+        let queued: Vec<(String, String)> = sqlx::query_as(
+            "SELECT session_id, workspace_id
+             FROM cloudsync_session_evictions ORDER BY session_id",
+        )
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            memberships_before_commit,
+            vec!["user-a".to_string(), "workspace-shared".to_string()]
+        );
+        assert_eq!(
+            queued,
+            vec![("session-shared".to_string(), "workspace-shared".to_string(),)]
+        );
+
+        let generation = commit_cloudsync_workspace_projection(
+            db.pool(),
+            &personal_only,
+            plan.requires_full_resync(),
+        )
+        .await
+        .unwrap()
+        .unwrap();
+
+        let memberships_after_commit: Vec<String> = sqlx::query_scalar(
+            "SELECT workspace_id FROM workspace_memberships ORDER BY workspace_id",
+        )
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+        let session_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sessions")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        assert_eq!(memberships_after_commit, vec!["user-a".to_string()]);
+        assert_eq!(session_count, 2);
+        assert_eq!(
+            cloudsync_full_resync_generation(db.pool()).await.unwrap(),
+            Some(generation.clone())
+        );
+        let newer_generation =
+            commit_cloudsync_workspace_projection(db.pool(), &personal_only, true)
+                .await
+                .unwrap()
+                .unwrap();
+        clear_cloudsync_full_resync_pending(db.pool(), &generation)
+            .await
+            .unwrap();
+        assert_eq!(
+            cloudsync_full_resync_generation(db.pool()).await.unwrap(),
+            Some(newer_generation.clone())
+        );
+        clear_cloudsync_full_resync_pending(db.pool(), &newer_generation)
+            .await
+            .unwrap();
+        assert_eq!(
+            cloudsync_full_resync_generation(db.pool()).await.unwrap(),
+            None
+        );
+    }
+
+    #[tokio::test]
+    async fn reauthorized_workspace_cancels_staged_session_evictions() {
+        let db = test_db().await;
+        claim_cloudsync_workspace(db.pool(), "user-a")
+            .await
+            .unwrap();
+        let current = projection(
+            "user-a",
+            vec![
+                projected_workspace(
+                    "user-a",
+                    "user-a",
+                    "personal",
+                    "membership-personal",
+                    "owner",
+                    "Personal",
+                ),
+                projected_workspace(
+                    "workspace-shared",
+                    "user-b",
+                    "shared",
+                    "membership-shared",
+                    "member",
+                    "Shared",
+                ),
+            ],
+        );
+        replace_cloudsync_workspace_projection(db.pool(), &current)
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, title)
+             VALUES ('session-shared', 'workspace-shared', 'Shared')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        let personal_only = projection(
+            "user-a",
+            vec![projected_workspace(
+                "user-a",
+                "user-a",
+                "personal",
+                "membership-personal",
+                "owner",
+                "Personal",
+            )],
+        );
+        stage_cloudsync_workspace_reconciliation(db.pool(), &personal_only)
+            .await
+            .unwrap();
+
+        commit_cloudsync_workspace_projection(db.pool(), &current, false)
+            .await
+            .unwrap();
+
+        let queued_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM cloudsync_session_evictions")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(queued_count, 0);
+    }
+
+    #[tokio::test]
+    async fn workspace_reconciliation_requires_the_claimed_account() {
+        let db = test_db().await;
+        let error = stage_cloudsync_workspace_reconciliation(
+            db.pool(),
+            &projection(
+                "user-a",
+                vec![projected_workspace(
+                    "user-a",
+                    "user-a",
+                    "personal",
+                    "membership-personal",
+                    "owner",
+                    "Personal",
+                )],
+            ),
+        )
+        .await
+        .unwrap_err();
+
+        assert!(matches!(error, CloudsyncWorkspaceError::AccountMismatch));
+        let queue_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM cloudsync_session_evictions")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(queue_count, 0);
+    }
+
+    #[tokio::test]
+    async fn cloudsync_write_filter_scope_is_local_and_versioned() {
+        let db = test_db().await;
+        assert!(
+            !cloudsync_write_filter_installed(db.pool(), "user-a")
+                .await
+                .unwrap()
+        );
+
+        set_cloudsync_personal_write_scope(db.pool(), "user-a")
+            .await
+            .unwrap();
+        mark_cloudsync_write_filter_installed(db.pool())
+            .await
+            .unwrap();
+
+        let writable_workspace_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT allowed_workspace_id
+                 FROM cloudsync_writable_workspaces
+                 ORDER BY allowed_workspace_id",
+        )
+        .fetch_all(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(writable_workspace_ids, vec!["user-a".to_string()]);
+        assert!(
+            cloudsync_write_filter_installed(db.pool(), "user-a")
+                .await
+                .unwrap()
         );
     }
 

--- a/crates/db-app/src/cloudsync.rs
+++ b/crates/db-app/src/cloudsync.rs
@@ -87,6 +87,8 @@ static CLOUDSYNC_TABLE_REGISTRY: LazyLock<Vec<CloudsyncTableSpec>> = LazyLock::n
         ("tags", false),
         ("templates", false),
         ("transcripts", true),
+        ("workspace_memberships", false),
+        ("workspaces", false),
     ]
     .into_iter()
     .map(|(table_name, enabled)| CloudsyncTableSpec {
@@ -182,6 +184,12 @@ pub async fn claim_cloudsync_workspace(
         .is_some_and(|id| id != account_user_id)
     {
         return Err(CloudsyncWorkspaceError::AccountMismatch);
+    }
+    if binding.workspace_id == account_user_id
+        && binding.account_user_id.as_deref() == Some(account_user_id)
+    {
+        transaction.commit().await?;
+        return Ok(());
     }
 
     for table in cloudsync_table_registry()
@@ -821,5 +829,31 @@ mod tests {
             error,
             CloudsyncWorkspaceError::ForeignWorkspace { table } if table == "sessions"
         ));
+    }
+
+    #[tokio::test]
+    async fn repeated_claim_allows_shared_workspace_rows() {
+        let db = test_db().await;
+        claim_cloudsync_workspace(db.pool(), "user-a")
+            .await
+            .unwrap();
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id)
+             VALUES ('shared-session', 'workspace-b', 'user-b')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        claim_cloudsync_workspace(db.pool(), "user-a")
+            .await
+            .unwrap();
+
+        let workspace_id: String =
+            sqlx::query_scalar("SELECT workspace_id FROM sessions WHERE id = 'shared-session'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(workspace_id, "workspace-b");
     }
 }

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -115,6 +115,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260716120000_personal_workspaces.sql"),
     },
+    hypr_db_migrate::MigrationStep {
+        id: "20260716130000_cloudsync_session_evictions",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260716130000_cloudsync_session_evictions.sql"),
+    },
 ];
 
 pub fn schema() -> hypr_db_migrate::DbSchema {
@@ -326,6 +331,8 @@ mod tests {
                 "calendars",
                 "chat_groups",
                 "chat_messages",
+                "cloudsync_session_evictions",
+                "cloudsync_writable_workspaces",
                 "daily_notes",
                 "entity_mentions",
                 "events",

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -110,6 +110,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         },
         sql: include_str!("../migrations/20260714120500_search_index_organizations_triggers.sql"),
     },
+    hypr_db_migrate::MigrationStep {
+        id: "20260716120000_personal_workspaces",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260716120000_personal_workspaces.sql"),
+    },
 ];
 
 pub fn schema() -> hypr_db_migrate::DbSchema {
@@ -340,8 +345,100 @@ mod tests {
                 "tags",
                 "templates",
                 "transcripts",
+                "workspace_memberships",
+                "workspaces",
             ]
         );
+    }
+
+    #[tokio::test]
+    async fn personal_workspace_migration_preserves_existing_session_workspace_ids() {
+        let db = Db::connect_memory_plain().await.unwrap();
+        hypr_db_migrate::migrate(
+            &db,
+            hypr_db_migrate::DbSchema {
+                steps: migration_steps_before("20260716120000_personal_workspaces"),
+                validate_cloudsync_table: cloudsync_alter_guard_required,
+            },
+        )
+        .await
+        .unwrap();
+
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session-1', 'user-1', 'user-1', 'Existing note')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        hypr_db_migrate::migrate(&db, schema()).await.unwrap();
+        sqlx::query(
+            "INSERT INTO workspaces (id, owner_user_id, name)
+             VALUES ('user-1', 'user-1', 'Personal')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO workspace_memberships (id, workspace_id, user_id, role)
+             VALUES ('membership-1', 'user-1', 'user-1', 'owner')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let session_workspace_id: String =
+            sqlx::query_scalar("SELECT workspace_id FROM sessions WHERE id = 'session-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let workspace: (String, String) =
+            sqlx::query_as("SELECT id, kind FROM workspaces WHERE id = 'user-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        let membership_role: String =
+            sqlx::query_scalar("SELECT role FROM workspace_memberships WHERE id = 'membership-1'")
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(session_workspace_id, "user-1");
+        assert_eq!(workspace, ("user-1".to_string(), "personal".to_string()));
+        assert_eq!(membership_role, "owner");
+
+        let duplicate = sqlx::query(
+            "INSERT INTO workspace_memberships (id, workspace_id, user_id)
+             VALUES ('membership-2', 'user-1', 'user-1')",
+        )
+        .execute(db.pool())
+        .await;
+        assert!(duplicate.is_err());
+    }
+
+    #[cfg(any(
+        all(target_os = "macos", target_arch = "aarch64"),
+        all(target_os = "macos", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "gnu", target_arch = "x86_64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "aarch64"),
+        all(target_os = "linux", target_env = "musl", target_arch = "x86_64"),
+        all(target_os = "windows", target_arch = "x86_64"),
+    ))]
+    #[tokio::test]
+    async fn workspace_tables_can_be_initialized_by_cloudsync() {
+        let db = Db::connect_memory().await.unwrap();
+        prepare_schema(&db).await.unwrap();
+
+        for table_name in ["workspaces", "workspace_memberships"] {
+            db.cloudsync_init(table_name, None, None).await.unwrap();
+            assert!(
+                hypr_db_core::cloudsync_is_enabled_on(db.pool(), table_name)
+                    .await
+                    .unwrap()
+            );
+        }
     }
 
     #[cfg(any(
@@ -576,7 +673,7 @@ mod tests {
             .map(|table| table.table_name.as_str())
             .collect();
 
-        assert_eq!(registry.len(), 17);
+        assert_eq!(registry.len(), 19);
         assert_eq!(
             enabled,
             vec![
@@ -601,7 +698,19 @@ mod tests {
                 "search_index_dirty" | "search_index_state"
             )
         }));
+        assert!(
+            registry
+                .iter()
+                .any(|table| { table.table_name == "workspaces" && !table.enabled })
+        );
+        assert!(
+            registry
+                .iter()
+                .any(|table| { table.table_name == "workspace_memberships" && !table.enabled })
+        );
         assert!(cloudsync_alter_guard_required("sessions"));
+        assert!(!cloudsync_alter_guard_required("workspaces"));
+        assert!(!cloudsync_alter_guard_required("workspace_memberships"));
         assert!(!cloudsync_alter_guard_required("calendars"));
     }
 

--- a/crates/db-app/tests/cloudsync.rs
+++ b/crates/db-app/tests/cloudsync.rs
@@ -103,6 +103,7 @@ async fn sync_ok(db: &Db, label: &str) {
         assert!(send.last_failure.is_none(), "{label} send failed");
     }
     if let Some(receive) = result.receive {
+        assert!(receive.complete, "{label} receive did not complete");
         assert!(receive.error.is_none(), "{label} receive failed");
         assert!(
             receive.last_failure.is_none(),
@@ -1490,37 +1491,65 @@ async fn access_token_workspace_attributes_allow_shared_reads_but_not_writes() {
     let foreign_insert_count =
         row_count_by_id(db_c_verifier.pool(), "sessions", &foreign_insert_c).await;
 
-    let db_a_without_shared = setup_db(
-        CloudsyncAuth::Token {
-            token: token_a_without_shared_c.clone(),
-        },
-        Some(&workspace_a),
-    )
-    .await;
-    db_a_without_shared
+    db_a_shared
+        .cloudsync_reconfigure(cloudsync_config(
+            CloudsyncAuth::Token {
+                token: token_a_without_shared_c.clone(),
+            },
+            5_000,
+            3,
+        ))
+        .await
+        .expect("same-client workspace A token reconfiguration failed");
+    if db_a_shared
+        .cloudsync_status()
+        .await
+        .expect("same-client workspace A status failed")
+        .has_unsent_changes
+        .unwrap_or(true)
+    {
+        sync_ok(&db_a_shared, "same-client workspace A pre-revocation drain").await;
+    }
+    db_a_shared
+        .cloudsync_logout(false)
+        .await
+        .expect("same-client workspace A replica logout failed");
+    let revoked_a_was_purged = row_count_by_id(db_a_shared.pool(), "sessions", &session_a).await
+        == 0
+        && row_count_by_id(db_a_shared.pool(), "sessions", &session_c).await == 0;
+
+    db_a_shared
+        .cloudsync_configure(cloudsync_config(
+            CloudsyncAuth::Token {
+                token: token_a_without_shared_c.clone(),
+            },
+            5_000,
+            3,
+        ))
+        .await
+        .expect("same-client workspace A post-logout configuration failed");
+    db_a_shared
+        .cloudsync_start()
+        .await
+        .expect("same-client workspace A post-logout start failed");
+    db_a_shared
         .cloudsync_network_reset_sync_version()
         .await
-        .expect("fresh workspace A token sync reset failed");
+        .expect("same-client workspace A token sync reset failed");
     sync_ok(
-        &db_a_without_shared,
-        "fresh workspace A token without C snapshot",
+        &db_a_shared,
+        "same-client workspace A token without C snapshot",
     )
     .await;
     sync_ok(
-        &db_a_without_shared,
-        "fresh workspace A token without C snapshot retry",
+        &db_a_shared,
+        "same-client workspace A token without C snapshot retry",
     )
     .await;
-    let fresh_a_reads_personal = row_count(
-        db_a_without_shared.pool(),
-        "sessions",
-        &session_a,
-        &workspace_a,
-    )
-    .await
-        == 1;
-    let fresh_a_cannot_read_c =
-        row_count_by_id(db_a_without_shared.pool(), "sessions", &session_c).await == 0;
+    let revoked_a_reads_personal =
+        row_count(db_a_shared.pool(), "sessions", &session_a, &workspace_a).await == 1;
+    let revoked_a_cannot_read_c =
+        row_count_by_id(db_a_shared.pool(), "sessions", &session_c).await == 0;
 
     sqlx::query("DELETE FROM sessions WHERE id = ?")
         .bind(&session_a)
@@ -1552,7 +1581,6 @@ async fn access_token_workspace_attributes_allow_shared_reads_but_not_writes() {
         (&update_attacker, "workspace C update attacker"),
         (&delete_attacker, "workspace C delete attacker"),
         (&db_c_verifier, "workspace C verifier"),
-        (&db_a_without_shared, "fresh workspace A reader"),
     ] {
         tokio::time::timeout(Duration::from_secs(15), db.cloudsync_stop())
             .await
@@ -1599,11 +1627,15 @@ async fn access_token_workspace_attributes_allow_shared_reads_but_not_writes() {
         "workspace A inserted a row into workspace C"
     );
     assert!(
-        fresh_a_reads_personal,
-        "fresh workspace A token could not read its personal row"
+        revoked_a_was_purged,
+        "same-client workspace A logout did not purge its prior replica"
     );
     assert!(
-        fresh_a_cannot_read_c,
-        "fresh workspace A token without C still read workspace C"
+        revoked_a_reads_personal,
+        "same-client workspace A token could not restore its personal row"
+    );
+    assert!(
+        revoked_a_cannot_read_c,
+        "same-client workspace A token without C restored workspace C"
     );
 }

--- a/crates/db-app/tests/cloudsync.rs
+++ b/crates/db-app/tests/cloudsync.rs
@@ -10,6 +10,7 @@ use hypr_db_core::{
 use sqlx::{AssertSqlSafe, SqlitePool};
 
 const SYNC_TIMEOUT: Duration = Duration::from_secs(90);
+const SYNC_ATTEMPTS: usize = 3;
 const POLICY_SYNC_TIMEOUT: Duration = Duration::from_secs(30);
 const STALE_SNAPSHOT_SYNC_ATTEMPTS: usize = 2;
 const SYNCED_TABLES: [&str; 8] = [
@@ -76,10 +77,27 @@ async fn setup_policy_db(auth: CloudsyncAuth, workspace_id: &str) -> Db {
 }
 
 async fn sync_ok(db: &Db, label: &str) {
-    let result = tokio::time::timeout(SYNC_TIMEOUT, db.cloudsync_trigger_sync())
-        .await
-        .unwrap_or_else(|_| panic!("{label} timed out"))
-        .unwrap_or_else(|error| panic!("{label} failed: {error}"));
+    let mut result = None;
+    let mut last_failure = None;
+    for attempt in 1..=SYNC_ATTEMPTS {
+        match tokio::time::timeout(SYNC_TIMEOUT, db.cloudsync_trigger_sync()).await {
+            Ok(Ok(value)) => {
+                result = Some(value);
+                break;
+            }
+            Ok(Err(error)) => last_failure = Some(error.to_string()),
+            Err(_) => last_failure = Some("timed out".to_string()),
+        }
+        if attempt < SYNC_ATTEMPTS {
+            tokio::time::sleep(Duration::from_secs(2)).await;
+        }
+    }
+    let result = result.unwrap_or_else(|| {
+        panic!(
+            "{label} failed after {SYNC_ATTEMPTS} attempts: {}",
+            last_failure.as_deref().unwrap_or("unknown error")
+        )
+    });
     if let Some(send) = result.send {
         assert_eq!(send.status, "synced", "{label} send did not complete");
         assert!(send.last_failure.is_none(), "{label} send failed");
@@ -473,6 +491,53 @@ fn fixture_value_column(table: &str) -> &'static str {
     }
 }
 
+async fn setup_snapshot_policy_db(
+    token: &str,
+    local_workspace: &str,
+    row_workspace: &str,
+    table: &str,
+    id: &str,
+) -> Db {
+    let db = setup_db(
+        CloudsyncAuth::Token {
+            token: token.to_string(),
+        },
+        Some(local_workspace),
+    )
+    .await;
+    db.cloudsync_network_reset_sync_version()
+        .await
+        .unwrap_or_else(|error| panic!("{table} snapshot fixture reset failed: {error}"));
+    for attempt in 1..=STALE_SNAPSHOT_SYNC_ATTEMPTS {
+        sync_ok(
+            &db,
+            &format!("{table} snapshot fixture download attempt {attempt}"),
+        )
+        .await;
+        if row_count(db.pool(), table, id, row_workspace).await == 1 {
+            break;
+        }
+    }
+    let downloaded_rows = row_count(db.pool(), table, id, row_workspace).await;
+    let status = db.cloudsync_status().await.unwrap();
+    assert_eq!(
+        downloaded_rows, 1,
+        "{table} snapshot fixture was not downloaded after a reset and \
+         {STALE_SNAPSHOT_SYNC_ATTEMPTS} bounded attempts; last sync: {:?}; last error: {:?}",
+        status.last_sync, status.last_error,
+    );
+    if status.has_unsent_changes != Some(false) {
+        sync_ok(&db, &format!("{table} snapshot fixture upload drain")).await;
+    }
+    assert_eq!(
+        db.cloudsync_status().await.unwrap().has_unsent_changes,
+        Some(false),
+        "{table} snapshot client had unrelated pending changes"
+    );
+
+    db
+}
+
 async fn setup_stale_policy_db(
     token_b: &str,
     token_a: &str,
@@ -480,42 +545,7 @@ async fn setup_stale_policy_db(
     table: &str,
     id: &str,
 ) -> Db {
-    let db = setup_db(
-        CloudsyncAuth::Token {
-            token: token_b.to_string(),
-        },
-        Some(workspace_b),
-    )
-    .await;
-    db.cloudsync_network_reset_sync_version()
-        .await
-        .unwrap_or_else(|error| panic!("{table} stale fixture reset failed: {error}"));
-    for attempt in 1..=STALE_SNAPSHOT_SYNC_ATTEMPTS {
-        sync_ok(
-            &db,
-            &format!("{table} stale fixture download attempt {attempt}"),
-        )
-        .await;
-        if row_count(db.pool(), table, id, workspace_b).await == 1 {
-            break;
-        }
-    }
-    let downloaded_rows = row_count(db.pool(), table, id, workspace_b).await;
-    let status = db.cloudsync_status().await.unwrap();
-    assert_eq!(
-        downloaded_rows, 1,
-        "{table} stale fixture was not downloaded after a reset and \
-         {STALE_SNAPSHOT_SYNC_ATTEMPTS} bounded attempts; last sync: {:?}; last error: {:?}",
-        status.last_sync, status.last_error,
-    );
-    if status.has_unsent_changes != Some(false) {
-        sync_ok(&db, &format!("{table} stale fixture upload drain")).await;
-    }
-    assert_eq!(
-        db.cloudsync_status().await.unwrap().has_unsent_changes,
-        Some(false),
-        "{table} stale client had unrelated pending changes before reauthentication"
-    );
+    let db = setup_snapshot_policy_db(token_b, workspace_b, workspace_b, table, id).await;
 
     // Keep the downloaded B-owned row, but switch only the network identity to A.
     tokio::time::timeout(Duration::from_secs(15), db.cloudsync_stop())
@@ -1243,5 +1273,337 @@ async fn access_tokens_isolate_two_workspaces() {
         fixture_b_violations.is_empty(),
         "workspace A mutated workspace B rows: {}",
         fixture_b_violations.join(", ")
+    );
+}
+
+#[tokio::test]
+#[ignore = "external verification only; requires ANARLOG_CLOUDSYNC_DATABASE_ID, ANARLOG_CLOUDSYNC_WORKSPACE_A/B/C, ANARLOG_CLOUDSYNC_TOKEN_A_WITH_SHARED_C, ANARLOG_CLOUDSYNC_TOKEN_A_WITHOUT_SHARED_C, ANARLOG_CLOUDSYNC_TOKEN_B, and ANARLOG_CLOUDSYNC_TOKEN_C_OWNER"]
+async fn access_token_workspace_attributes_allow_shared_reads_but_not_writes() {
+    let workspace_a = std::env::var("ANARLOG_CLOUDSYNC_WORKSPACE_A")
+        .expect("ANARLOG_CLOUDSYNC_WORKSPACE_A must be set");
+    let workspace_b = std::env::var("ANARLOG_CLOUDSYNC_WORKSPACE_B")
+        .expect("ANARLOG_CLOUDSYNC_WORKSPACE_B must be set");
+    let workspace_c = std::env::var("ANARLOG_CLOUDSYNC_WORKSPACE_C")
+        .expect("ANARLOG_CLOUDSYNC_WORKSPACE_C must be set");
+    assert_ne!(workspace_a, workspace_b);
+    assert_ne!(workspace_a, workspace_c);
+    assert_ne!(workspace_b, workspace_c);
+
+    let token_a_with_shared_c = std::env::var("ANARLOG_CLOUDSYNC_TOKEN_A_WITH_SHARED_C")
+        .expect("ANARLOG_CLOUDSYNC_TOKEN_A_WITH_SHARED_C must be set");
+    let token_a_without_shared_c = std::env::var("ANARLOG_CLOUDSYNC_TOKEN_A_WITHOUT_SHARED_C")
+        .expect("ANARLOG_CLOUDSYNC_TOKEN_A_WITHOUT_SHARED_C must be set");
+    let token_b =
+        std::env::var("ANARLOG_CLOUDSYNC_TOKEN_B").expect("ANARLOG_CLOUDSYNC_TOKEN_B must be set");
+    let token_c_owner = std::env::var("ANARLOG_CLOUDSYNC_TOKEN_C_OWNER")
+        .expect("ANARLOG_CLOUDSYNC_TOKEN_C_OWNER must be set");
+
+    let db_a_owner = setup_db(
+        CloudsyncAuth::Token {
+            token: token_a_without_shared_c.clone(),
+        },
+        Some(&workspace_a),
+    )
+    .await;
+    let db_b_owner = setup_db(
+        CloudsyncAuth::Token {
+            token: token_b.clone(),
+        },
+        Some(&workspace_b),
+    )
+    .await;
+    let db_c_owner = setup_db(
+        CloudsyncAuth::Token {
+            token: token_c_owner.clone(),
+        },
+        Some(&workspace_c),
+    )
+    .await;
+
+    let marker = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let session_a: String = sqlx::query_scalar("SELECT cloudsync_uuid()")
+        .fetch_one(db_a_owner.pool())
+        .await
+        .unwrap();
+    let session_b: String = sqlx::query_scalar("SELECT cloudsync_uuid()")
+        .fetch_one(db_b_owner.pool())
+        .await
+        .unwrap();
+    let session_c: String = sqlx::query_scalar("SELECT cloudsync_uuid()")
+        .fetch_one(db_c_owner.pool())
+        .await
+        .unwrap();
+    let foreign_insert_c: String = sqlx::query_scalar("SELECT cloudsync_uuid()")
+        .fetch_one(db_a_owner.pool())
+        .await
+        .unwrap();
+    let title_a = format!("anarlog-workspace-attributes-a-{marker}");
+    let title_b = format!("anarlog-workspace-attributes-b-{marker}");
+    let title_c = format!("anarlog-workspace-attributes-c-{marker}");
+
+    for (db, id, workspace_id, title) in [
+        (&db_a_owner, &session_a, &workspace_a, &title_a),
+        (&db_b_owner, &session_b, &workspace_b, &title_b),
+        (&db_c_owner, &session_c, &workspace_c, &title_c),
+    ] {
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title) VALUES (?, ?, ?, ?)",
+        )
+        .bind(id)
+        .bind(workspace_id)
+        .bind(workspace_id)
+        .bind(title)
+        .execute(db.pool())
+        .await
+        .unwrap();
+    }
+    sync_ok(&db_a_owner, "workspace attribute A fixture upload").await;
+    sync_ok(&db_b_owner, "workspace attribute B fixture upload").await;
+    sync_ok(&db_c_owner, "workspace attribute C fixture upload").await;
+
+    let db_a_shared = setup_db(
+        CloudsyncAuth::Token {
+            token: token_a_with_shared_c.clone(),
+        },
+        Some(&workspace_a),
+    )
+    .await;
+    let db_b_reader = setup_db(
+        CloudsyncAuth::Token {
+            token: token_b.clone(),
+        },
+        Some(&workspace_b),
+    )
+    .await;
+    for (db, label) in [
+        (&db_a_shared, "workspace A shared-read snapshot"),
+        (&db_b_reader, "workspace B isolation snapshot"),
+    ] {
+        sync_ok(db, label).await;
+        sync_ok(db, label).await;
+    }
+
+    let a_reads_personal =
+        row_count(db_a_shared.pool(), "sessions", &session_a, &workspace_a).await == 1;
+    let a_reads_shared_c =
+        row_count(db_a_shared.pool(), "sessions", &session_c, &workspace_c).await == 1;
+    let a_cannot_read_b = row_count_by_id(db_a_shared.pool(), "sessions", &session_b).await == 0;
+    let b_reads_personal =
+        row_count(db_b_reader.pool(), "sessions", &session_b, &workspace_b).await == 1;
+    let b_cannot_read_c = row_count_by_id(db_b_reader.pool(), "sessions", &session_c).await == 0;
+
+    let insert_attacker = setup_policy_db(
+        CloudsyncAuth::Token {
+            token: token_a_with_shared_c.clone(),
+        },
+        &workspace_a,
+    )
+    .await;
+    sqlx::query(
+        "INSERT INTO sessions (id, workspace_id, owner_user_id, title) VALUES (?, ?, ?, ?)",
+    )
+    .bind(&foreign_insert_c)
+    .bind(&workspace_c)
+    .bind(&workspace_c)
+    .bind(format!(
+        "anarlog-workspace-attributes-foreign-insert-{marker}"
+    ))
+    .execute(insert_attacker.pool())
+    .await
+    .unwrap();
+    let insert_policy =
+        expect_policy_sync_completed_or_denied(&insert_attacker, "shared workspace C INSERT").await;
+
+    let update_attacker = setup_snapshot_policy_db(
+        &token_a_with_shared_c,
+        &workspace_a,
+        &workspace_c,
+        "sessions",
+        &session_c,
+    )
+    .await;
+    let update_rows = sqlx::query("UPDATE sessions SET title = ? WHERE id = ?")
+        .bind(format!(
+            "anarlog-workspace-attributes-foreign-update-{marker}"
+        ))
+        .bind(&session_c)
+        .execute(update_attacker.pool())
+        .await
+        .unwrap()
+        .rows_affected();
+    let update_policy = if update_rows == 1 {
+        expect_policy_sync_completed_or_denied(&update_attacker, "shared workspace C UPDATE").await
+    } else {
+        Err("shared workspace C was not available for the UPDATE attempt".to_string())
+    };
+
+    let delete_attacker = setup_snapshot_policy_db(
+        &token_a_with_shared_c,
+        &workspace_a,
+        &workspace_c,
+        "sessions",
+        &session_c,
+    )
+    .await;
+    let delete_rows = sqlx::query("DELETE FROM sessions WHERE id = ?")
+        .bind(&session_c)
+        .execute(delete_attacker.pool())
+        .await
+        .unwrap()
+        .rows_affected();
+    let delete_policy = if delete_rows == 1 {
+        expect_policy_sync_completed_or_denied(&delete_attacker, "shared workspace C DELETE").await
+    } else {
+        Err("shared workspace C was not available for the DELETE attempt".to_string())
+    };
+
+    let db_c_verifier = setup_db(
+        CloudsyncAuth::Token {
+            token: token_c_owner.clone(),
+        },
+        Some(&workspace_c),
+    )
+    .await;
+    db_c_verifier
+        .cloudsync_network_reset_sync_version()
+        .await
+        .expect("workspace C verification sync reset failed");
+    sync_ok(
+        &db_c_verifier,
+        "shared workspace C write-policy verification",
+    )
+    .await;
+    sync_ok(
+        &db_c_verifier,
+        "shared workspace C write-policy verification retry",
+    )
+    .await;
+    let verified_title_c: Option<String> =
+        sqlx::query_scalar("SELECT title FROM sessions WHERE id = ?")
+            .bind(&session_c)
+            .fetch_optional(db_c_verifier.pool())
+            .await
+            .unwrap();
+    let foreign_insert_count =
+        row_count_by_id(db_c_verifier.pool(), "sessions", &foreign_insert_c).await;
+
+    let db_a_without_shared = setup_db(
+        CloudsyncAuth::Token {
+            token: token_a_without_shared_c.clone(),
+        },
+        Some(&workspace_a),
+    )
+    .await;
+    db_a_without_shared
+        .cloudsync_network_reset_sync_version()
+        .await
+        .expect("fresh workspace A token sync reset failed");
+    sync_ok(
+        &db_a_without_shared,
+        "fresh workspace A token without C snapshot",
+    )
+    .await;
+    sync_ok(
+        &db_a_without_shared,
+        "fresh workspace A token without C snapshot retry",
+    )
+    .await;
+    let fresh_a_reads_personal = row_count(
+        db_a_without_shared.pool(),
+        "sessions",
+        &session_a,
+        &workspace_a,
+    )
+    .await
+        == 1;
+    let fresh_a_cannot_read_c =
+        row_count_by_id(db_a_without_shared.pool(), "sessions", &session_c).await == 0;
+
+    sqlx::query("DELETE FROM sessions WHERE id = ?")
+        .bind(&session_a)
+        .execute(db_a_owner.pool())
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM sessions WHERE id = ?")
+        .bind(&session_b)
+        .execute(db_b_owner.pool())
+        .await
+        .unwrap();
+    sqlx::query("DELETE FROM sessions WHERE id = ? OR id = ?")
+        .bind(&session_c)
+        .bind(&foreign_insert_c)
+        .execute(db_c_verifier.pool())
+        .await
+        .unwrap();
+    sync_ok(&db_a_owner, "workspace attribute A fixture cleanup").await;
+    sync_ok(&db_b_owner, "workspace attribute B fixture cleanup").await;
+    sync_ok(&db_c_verifier, "workspace attribute C fixture cleanup").await;
+
+    for (db, label) in [
+        (&db_a_owner, "workspace A owner"),
+        (&db_b_owner, "workspace B owner"),
+        (&db_c_owner, "workspace C owner"),
+        (&db_a_shared, "workspace A shared reader"),
+        (&db_b_reader, "workspace B reader"),
+        (&insert_attacker, "workspace C insert attacker"),
+        (&update_attacker, "workspace C update attacker"),
+        (&delete_attacker, "workspace C delete attacker"),
+        (&db_c_verifier, "workspace C verifier"),
+        (&db_a_without_shared, "fresh workspace A reader"),
+    ] {
+        tokio::time::timeout(Duration::from_secs(15), db.cloudsync_stop())
+            .await
+            .unwrap_or_else(|_| panic!("{label} stop timed out"))
+            .unwrap();
+    }
+
+    assert!(
+        a_reads_personal,
+        "workspace A could not read its personal row"
+    );
+    assert!(
+        a_reads_shared_c,
+        "workspace A could not read shared workspace C"
+    );
+    assert!(a_cannot_read_b, "workspace A read unrelated workspace B");
+    assert!(
+        b_reads_personal,
+        "workspace B could not read its personal row"
+    );
+    assert!(b_cannot_read_c, "workspace B read shared workspace C");
+    assert!(
+        insert_policy.is_ok(),
+        "workspace A shared INSERT returned an unexpected sync result: {:?}",
+        insert_policy.err()
+    );
+    assert!(
+        update_policy.is_ok(),
+        "workspace A shared UPDATE returned an unexpected sync result: {:?}",
+        update_policy.err()
+    );
+    assert!(
+        delete_policy.is_ok(),
+        "workspace A shared DELETE returned an unexpected sync result: {:?}",
+        delete_policy.err()
+    );
+    assert_eq!(
+        verified_title_c.as_deref(),
+        Some(title_c.as_str()),
+        "workspace A updated or deleted workspace C's row"
+    );
+    assert_eq!(
+        foreign_insert_count, 0,
+        "workspace A inserted a row into workspace C"
+    );
+    assert!(
+        fresh_a_reads_personal,
+        "fresh workspace A token could not read its personal row"
+    );
+    assert!(
+        fresh_a_cannot_read_c,
+        "fresh workspace A token without C still read workspace C"
     );
 }

--- a/crates/db-core/src/cloudsync/ops.rs
+++ b/crates/db-core/src/cloudsync/ops.rs
@@ -62,6 +62,22 @@ impl Db {
         result
     }
 
+    pub async fn cloudsync_set_filter(
+        &self,
+        table_name: &str,
+        filter_expression: &str,
+    ) -> Result<(), hypr_cloudsync::Error> {
+        let mut connection = self.lock_cloudsync_connection().await?;
+        let result = hypr_cloudsync::set_filter(
+            &mut **connection.as_mut().unwrap(),
+            table_name,
+            filter_expression,
+        )
+        .await;
+        self.release_single_pool_connection(&mut connection);
+        result
+    }
+
     pub(crate) async fn cloudsync_init_enabled_tables(
         &self,
         tables: &[CloudsyncTableSpec],

--- a/crates/fs-sync-core/src/session.rs
+++ b/crates/fs-sync-core/src/session.rs
@@ -8,35 +8,42 @@ pub fn find_session_dir(sessions_base: &Path, session_id: &str) -> Result<PathBu
         return Err(Error::Path("session_id_invalid".into()));
     }
 
-    if let Some(found) = find_session_dir_recursive(sessions_base, session_id) {
+    if let Some(found) = find_session_dir_recursive(sessions_base, session_id)? {
         return Ok(found);
     }
     Ok(sessions_base.join(session_id))
 }
 
-fn find_session_dir_recursive(dir: &Path, session_id: &str) -> Option<PathBuf> {
-    let entries = std::fs::read_dir(dir).ok()?;
+fn find_session_dir_recursive(dir: &Path, session_id: &str) -> std::io::Result<Option<PathBuf>> {
+    let entries = match std::fs::read_dir(dir) {
+        Ok(entries) => entries,
+        Err(error) if error.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(error) => return Err(error),
+    };
 
-    for entry in entries.flatten() {
+    for entry in entries {
+        let entry = entry?;
         let path = entry.path();
-        if !path.is_dir() {
+        if !entry.file_type()?.is_dir() {
             continue;
         }
 
-        let name = path.file_name()?.to_str()?;
+        let Some(name) = path.file_name().and_then(|name| name.to_str()) else {
+            continue;
+        };
 
         if name == session_id {
-            return Some(path);
+            return Ok(Some(path));
         }
 
         if !is_uuid(name)
-            && let Some(found) = find_session_dir_recursive(&path, session_id)
+            && let Some(found) = find_session_dir_recursive(&path, session_id)?
         {
-            return Some(found);
+            return Ok(Some(found));
         }
     }
 
-    None
+    Ok(None)
 }
 
 pub fn delete_session_dir(session_dir: &Path) -> std::io::Result<()> {

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -73,6 +73,34 @@ export const events = sqliteTable(
   ],
 );
 
+export const workspaces = sqliteTable(
+  "workspaces",
+  {
+    id: text("id").primaryKey().notNull(),
+    ownerUserId: text("owner_user_id").notNull().default(""),
+    kind: text("kind").notNull().default("personal"),
+    name: text("name").notNull().default(""),
+    createdAt: text("created_at").notNull().default(currentTimestamp),
+    updatedAt: text("updated_at").notNull().default(currentTimestamp),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [index("idx_workspaces_owner_user_id").on(table.ownerUserId)],
+);
+
+export const workspaceMemberships = sqliteTable(
+  "workspace_memberships",
+  {
+    id: text("id").primaryKey().notNull(),
+    workspaceId: text("workspace_id").notNull().default(""),
+    userId: text("user_id").notNull().default(""),
+    role: text("role").notNull().default("member"),
+    createdAt: text("created_at").notNull().default(currentTimestamp),
+    updatedAt: text("updated_at").notNull().default(currentTimestamp),
+    deletedAt: text("deleted_at"),
+  },
+  (table) => [index("idx_workspace_memberships_user_id").on(table.userId)],
+);
+
 export const organizations = sqliteTable("organizations", {
   id: text("id").primaryKey().notNull(),
   workspaceId: text("workspace_id").notNull().default(""),

--- a/plugins/db/js/bindings.gen.ts
+++ b/plugins/db/js/bindings.gen.ts
@@ -126,9 +126,9 @@ async bindCloudsyncAccount(accountUserId: string) : Promise<Result<boolean, stri
     else return { status: "error", error: e  as any };
 }
 },
-async configureCloudsyncToken(databaseId: string, token: string, workspaceId: string) : Promise<Result<CloudsyncTokenConfigurationResult, string>> {
+async configureCloudsyncToken(databaseId: string, token: string, workspaceId: string, workspaceProjection: CloudsyncWorkspaceProjection | null) : Promise<Result<CloudsyncTokenConfigurationResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("plugin:db|configure_cloudsync_token", { databaseId, token, workspaceId }) };
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|configure_cloudsync_token", { databaseId, token, workspaceId, workspaceProjection }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -188,6 +188,8 @@ async syncCloudsyncNow() : Promise<Result<JsonValue, string>> {
 
 export type ActionItem = { id: string; assignee_human_id: string; status: string; text: string; due_at: string; completed_at: string | null }
 export type CloudsyncTokenConfigurationResult = "configured" | "account_mismatch"
+export type CloudsyncWorkspaceProjection = { accountUserId: string; personalWorkspaceId: string; workspaces: CloudsyncWorkspaceProjectionEntry[] }
+export type CloudsyncWorkspaceProjectionEntry = { id: string; ownerUserId: string; kind: string; name: string; membershipId: string; role: string; membershipCreatedAt: string; membershipUpdatedAt: string; createdAt: string; updatedAt: string }
 export type DependencyAnalysis = { kind: "reactive"; data: { targets: DependencyTarget[] } } | { kind: "non_reactive"; data: { reason: string } }
 export type DependencyTarget = { kind: "table"; data: string } | { kind: "virtual_table"; data: string }
 export type Document = { id: string; kind: string; template_id: string; title: string; markdown: string; sort_order: number; created_at: string; updated_at: string }

--- a/plugins/db/js/index.ts
+++ b/plugins/db/js/index.ts
@@ -5,6 +5,7 @@ import type {
   GetMeetingTranscriptInput as GeneratedGetMeetingTranscriptInput,
   GetRecurringMeetingHistoryInput as GeneratedGetRecurringMeetingHistoryInput,
   CloudsyncTokenConfigurationResult,
+  CloudsyncWorkspaceProjection,
   LegacyCleanupResult,
   LegacyCleanupStatus,
   LegacyImportReport,
@@ -17,6 +18,7 @@ import type {
 
 export type {
   CloudsyncTokenConfigurationResult,
+  CloudsyncWorkspaceProjection,
   GetMeetingInput,
   LegacyCleanupResult,
   LegacyCleanupStatus,
@@ -171,11 +173,13 @@ export async function configureCloudsyncToken(
   databaseId: string,
   token: string,
   workspaceId: string,
+  workspaceProjection?: CloudsyncWorkspaceProjection,
 ): Promise<CloudsyncTokenConfigurationResult> {
   return invoke("plugin:db|configure_cloudsync_token", {
     databaseId,
     token,
     workspaceId,
+    workspaceProjection: workspaceProjection ?? null,
   });
 }
 

--- a/plugins/db/src/commands.rs
+++ b/plugins/db/src/commands.rs
@@ -114,7 +114,8 @@ pub(crate) async fn get_legacy_cleanup_status(
 pub(crate) async fn cleanup_legacy_files(
     state: tauri::State<'_, ManagedState>,
 ) -> Result<crate::LegacyCleanupResult, String> {
-    crate::import::cleanup_legacy_files(state.pool())
+    state
+        .cleanup_legacy_files()
         .await
         .map_err(|error| error.to_string())
 }
@@ -125,7 +126,8 @@ pub(crate) async fn run_legacy_import(
     state: tauri::State<'_, ManagedState>,
     dry_run: bool,
 ) -> Result<String, String> {
-    crate::import::rerun_legacy_import(state.pool(), dry_run)
+    state
+        .rerun_legacy_import(dry_run)
         .await
         .map_err(|error| error.to_string())
 }

--- a/plugins/db/src/commands.rs
+++ b/plugins/db/src/commands.rs
@@ -179,9 +179,15 @@ pub(crate) async fn configure_cloudsync_token(
     database_id: String,
     token: String,
     workspace_id: String,
+    workspace_projection: Option<crate::CloudsyncWorkspaceProjection>,
 ) -> Result<crate::CloudsyncTokenConfigurationResult, String> {
     state
-        .configure_cloudsync_token(database_id, token, workspace_id)
+        .configure_cloudsync_token_with_projection(
+            database_id,
+            token,
+            workspace_id,
+            workspace_projection.map(Into::into),
+        )
         .await
         .map_err(|error| error.to_string())
 }

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -125,6 +125,54 @@ pub enum CloudsyncTokenConfigurationResult {
     AccountMismatch,
 }
 
+#[derive(Debug, Clone, serde::Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudsyncWorkspaceProjection {
+    pub account_user_id: String,
+    pub personal_workspace_id: String,
+    pub workspaces: Vec<CloudsyncWorkspaceProjectionEntry>,
+}
+
+#[derive(Debug, Clone, serde::Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudsyncWorkspaceProjectionEntry {
+    pub id: String,
+    pub owner_user_id: String,
+    pub kind: String,
+    pub name: String,
+    pub membership_id: String,
+    pub role: String,
+    pub membership_created_at: String,
+    pub membership_updated_at: String,
+    pub created_at: String,
+    pub updated_at: String,
+}
+
+impl From<CloudsyncWorkspaceProjection> for hypr_db_app::CloudsyncWorkspaceProjection {
+    fn from(projection: CloudsyncWorkspaceProjection) -> Self {
+        Self {
+            account_user_id: projection.account_user_id,
+            personal_workspace_id: projection.personal_workspace_id,
+            workspaces: projection
+                .workspaces
+                .into_iter()
+                .map(|workspace| hypr_db_app::CloudsyncWorkspaceProjectionEntry {
+                    id: workspace.id,
+                    owner_user_id: workspace.owner_user_id,
+                    kind: workspace.kind,
+                    name: workspace.name,
+                    membership_id: workspace.membership_id,
+                    role: workspace.role,
+                    membership_created_at: workspace.membership_created_at,
+                    membership_updated_at: workspace.membership_updated_at,
+                    created_at: workspace.created_at,
+                    updated_at: workspace.updated_at,
+                })
+                .collect(),
+        }
+    }
+}
+
 fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
     tauri_specta::Builder::<R>::new()
         .plugin_name(PLUGIN_NAME)
@@ -720,6 +768,54 @@ mod test {
     }
 
     #[tokio::test]
+    async fn invalid_projection_does_not_claim_an_unbound_database() {
+        let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
+        sqlx::query("DELETE FROM app_settings WHERE id = 'cloudsync_workspace_binding'")
+            .execute(runtime.pool())
+            .await
+            .unwrap();
+        sqlx::query("INSERT INTO sessions (id, title) VALUES ('session', 'Session')")
+            .execute(runtime.pool())
+            .await
+            .unwrap();
+
+        let error = runtime
+            .configure_cloudsync_token_with_projection(
+                "managed-database-id".to_string(),
+                "token".to_string(),
+                "user-a".to_string(),
+                Some(hypr_db_app::CloudsyncWorkspaceProjection {
+                    account_user_id: "user-a".to_string(),
+                    personal_workspace_id: "user-a".to_string(),
+                    workspaces: vec![],
+                }),
+            )
+            .await
+            .unwrap_err();
+
+        let binding_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM app_settings WHERE id = 'cloudsync_workspace_binding'",
+        )
+        .fetch_one(runtime.pool())
+        .await
+        .unwrap();
+        let session: (String, String) =
+            sqlx::query_as("SELECT workspace_id, owner_user_id FROM sessions WHERE id = 'session'")
+                .fetch_one(runtime.pool())
+                .await
+                .unwrap();
+
+        assert!(matches!(
+            error,
+            crate::Error::CloudsyncWorkspace(
+                hypr_db_app::CloudsyncWorkspaceError::InvalidWorkspaceProjection
+            )
+        ));
+        assert_eq!(binding_count, 0);
+        assert_eq!(session, (String::new(), String::new()));
+    }
+
+    #[tokio::test]
     async fn token_configuration_claims_workspace_and_can_be_suspended() {
         let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
         let local_workspace = hypr_db_app::ensure_cloudsync_workspace_binding(runtime.pool())
@@ -771,6 +867,169 @@ mod test {
         assert_eq!(session, ("user-a".to_string(), "user-a".to_string()));
         assert_eq!(binding, ("user-a".to_string(), "user-a".to_string()));
         runtime.suspend_cloudsync().await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn token_configuration_projects_server_workspaces_after_account_claim() {
+        let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
+        assert!(
+            runtime
+                .bind_cloudsync_account("user-a".to_string())
+                .await
+                .unwrap()
+        );
+
+        let projection = hypr_db_app::CloudsyncWorkspaceProjection {
+            account_user_id: "user-a".to_string(),
+            personal_workspace_id: "user-a".to_string(),
+            workspaces: vec![
+                hypr_db_app::CloudsyncWorkspaceProjectionEntry {
+                    id: "user-a".to_string(),
+                    owner_user_id: "user-a".to_string(),
+                    kind: "personal".to_string(),
+                    name: "Personal".to_string(),
+                    membership_id: "membership-personal".to_string(),
+                    role: "owner".to_string(),
+                    membership_created_at: "2026-07-01T01:00:00Z".to_string(),
+                    membership_updated_at: "2026-07-16T01:00:00Z".to_string(),
+                    created_at: "2026-07-01T00:00:00Z".to_string(),
+                    updated_at: "2026-07-16T00:00:00Z".to_string(),
+                },
+                hypr_db_app::CloudsyncWorkspaceProjectionEntry {
+                    id: "workspace-shared".to_string(),
+                    owner_user_id: "user-b".to_string(),
+                    kind: "shared".to_string(),
+                    name: "Shared".to_string(),
+                    membership_id: "membership-shared".to_string(),
+                    role: "member".to_string(),
+                    membership_created_at: "2026-07-02T01:00:00Z".to_string(),
+                    membership_updated_at: "2026-07-15T01:00:00Z".to_string(),
+                    created_at: "2026-07-02T00:00:00Z".to_string(),
+                    updated_at: "2026-07-15T00:00:00Z".to_string(),
+                },
+            ],
+        };
+
+        assert_eq!(
+            runtime
+                .configure_cloudsync_token_with_projection(
+                    "managed-database-id".to_string(),
+                    "token".to_string(),
+                    "user-a".to_string(),
+                    Some(projection),
+                )
+                .await
+                .unwrap(),
+            CloudsyncTokenConfigurationResult::Configured
+        );
+
+        let workspaces: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, name FROM workspaces ORDER BY id")
+                .fetch_all(runtime.pool())
+                .await
+                .unwrap();
+        let memberships: Vec<(String, String, String)> = sqlx::query_as(
+            "SELECT workspace_id, user_id, role FROM workspace_memberships ORDER BY workspace_id",
+        )
+        .fetch_all(runtime.pool())
+        .await
+        .unwrap();
+
+        assert_eq!(
+            workspaces,
+            vec![
+                ("user-a".to_string(), "Personal".to_string()),
+                ("workspace-shared".to_string(), "Shared".to_string()),
+            ]
+        );
+        assert_eq!(
+            memberships,
+            vec![
+                (
+                    "user-a".to_string(),
+                    "user-a".to_string(),
+                    "owner".to_string(),
+                ),
+                (
+                    "workspace-shared".to_string(),
+                    "user-a".to_string(),
+                    "member".to_string(),
+                ),
+            ]
+        );
+    }
+
+    #[tokio::test]
+    async fn token_configuration_account_mismatch_preserves_workspace_projection() {
+        let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
+        assert!(
+            runtime
+                .bind_cloudsync_account("user-a".to_string())
+                .await
+                .unwrap()
+        );
+        hypr_db_app::replace_cloudsync_workspace_projection(
+            runtime.pool(),
+            &hypr_db_app::CloudsyncWorkspaceProjection {
+                account_user_id: "user-a".to_string(),
+                personal_workspace_id: "user-a".to_string(),
+                workspaces: vec![hypr_db_app::CloudsyncWorkspaceProjectionEntry {
+                    id: "user-a".to_string(),
+                    owner_user_id: "user-a".to_string(),
+                    kind: "personal".to_string(),
+                    name: "Existing".to_string(),
+                    membership_id: "membership-existing".to_string(),
+                    role: "owner".to_string(),
+                    membership_created_at: "2026-07-01T01:00:00Z".to_string(),
+                    membership_updated_at: "2026-07-16T01:00:00Z".to_string(),
+                    created_at: "2026-07-01T00:00:00Z".to_string(),
+                    updated_at: "2026-07-16T00:00:00Z".to_string(),
+                }],
+            },
+        )
+        .await
+        .unwrap();
+
+        let error = runtime
+            .configure_cloudsync_token_with_projection(
+                "managed-database-id".to_string(),
+                "token".to_string(),
+                "user-a".to_string(),
+                Some(hypr_db_app::CloudsyncWorkspaceProjection {
+                    account_user_id: "user-b".to_string(),
+                    personal_workspace_id: "user-b".to_string(),
+                    workspaces: vec![hypr_db_app::CloudsyncWorkspaceProjectionEntry {
+                        id: "user-b".to_string(),
+                        owner_user_id: "user-b".to_string(),
+                        kind: "personal".to_string(),
+                        name: "Replacement".to_string(),
+                        membership_id: "membership-replacement".to_string(),
+                        role: "owner".to_string(),
+                        membership_created_at: "2026-07-01T01:00:00Z".to_string(),
+                        membership_updated_at: "2026-07-16T01:00:00Z".to_string(),
+                        created_at: "2026-07-01T00:00:00Z".to_string(),
+                        updated_at: "2026-07-16T00:00:00Z".to_string(),
+                    }],
+                }),
+            )
+            .await
+            .unwrap_err();
+
+        let workspaces: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, name FROM workspaces ORDER BY id")
+                .fetch_all(runtime.pool())
+                .await
+                .unwrap();
+        assert!(matches!(
+            error,
+            crate::Error::CloudsyncWorkspace(
+                hypr_db_app::CloudsyncWorkspaceError::InvalidWorkspaceProjection
+            )
+        ));
+        assert_eq!(
+            workspaces,
+            vec![("user-a".to_string(), "Existing".to_string())]
+        );
     }
 
     #[tokio::test]

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -934,6 +934,14 @@ mod test {
         .fetch_all(runtime.pool())
         .await
         .unwrap();
+        let writable_workspace_ids: Vec<String> = sqlx::query_scalar(
+            "SELECT allowed_workspace_id
+             FROM cloudsync_writable_workspaces
+             ORDER BY allowed_workspace_id",
+        )
+        .fetch_all(runtime.pool())
+        .await
+        .unwrap();
 
         assert_eq!(
             workspaces,
@@ -957,6 +965,13 @@ mod test {
                 ),
             ]
         );
+        assert_eq!(writable_workspace_ids, vec!["user-a".to_string()]);
+        assert!(
+            hypr_db_app::cloudsync_write_filter_installed(runtime.pool(), "user-a")
+                .await
+                .unwrap()
+        );
+        assert!(runtime.cloudsync_write_filters_match().await.unwrap());
     }
 
     #[tokio::test]

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -8,6 +8,8 @@ use tauri::ipc::Channel;
 use crate::{QueryEvent, Result, TransactionStatement};
 
 const DEFAULT_CLOUDSYNC_INTERVAL_MS: u64 = 30_000;
+const CLOUDSYNC_WRITE_FILTER: &str =
+    "workspace_id IN (SELECT allowed_workspace_id FROM cloudsync_writable_workspaces)";
 
 #[derive(Clone)]
 pub struct QueryEventChannel(Channel<QueryEvent>);
@@ -35,6 +37,7 @@ impl QueryEventSink for QueryEventChannel {
 pub struct PluginDbRuntime {
     db: std::sync::Arc<Db>,
     schema_ready: tokio::sync::OnceCell<()>,
+    synced_write_barrier: tokio::sync::RwLock<()>,
     executor: DbExecutor,
     live_query_runtime: LiveQueryRuntime<QueryEventChannel>,
 }
@@ -44,6 +47,7 @@ impl PluginDbRuntime {
         Self {
             db: std::sync::Arc::clone(&db),
             schema_ready: tokio::sync::OnceCell::new(),
+            synced_write_barrier: tokio::sync::RwLock::new(()),
             executor: DbExecutor::new(std::sync::Arc::clone(&db)),
             live_query_runtime: LiveQueryRuntime::new(db),
         }
@@ -78,6 +82,7 @@ impl PluginDbRuntime {
         sql: String,
         params: Vec<serde_json::Value>,
     ) -> Result<Vec<serde_json::Value>> {
+        let _write_guard = self.synced_write_barrier.read().await;
         self.ensure_app_schema().await?;
         Ok(self.executor.execute(sql, params).await?)
     }
@@ -86,6 +91,7 @@ impl PluginDbRuntime {
         &self,
         statements: Vec<TransactionStatement>,
     ) -> Result<Vec<u64>> {
+        let _write_guard = self.synced_write_barrier.read().await;
         self.ensure_app_schema().await?;
         let mut transaction = self.db.pool().begin_with("BEGIN IMMEDIATE").await?;
         let mut rows_affected = Vec::with_capacity(statements.len());
@@ -120,8 +126,19 @@ impl PluginDbRuntime {
         params: Vec<serde_json::Value>,
         method: ProxyQueryMethod,
     ) -> Result<ProxyQueryResult> {
+        let _write_guard = self.synced_write_barrier.read().await;
         self.ensure_app_schema().await?;
         Ok(self.executor.execute_proxy(sql, params, method).await?)
+    }
+
+    pub async fn cleanup_legacy_files(&self) -> Result<crate::LegacyCleanupResult> {
+        let _write_guard = self.synced_write_barrier.read().await;
+        Ok(crate::import::cleanup_legacy_files(self.db.pool()).await?)
+    }
+
+    pub async fn rerun_legacy_import(&self, dry_run: bool) -> Result<String> {
+        let _write_guard = self.synced_write_barrier.read().await;
+        Ok(crate::import::rerun_legacy_import(self.db.pool(), dry_run).await?)
     }
 
     pub async fn subscribe(
@@ -162,6 +179,11 @@ impl PluginDbRuntime {
         account_user_id: String,
         workspace_projection: Option<hypr_db_app::CloudsyncWorkspaceProjection>,
     ) -> Result<crate::CloudsyncTokenConfigurationResult> {
+        let _reconciliation_guard = if workspace_projection.is_some() {
+            Some(self.synced_write_barrier.write().await)
+        } else {
+            None
+        };
         if !self.db.cloudsync_enabled() {
             return Err(hypr_db_core::CloudsyncRuntimeError::Unavailable.into());
         }
@@ -182,27 +204,138 @@ impl PluginDbRuntime {
             return Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch);
         }
 
-        if let Some(workspace_projection) = workspace_projection {
-            hypr_db_app::replace_cloudsync_workspace_projection(
-                self.db.pool(),
-                &workspace_projection,
-            )
-            .await?;
+        if workspace_projection.is_some() {
+            self.db.cloudsync_suspend().await?;
         }
 
-        self.apply_cloudsync_config_fail_closed(hypr_db_core::CloudsyncRuntimeConfig {
+        let write_filter_version_current = match workspace_projection.as_ref() {
+            Some(_) => hypr_db_app::cloudsync_write_filter_version_current(self.db.pool()).await?,
+            None => true,
+        };
+        let write_filter_installed = match workspace_projection.as_ref() {
+            Some(projection) => {
+                hypr_db_app::cloudsync_write_filter_installed(
+                    self.db.pool(),
+                    &projection.personal_workspace_id,
+                )
+                .await?
+                    && self.cloudsync_write_filters_match().await?
+            }
+            None => true,
+        };
+        let write_filter_requires_reset = if write_filter_installed {
+            false
+        } else {
+            write_filter_version_current || self.cloudsync_has_initialized_tables().await?
+        };
+        let mut install_write_filter = !write_filter_installed;
+
+        let reconciliation = match workspace_projection.as_ref() {
+            Some(projection) => Some(
+                hypr_db_app::stage_cloudsync_workspace_reconciliation(self.db.pool(), projection)
+                    .await?,
+            ),
+            None => None,
+        };
+        let config = hypr_db_core::CloudsyncRuntimeConfig {
             connection_string: database_id,
             auth: hypr_db_core::CloudsyncAuth::Token { token },
             tables: hypr_db_app::cloudsync_table_registry().to_vec(),
             sync_interval_ms: DEFAULT_CLOUDSYNC_INTERVAL_MS,
             wait_ms: Some(5_000),
             max_retries: Some(3),
-        })
-        .await?;
+        };
+
+        if reconciliation
+            .as_ref()
+            .is_some_and(|plan| plan.requires_replica_reset())
+            || write_filter_requires_reset
+        {
+            self.apply_cloudsync_config_fail_closed(config.clone())
+                .await?;
+            match self.db.cloudsync_trigger_sync().await {
+                Ok(result) if cloudsync_send_completed(&result) => {}
+                Ok(_) => {
+                    let _ = self.db.cloudsync_suspend().await;
+                    return Err(hypr_db_core::CloudsyncRuntimeError::UnsentChanges.into());
+                }
+                Err(error) => {
+                    let _ = self.db.cloudsync_suspend().await;
+                    return Err(error.into());
+                }
+            }
+            let status = match self.db.cloudsync_status().await {
+                Ok(status) => status,
+                Err(error) => {
+                    let _ = self.db.cloudsync_suspend().await;
+                    return Err(error.into());
+                }
+            };
+            if status.has_unsent_changes != Some(false) {
+                let _ = self.db.cloudsync_suspend().await;
+                return Err(hypr_db_core::CloudsyncRuntimeError::UnsentChanges.into());
+            }
+            if let Err(error) = self.db.cloudsync_logout(false).await {
+                let _ = self.db.cloudsync_suspend().await;
+                return Err(error.into());
+            }
+            install_write_filter = true;
+        }
+
+        if let Some(projection) = workspace_projection.as_ref()
+            && install_write_filter
+        {
+            hypr_db_app::set_cloudsync_personal_write_scope(
+                self.db.pool(),
+                &projection.personal_workspace_id,
+            )
+            .await?;
+            for table in hypr_db_app::cloudsync_table_registry()
+                .iter()
+                .filter(|table| table.enabled)
+            {
+                self.db
+                    .cloudsync_init(
+                        &table.table_name,
+                        table.crdt_algo.as_deref(),
+                        table.init_flags,
+                    )
+                    .await
+                    .map_err(hypr_db_core::CloudsyncRuntimeError::from)?;
+                self.db
+                    .cloudsync_set_filter(&table.table_name, CLOUDSYNC_WRITE_FILTER)
+                    .await
+                    .map_err(hypr_db_core::CloudsyncRuntimeError::from)?;
+            }
+            hypr_db_app::mark_cloudsync_write_filter_installed(self.db.pool()).await?;
+        }
+
+        if let (Some(projection), Some(reconciliation)) =
+            (workspace_projection.as_ref(), reconciliation.as_ref())
+        {
+            let _ = hypr_db_app::commit_cloudsync_workspace_projection(
+                self.db.pool(),
+                projection,
+                reconciliation.requires_full_resync() || install_write_filter,
+            )
+            .await?;
+        }
+
+        self.apply_cloudsync_config_fail_closed(config).await?;
+        if let Some(generation) =
+            hypr_db_app::cloudsync_full_resync_generation(self.db.pool()).await?
+        {
+            if let Err(error) = self.db.cloudsync_network_reset_sync_version().await {
+                let _ = self.db.cloudsync_suspend().await;
+                return Err(hypr_db_core::CloudsyncRuntimeError::from(error).into());
+            }
+            self.schedule_cloudsync_full_resync(generation);
+        }
         Ok(crate::CloudsyncTokenConfigurationResult::Configured)
     }
 
     pub async fn bind_cloudsync_account(&self, account_user_id: String) -> Result<bool> {
+        let _write_guard = self.synced_write_barrier.write().await;
         self.ensure_app_schema().await?;
         match hypr_db_app::bind_cloudsync_account(self.db.pool(), &account_user_id).await {
             Ok(()) => Ok(true),
@@ -258,6 +391,88 @@ impl PluginDbRuntime {
         Ok(())
     }
 
+    fn schedule_cloudsync_full_resync(&self, generation: String) {
+        let db = std::sync::Arc::clone(&self.db);
+        tokio::spawn(async move {
+            for attempt in 0..3 {
+                match db.cloudsync_trigger_sync().await {
+                    Ok(result) if cloudsync_snapshot_completed(&result) => {
+                        if let Err(error) =
+                            hypr_db_app::clear_cloudsync_full_resync_pending(db.pool(), &generation)
+                                .await
+                        {
+                            tracing::warn!(%error, "failed to clear CloudSync full resync marker");
+                        }
+                        return;
+                    }
+                    Ok(_) if attempt < 2 => {
+                        tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                    }
+                    Ok(_) => {
+                        tracing::warn!("CloudSync full resync remains incomplete");
+                    }
+                    Err(error) => {
+                        tracing::warn!(%error, "CloudSync full resync remains pending");
+                        return;
+                    }
+                }
+            }
+        });
+    }
+
+    async fn cloudsync_has_initialized_tables(&self) -> Result<bool> {
+        for table in hypr_db_app::cloudsync_table_registry()
+            .iter()
+            .filter(|table| table.enabled)
+        {
+            if hypr_db_core::cloudsync_is_enabled_on(self.db.pool(), &table.table_name)
+                .await
+                .map_err(hypr_db_core::CloudsyncRuntimeError::from)?
+            {
+                return Ok(true);
+            }
+        }
+        Ok(false)
+    }
+
+    pub(crate) async fn cloudsync_write_filters_match(&self) -> Result<bool> {
+        let settings_exist: bool = sqlx::query_scalar(
+            "SELECT EXISTS(
+               SELECT 1 FROM sqlite_master
+               WHERE type = 'table' AND name = 'cloudsync_table_settings'
+             )",
+        )
+        .fetch_one(self.db.pool())
+        .await?;
+        if !settings_exist {
+            return Ok(false);
+        }
+
+        for table in hypr_db_app::cloudsync_table_registry()
+            .iter()
+            .filter(|table| table.enabled)
+        {
+            let matches: bool = sqlx::query_scalar(
+                "SELECT EXISTS(
+                   SELECT 1
+                   FROM cloudsync_table_settings
+                   WHERE tbl_name = ? COLLATE NOCASE
+                     AND col_name = '*'
+                     AND key = 'filter'
+                     AND value = ?
+                 )",
+            )
+            .bind(&table.table_name)
+            .bind(CLOUDSYNC_WRITE_FILTER)
+            .fetch_one(self.db.pool())
+            .await?;
+            if !matches {
+                return Ok(false);
+            }
+        }
+        Ok(true)
+    }
+
     pub async fn start_cloudsync(&self) -> Result<()> {
         self.ensure_legacy_migration_verified().await?;
         self.db.cloudsync_start().await?;
@@ -286,9 +501,30 @@ impl PluginDbRuntime {
     }
 
     pub async fn logout_cloudsync(&self, discard_unsent_changes: bool) -> Result<()> {
+        let _write_guard = self.synced_write_barrier.write().await;
         self.db.cloudsync_logout(discard_unsent_changes).await?;
         Ok(())
     }
+}
+
+fn cloudsync_send_completed(result: &hypr_db_core::CloudsyncNetworkResult) -> bool {
+    let Some(send) = result.send.as_ref() else {
+        return false;
+    };
+    let receive_completed = result.receive.as_ref().is_none_or(|receive| {
+        receive.complete && receive.error.is_none() && receive.last_failure.is_none()
+    });
+    send.status == "synced" && send.last_failure.is_none() && receive_completed
+}
+
+fn cloudsync_snapshot_completed(result: &hypr_db_core::CloudsyncNetworkResult) -> bool {
+    let Some(receive) = result.receive.as_ref() else {
+        return false;
+    };
+    cloudsync_send_completed(result)
+        && receive.complete
+        && receive.error.is_none()
+        && receive.last_failure.is_none()
 }
 
 fn is_permanent_cloudsync_workspace_rejection(
@@ -408,6 +644,98 @@ async fn database_uses_cloudsync_schema(db: &Db) -> std::result::Result<bool, sq
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn cloudsync_completion_requires_confirmed_send_and_receive() {
+        let completed: hypr_db_core::CloudsyncNetworkResult =
+            serde_json::from_value(serde_json::json!({
+                "send": {
+                    "status": "synced",
+                    "localVersion": 2,
+                    "serverVersion": 2
+                },
+                "receive": {
+                    "rows": 0,
+                    "tables": [],
+                    "complete": true
+                }
+            }))
+            .unwrap();
+        let unconfirmed_send: hypr_db_core::CloudsyncNetworkResult =
+            serde_json::from_value(serde_json::json!({
+                "send": {
+                    "status": "syncing",
+                    "localVersion": 2,
+                    "serverVersion": 1
+                }
+            }))
+            .unwrap();
+        let incomplete_receive: hypr_db_core::CloudsyncNetworkResult =
+            serde_json::from_value(serde_json::json!({
+                "send": {
+                    "status": "synced",
+                    "localVersion": 2,
+                    "serverVersion": 2
+                },
+                "receive": {
+                    "rows": 1,
+                    "tables": ["sessions"],
+                    "complete": false
+                }
+            }))
+            .unwrap();
+        let send_only: hypr_db_core::CloudsyncNetworkResult =
+            serde_json::from_value(serde_json::json!({
+                "send": {
+                    "status": "synced",
+                    "localVersion": 2,
+                    "serverVersion": 2
+                }
+            }))
+            .unwrap();
+
+        assert!(cloudsync_send_completed(&completed));
+        assert!(cloudsync_snapshot_completed(&completed));
+        assert!(!cloudsync_send_completed(&unconfirmed_send));
+        assert!(!cloudsync_snapshot_completed(&unconfirmed_send));
+        assert!(!cloudsync_send_completed(&incomplete_receive));
+        assert!(!cloudsync_snapshot_completed(&incomplete_receive));
+        assert!(cloudsync_send_completed(&send_only));
+        assert!(!cloudsync_snapshot_completed(&send_only));
+        assert!(!cloudsync_send_completed(
+            &hypr_db_core::CloudsyncNetworkResult::default()
+        ));
+    }
+
+    #[tokio::test]
+    async fn reconciliation_barrier_blocks_renderer_writes() {
+        let db = std::sync::Arc::new(Db::connect_memory_plain().await.unwrap());
+        let runtime = std::sync::Arc::new(PluginDbRuntime::new(db));
+        let guard = runtime.synced_write_barrier.write().await;
+        let write_runtime = std::sync::Arc::clone(&runtime);
+        let mut write = tokio::spawn(async move {
+            write_runtime
+                .execute(
+                    "INSERT INTO sessions (id, title) VALUES ('session', 'Session')".to_string(),
+                    vec![],
+                )
+                .await
+        });
+
+        assert!(
+            tokio::time::timeout(std::time::Duration::from_millis(25), &mut write)
+                .await
+                .is_err()
+        );
+        drop(guard);
+        write.await.unwrap().unwrap();
+
+        let session_count: i64 = sqlx::query_scalar("SELECT COUNT(*) FROM sessions")
+            .fetch_one(runtime.pool())
+            .await
+            .unwrap();
+        assert_eq!(session_count, 1);
+    }
 
     fn unavailable_extension_error() -> DbOpenError {
         DbOpenError::Io(std::io::Error::other("cloudsync extension unavailable"))

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -149,15 +149,45 @@ impl PluginDbRuntime {
         &self,
         database_id: String,
         token: String,
-        workspace_id: String,
+        account_user_id: String,
+    ) -> Result<crate::CloudsyncTokenConfigurationResult> {
+        self.configure_cloudsync_token_with_projection(database_id, token, account_user_id, None)
+            .await
+    }
+
+    pub async fn configure_cloudsync_token_with_projection(
+        &self,
+        database_id: String,
+        token: String,
+        account_user_id: String,
+        workspace_projection: Option<hypr_db_app::CloudsyncWorkspaceProjection>,
     ) -> Result<crate::CloudsyncTokenConfigurationResult> {
         if !self.db.cloudsync_enabled() {
             return Err(hypr_db_core::CloudsyncRuntimeError::Unavailable.into());
         }
+
+        if workspace_projection
+            .as_ref()
+            .is_some_and(|projection| projection.account_user_id != account_user_id)
+        {
+            return Err(hypr_db_app::CloudsyncWorkspaceError::InvalidWorkspaceProjection.into());
+        }
+        if let Some(projection) = workspace_projection.as_ref() {
+            hypr_db_app::validate_cloudsync_workspace_projection(projection)?;
+        }
+
         self.ensure_legacy_migration_verified().await?;
 
-        if !self.claim_cloudsync_workspace(workspace_id).await? {
+        if !self.claim_cloudsync_workspace(account_user_id).await? {
             return Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch);
+        }
+
+        if let Some(workspace_projection) = workspace_projection {
+            hypr_db_app::replace_cloudsync_workspace_projection(
+                self.db.pool(),
+                &workspace_projection,
+            )
+            .await?;
         }
 
         self.apply_cloudsync_config_fail_closed(hypr_db_core::CloudsyncRuntimeConfig {

--- a/supabase/migrations/20260716082318_personal_workspaces.sql
+++ b/supabase/migrations/20260716082318_personal_workspaces.sql
@@ -1,0 +1,149 @@
+CREATE TABLE public.workspaces (
+  id uuid PRIMARY KEY,
+  owner_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  kind text NOT NULL DEFAULT 'personal',
+  name text NOT NULL DEFAULT 'Personal',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  CONSTRAINT workspaces_kind_check CHECK (kind = 'personal'),
+  CONSTRAINT workspaces_personal_identity_check CHECK (id = owner_user_id)
+);
+
+CREATE TABLE public.workspace_memberships (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  role text NOT NULL DEFAULT 'member',
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  CONSTRAINT workspace_memberships_role_check CHECK (
+    role IN ('owner', 'admin', 'member')
+  ),
+  CONSTRAINT workspace_memberships_workspace_user_key UNIQUE (workspace_id, user_id)
+);
+
+CREATE UNIQUE INDEX workspaces_personal_owner_key
+  ON public.workspaces(owner_user_id)
+  WHERE kind = 'personal' AND deleted_at IS NULL;
+
+CREATE INDEX workspace_memberships_user_active_idx
+  ON public.workspace_memberships(user_id, workspace_id)
+  WHERE deleted_at IS NULL;
+
+ALTER TABLE public.workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_memberships ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.workspaces FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON TABLE public.workspace_memberships FROM PUBLIC, anon, authenticated;
+GRANT SELECT ON TABLE public.workspaces TO authenticated;
+GRANT SELECT ON TABLE public.workspace_memberships TO authenticated;
+GRANT ALL ON TABLE public.workspaces TO service_role;
+GRANT ALL ON TABLE public.workspace_memberships TO service_role;
+
+CREATE POLICY workspaces_select_member
+  ON public.workspaces
+  FOR SELECT
+  TO authenticated
+  USING (
+    deleted_at IS NULL
+    AND id IN (
+      SELECT membership.workspace_id
+      FROM public.workspace_memberships AS membership
+      WHERE membership.user_id = (SELECT auth.uid())
+        AND membership.deleted_at IS NULL
+    )
+  );
+
+CREATE POLICY workspaces_service_all
+  ON public.workspaces
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE POLICY workspace_memberships_select_self
+  ON public.workspace_memberships
+  FOR SELECT
+  TO authenticated
+  USING (
+    user_id = (SELECT auth.uid())
+    AND deleted_at IS NULL
+  );
+
+CREATE POLICY workspace_memberships_service_all
+  ON public.workspace_memberships
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+CREATE SCHEMA IF NOT EXISTS private;
+REVOKE ALL ON SCHEMA private FROM PUBLIC, anon, authenticated;
+GRANT USAGE ON SCHEMA private TO supabase_auth_admin;
+
+CREATE OR REPLACE FUNCTION private.handle_new_user_workspace()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF COALESCE(NEW.is_anonymous, false) THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.workspaces (id, owner_user_id, kind)
+  VALUES (NEW.id, NEW.id, 'personal')
+  ON CONFLICT (id) DO UPDATE SET
+    deleted_at = NULL,
+    updated_at = now();
+
+  INSERT INTO public.workspace_memberships (id, workspace_id, user_id, role)
+  VALUES (NEW.id, NEW.id, NEW.id, 'owner')
+  ON CONFLICT (workspace_id, user_id) DO UPDATE SET
+    role = 'owner',
+    deleted_at = NULL,
+    updated_at = now();
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.handle_new_user_workspace() FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.handle_new_user_workspace() TO supabase_auth_admin;
+
+DROP TRIGGER IF EXISTS on_auth_user_workspace_created ON auth.users;
+CREATE TRIGGER on_auth_user_workspace_created
+  AFTER INSERT ON auth.users
+  FOR EACH ROW EXECUTE FUNCTION private.handle_new_user_workspace();
+
+INSERT INTO public.workspaces (
+  id,
+  owner_user_id,
+  kind,
+  name,
+  created_at,
+  updated_at
+)
+SELECT id, id, 'personal', 'Personal', created_at, created_at
+FROM auth.users
+WHERE COALESCE(is_anonymous, false) = false
+ON CONFLICT (id) DO NOTHING;
+
+INSERT INTO public.workspace_memberships (
+  id,
+  workspace_id,
+  user_id,
+  role,
+  created_at,
+  updated_at
+)
+SELECT id, id, id, 'owner', created_at, created_at
+FROM auth.users
+WHERE COALESCE(is_anonymous, false) = false
+ON CONFLICT (workspace_id, user_id) DO UPDATE SET
+  role = 'owner',
+  deleted_at = NULL,
+  updated_at = now();

--- a/supabase/migrations/20260716145904_workspace_invitations.sql
+++ b/supabase/migrations/20260716145904_workspace_invitations.sql
@@ -1,0 +1,755 @@
+CREATE EXTENSION IF NOT EXISTS pgcrypto WITH SCHEMA extensions;
+
+ALTER TABLE public.workspaces
+  DROP CONSTRAINT workspaces_kind_check,
+  DROP CONSTRAINT workspaces_personal_identity_check,
+  ADD CONSTRAINT workspaces_kind_check CHECK (
+    kind IN ('personal', 'shared')
+  ),
+  ADD CONSTRAINT workspaces_identity_check CHECK (
+    (kind = 'personal' AND id = owner_user_id)
+    OR (kind = 'shared' AND id <> owner_user_id)
+  );
+
+CREATE TABLE public.workspace_invitations (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  invitee_email text NOT NULL,
+  invitee_user_id uuid REFERENCES auth.users(id) ON DELETE CASCADE,
+  token_hash bytea NOT NULL,
+  role text NOT NULL DEFAULT 'member',
+  invited_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  revoked_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  expires_at timestamptz NOT NULL,
+  accepted_at timestamptz,
+  revoked_at timestamptz,
+  CONSTRAINT workspace_invitations_email_check CHECK (
+    invitee_email = lower(btrim(invitee_email))
+    AND invitee_email ~ '^[^[:space:]@]+@[^[:space:]@]+$'
+    AND invitee_email !~ '[[:cntrl:]]'
+    AND octet_length(invitee_email) <= 320
+  ),
+  CONSTRAINT workspace_invitations_token_hash_check CHECK (
+    octet_length(token_hash) = 32
+  ),
+  CONSTRAINT workspace_invitations_role_check CHECK (role = 'member'),
+  CONSTRAINT workspace_invitations_state_check CHECK (
+    (accepted_at IS NULL OR (invitee_user_id IS NOT NULL AND revoked_at IS NULL))
+    AND (revoked_at IS NULL OR accepted_at IS NULL)
+    AND (revoked_by_user_id IS NULL OR revoked_at IS NOT NULL)
+  ),
+  CONSTRAINT workspace_invitations_expiry_check CHECK (expires_at > created_at),
+  CONSTRAINT workspace_invitations_token_hash_key UNIQUE (token_hash)
+);
+
+CREATE UNIQUE INDEX workspace_invitations_pending_key
+  ON public.workspace_invitations(workspace_id, invitee_email)
+  WHERE accepted_at IS NULL AND revoked_at IS NULL;
+
+ALTER TABLE public.workspace_invitations ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.workspace_invitations FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.workspace_invitations TO service_role;
+
+CREATE POLICY workspace_invitations_service_all
+  ON public.workspace_invitations
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+DROP TRIGGER IF EXISTS on_auth_user_workspace_converted ON auth.users;
+CREATE TRIGGER on_auth_user_workspace_converted
+  AFTER UPDATE OF is_anonymous ON auth.users
+  FOR EACH ROW
+  WHEN (OLD.is_anonymous IS TRUE AND NEW.is_anonymous IS FALSE)
+  EXECUTE FUNCTION private.handle_new_user_workspace();
+
+DROP POLICY workspace_memberships_select_self ON public.workspace_memberships;
+CREATE POLICY workspace_memberships_select_self
+  ON public.workspace_memberships
+  FOR SELECT
+  TO authenticated
+  USING (
+    COALESCE(((SELECT auth.jwt()) ->> 'is_anonymous')::boolean, false) = false
+    AND user_id = (SELECT auth.uid())
+    AND deleted_at IS NULL
+  );
+
+DROP POLICY workspaces_select_member ON public.workspaces;
+CREATE POLICY workspaces_select_member
+  ON public.workspaces
+  FOR SELECT
+  TO authenticated
+  USING (
+    COALESCE(((SELECT auth.jwt()) ->> 'is_anonymous')::boolean, false) = false
+    AND deleted_at IS NULL
+    AND id IN (
+      SELECT membership.workspace_id
+      FROM public.workspace_memberships AS membership
+      WHERE membership.user_id = (SELECT auth.uid())
+        AND membership.deleted_at IS NULL
+    )
+  );
+
+GRANT USAGE ON SCHEMA private TO authenticated;
+
+CREATE OR REPLACE FUNCTION private.create_workspace_invitation(
+  p_workspace_id uuid,
+  p_invitee_email text
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  invite_token text,
+  invitation_expires_at timestamptz,
+  was_created boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_actor_role text;
+  v_email text := lower(btrim(p_invitee_email));
+  v_existing public.workspace_invitations%ROWTYPE;
+  v_expires_at timestamptz;
+  v_invitation_id uuid;
+  v_invitee_user_id uuid;
+  v_token text;
+BEGIN
+  SELECT membership.role
+  INTO v_actor_role
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND membership.user_id = v_actor_id
+    AND membership.role IN ('owner', 'admin')
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false
+  FOR UPDATE OF workspace;
+
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'workspace invitation operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_email IS NULL
+    OR v_email !~ '^[^[:space:]@]+@[^[:space:]@]+$'
+    OR v_email ~ '[[:cntrl:]]'
+    OR octet_length(v_email) > 320
+  THEN
+    RAISE EXCEPTION 'invalid invitation email'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT auth_user.id
+  INTO v_invitee_user_id
+  FROM auth.users AS auth_user
+  WHERE lower(btrim(auth_user.email)) = v_email
+    AND auth_user.email_confirmed_at IS NOT NULL
+    AND COALESCE(auth_user.is_anonymous, false) = false
+  ORDER BY auth_user.created_at, auth_user.id
+  LIMIT 1;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.workspace_memberships AS membership
+    JOIN auth.users AS member_user
+      ON member_user.id = membership.user_id
+    WHERE membership.workspace_id = p_workspace_id
+      AND membership.deleted_at IS NULL
+      AND lower(btrim(member_user.email)) = v_email
+  ) THEN
+    RAISE EXCEPTION 'workspace invitation not needed'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT invitation.*
+  INTO v_existing
+  FROM public.workspace_invitations AS invitation
+  WHERE invitation.workspace_id = p_workspace_id
+    AND invitation.invitee_email = v_email
+    AND invitation.accepted_at IS NULL
+    AND invitation.revoked_at IS NULL
+  FOR UPDATE;
+
+  IF FOUND AND v_existing.expires_at > now() THEN
+    RETURN QUERY
+    SELECT v_existing.id, NULL::text, v_existing.expires_at, false;
+    RETURN;
+  END IF;
+
+  IF FOUND THEN
+    UPDATE public.workspace_invitations
+    SET
+      revoked_by_user_id = v_actor_id,
+      revoked_at = now(),
+      updated_at = now()
+    WHERE id = v_existing.id;
+  END IF;
+
+  v_token := rtrim(
+    translate(encode(extensions.gen_random_bytes(32), 'base64'), '+/', '-_'),
+    '='
+  );
+  v_expires_at := now() + interval '30 days';
+
+  INSERT INTO public.workspace_invitations (
+    workspace_id,
+    invitee_email,
+    invitee_user_id,
+    token_hash,
+    role,
+    invited_by_user_id,
+    expires_at
+  ) VALUES (
+    p_workspace_id,
+    v_email,
+    v_invitee_user_id,
+    extensions.digest(v_token, 'sha256'),
+    'member',
+    v_actor_id,
+    v_expires_at
+  )
+  RETURNING id INTO v_invitation_id;
+
+  RETURN QUERY
+  SELECT v_invitation_id, v_token, v_expires_at, true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.accept_workspace_invitation(
+  p_invitation_id uuid,
+  p_invite_token text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  membership_id uuid
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_actor_email text;
+  v_invitation public.workspace_invitations%ROWTYPE;
+  v_membership public.workspace_memberships%ROWTYPE;
+BEGIN
+  SELECT lower(btrim(auth_user.email))
+  INTO v_actor_email
+  FROM auth.users AS auth_user
+  WHERE auth_user.id = v_actor_id
+    AND auth_user.email_confirmed_at IS NOT NULL
+    AND COALESCE(auth_user.is_anonymous, false) = false;
+
+  IF v_actor_email IS NULL
+    OR p_invite_token IS NULL
+    OR p_invite_token !~ '^[A-Za-z0-9_-]{43}$'
+  THEN
+    RAISE EXCEPTION 'workspace invitation is invalid or unavailable'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT invitation.*
+  INTO v_invitation
+  FROM public.workspace_invitations AS invitation
+  WHERE invitation.id = p_invitation_id
+    AND invitation.token_hash = extensions.digest(p_invite_token, 'sha256')
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR v_invitation.revoked_at IS NOT NULL
+    OR v_invitation.expires_at <= now()
+    OR v_invitation.invitee_email <> v_actor_email
+    OR (
+      v_invitation.invitee_user_id IS NOT NULL
+      AND v_invitation.invitee_user_id <> v_actor_id
+    )
+    OR NOT EXISTS (
+      SELECT 1
+      FROM public.workspaces AS workspace
+      WHERE workspace.id = v_invitation.workspace_id
+        AND workspace.kind = 'shared'
+        AND workspace.deleted_at IS NULL
+    )
+  THEN
+    RAISE EXCEPTION 'workspace invitation is invalid or unavailable'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT membership.*
+  INTO v_membership
+  FROM public.workspace_memberships AS membership
+  WHERE membership.workspace_id = v_invitation.workspace_id
+    AND membership.user_id = v_actor_id
+  FOR UPDATE;
+
+  IF v_invitation.accepted_at IS NOT NULL THEN
+    IF v_membership.id IS NULL OR v_membership.deleted_at IS NOT NULL THEN
+      RAISE EXCEPTION 'workspace invitation is invalid or unavailable'
+        USING ERRCODE = '22023';
+    END IF;
+
+    RETURN QUERY
+    SELECT v_invitation.workspace_id, v_membership.id;
+    RETURN;
+  END IF;
+
+  IF v_membership.id IS NULL THEN
+    INSERT INTO public.workspace_memberships (
+      workspace_id,
+      user_id,
+      role
+    ) VALUES (
+      v_invitation.workspace_id,
+      v_actor_id,
+      'member'
+    )
+    RETURNING * INTO v_membership;
+  ELSIF v_membership.deleted_at IS NOT NULL THEN
+    IF v_membership.role <> 'member' THEN
+      RAISE EXCEPTION 'workspace invitation is invalid or unavailable'
+        USING ERRCODE = '22023';
+    END IF;
+
+    UPDATE public.workspace_memberships
+    SET
+      deleted_at = NULL,
+      updated_at = now()
+    WHERE id = v_membership.id
+    RETURNING * INTO v_membership;
+  END IF;
+
+  UPDATE public.workspace_invitations
+  SET
+    invitee_user_id = v_actor_id,
+    accepted_at = now(),
+    updated_at = now()
+  WHERE id = v_invitation.id;
+
+  RETURN QUERY
+  SELECT v_invitation.workspace_id, v_membership.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.revoke_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  revoked_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_invitation public.workspace_invitations%ROWTYPE;
+  v_actor_role text;
+  v_revoked_at timestamptz;
+BEGIN
+  SELECT invitation.*
+  INTO v_invitation
+  FROM public.workspace_invitations AS invitation
+  WHERE invitation.id = p_invitation_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'workspace invitation operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT membership.role
+  INTO v_actor_role
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = v_invitation.workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND membership.user_id = v_actor_id
+    AND membership.role IN ('owner', 'admin')
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false;
+
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'workspace invitation operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_invitation.accepted_at IS NOT NULL THEN
+    RAISE EXCEPTION 'accepted invitations require membership revocation'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF v_invitation.revoked_at IS NULL THEN
+    v_revoked_at := now();
+
+    UPDATE public.workspace_invitations
+    SET
+      revoked_by_user_id = v_actor_id,
+      revoked_at = v_revoked_at,
+      updated_at = v_revoked_at
+    WHERE id = v_invitation.id;
+  ELSE
+    v_revoked_at := v_invitation.revoked_at;
+  END IF;
+
+  RETURN QUERY
+  SELECT v_invitation.id, v_revoked_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.revoke_workspace_membership(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  membership_id uuid,
+  revoked_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := auth.uid();
+  v_actor_role text;
+  v_owner_user_id uuid;
+  v_target public.workspace_memberships%ROWTYPE;
+  v_revoked_at timestamptz;
+BEGIN
+  SELECT workspace.owner_user_id, membership.role
+  INTO v_owner_user_id, v_actor_role
+  FROM public.workspaces AS workspace
+  JOIN public.workspace_memberships AS membership
+    ON membership.workspace_id = workspace.id
+  JOIN auth.users AS actor
+    ON actor.id = membership.user_id
+  WHERE workspace.id = p_workspace_id
+    AND workspace.kind = 'shared'
+    AND workspace.deleted_at IS NULL
+    AND membership.user_id = v_actor_id
+    AND membership.role IN ('owner', 'admin')
+    AND membership.deleted_at IS NULL
+    AND actor.email_confirmed_at IS NOT NULL
+    AND COALESCE(actor.is_anonymous, false) = false;
+
+  IF v_actor_role IS NULL THEN
+    RAISE EXCEPTION 'workspace membership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT membership.*
+  INTO v_target
+  FROM public.workspace_memberships AS membership
+  WHERE membership.workspace_id = p_workspace_id
+    AND membership.user_id = p_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR v_target.user_id = v_owner_user_id
+    OR v_target.role = 'owner'
+    OR (v_actor_role = 'admin' AND v_target.role <> 'member')
+  THEN
+    RAISE EXCEPTION 'workspace membership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_target.deleted_at IS NULL THEN
+    v_revoked_at := now();
+
+    UPDATE public.workspace_memberships
+    SET
+      deleted_at = v_revoked_at,
+      updated_at = v_revoked_at
+    WHERE id = v_target.id;
+  ELSE
+    v_revoked_at := v_target.deleted_at;
+  END IF;
+
+  RETURN QUERY
+  SELECT v_target.id, v_revoked_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_workspace_invitations(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  invitee_email text,
+  invitee_user_id uuid,
+  invited_by_user_id uuid,
+  created_at timestamptz,
+  expires_at timestamptz,
+  accepted_at timestamptz,
+  revoked_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    JOIN auth.users AS actor
+      ON actor.id = membership.user_id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.kind = 'shared'
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = auth.uid()
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'workspace invitation operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    invitation.id,
+    invitation.invitee_email,
+    invitation.invitee_user_id,
+    invitation.invited_by_user_id,
+    invitation.created_at,
+    invitation.expires_at,
+    invitation.accepted_at,
+    invitation.revoked_at
+  FROM public.workspace_invitations AS invitation
+  WHERE invitation.workspace_id = p_workspace_id
+  ORDER BY invitation.created_at DESC, invitation.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_workspace_memberships(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  membership_id uuid,
+  user_id uuid,
+  user_email text,
+  role text,
+  created_at timestamptz,
+  deleted_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1
+    FROM public.workspaces AS workspace
+    JOIN public.workspace_memberships AS membership
+      ON membership.workspace_id = workspace.id
+    JOIN auth.users AS actor
+      ON actor.id = membership.user_id
+    WHERE workspace.id = p_workspace_id
+      AND workspace.kind = 'shared'
+      AND workspace.deleted_at IS NULL
+      AND membership.user_id = auth.uid()
+      AND membership.role IN ('owner', 'admin')
+      AND membership.deleted_at IS NULL
+      AND actor.email_confirmed_at IS NOT NULL
+      AND COALESCE(actor.is_anonymous, false) = false
+  ) THEN
+    RAISE EXCEPTION 'workspace membership operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    membership.id,
+    membership.user_id,
+    lower(btrim(member_user.email)),
+    membership.role,
+    membership.created_at,
+    membership.deleted_at
+  FROM public.workspace_memberships AS membership
+  LEFT JOIN auth.users AS member_user
+    ON member_user.id = membership.user_id
+  WHERE membership.workspace_id = p_workspace_id
+  ORDER BY membership.created_at, membership.id;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.create_workspace_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.accept_workspace_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.revoke_workspace_invitation(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.revoke_workspace_membership(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_workspace_invitations(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_workspace_memberships(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.create_workspace_invitation(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.accept_workspace_invitation(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.revoke_workspace_invitation(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.revoke_workspace_membership(uuid, uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_workspace_invitations(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_workspace_memberships(uuid)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_workspace_invitation(
+  p_workspace_id uuid,
+  p_invitee_email text
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  invite_token text,
+  invitation_expires_at timestamptz,
+  was_created boolean
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.create_workspace_invitation(p_workspace_id, p_invitee_email);
+$$;
+
+CREATE OR REPLACE FUNCTION public.accept_workspace_invitation(
+  p_invitation_id uuid,
+  p_invite_token text
+)
+RETURNS TABLE (
+  workspace_id uuid,
+  membership_id uuid
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.accept_workspace_invitation(p_invitation_id, p_invite_token);
+$$;
+
+CREATE OR REPLACE FUNCTION public.revoke_workspace_invitation(
+  p_invitation_id uuid
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  revoked_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.revoke_workspace_invitation(p_invitation_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.revoke_workspace_membership(
+  p_workspace_id uuid,
+  p_user_id uuid
+)
+RETURNS TABLE (
+  membership_id uuid,
+  revoked_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.revoke_workspace_membership(p_workspace_id, p_user_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_workspace_invitations(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  invitation_id uuid,
+  invitee_email text,
+  invitee_user_id uuid,
+  invited_by_user_id uuid,
+  created_at timestamptz,
+  expires_at timestamptz,
+  accepted_at timestamptz,
+  revoked_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.list_workspace_invitations(p_workspace_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_workspace_memberships(
+  p_workspace_id uuid
+)
+RETURNS TABLE (
+  membership_id uuid,
+  user_id uuid,
+  user_email text,
+  role text,
+  created_at timestamptz,
+  deleted_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.list_workspace_memberships(p_workspace_id);
+$$;
+
+REVOKE ALL ON FUNCTION public.create_workspace_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.accept_workspace_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.revoke_workspace_invitation(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.revoke_workspace_membership(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_workspace_invitations(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_workspace_memberships(uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_workspace_invitation(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.accept_workspace_invitation(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.revoke_workspace_invitation(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.revoke_workspace_membership(uuid, uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_workspace_invitations(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_workspace_memberships(uuid)
+  TO authenticated;

--- a/supabase/tests/007-workspace-tenancy.sql
+++ b/supabase/tests/007-workspace-tenancy.sql
@@ -1,0 +1,174 @@
+begin;
+select plan(13);
+
+select tests.create_supabase_user('workspace_owner', 'workspace-owner@example.com');
+select tests.create_supabase_user('workspace_other', 'workspace-other@example.com');
+
+select tests.authenticate_as('workspace_owner');
+
+select results_eq(
+  $$
+    select id
+    from public.workspaces
+    where id = auth.uid()
+      and owner_user_id = auth.uid()
+      and kind = 'personal'
+  $$,
+  array[tests.get_supabase_uid('workspace_owner')],
+  'Signup creates a personal workspace whose id matches the user id'
+);
+
+select results_eq(
+  $$
+    select role
+    from public.workspace_memberships
+    where workspace_id = auth.uid()
+      and user_id = auth.uid()
+  $$,
+  array['owner'::text],
+  'Signup creates the personal workspace owner membership'
+);
+
+select results_eq(
+  $$select count(*) from public.workspaces$$,
+  array[1::bigint],
+  'A user initially sees only their personal workspace'
+);
+
+select results_eq(
+  $$select count(*) from public.workspace_memberships$$,
+  array[1::bigint],
+  'A user initially sees only their own active membership'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.workspaces', 'INSERT')
+    and not has_table_privilege('authenticated', 'public.workspaces', 'UPDATE')
+    and not has_table_privilege('authenticated', 'public.workspaces', 'DELETE'),
+  'Authenticated clients cannot mutate workspaces'
+);
+
+select ok(
+  not has_table_privilege('authenticated', 'public.workspace_memberships', 'INSERT')
+    and not has_table_privilege('authenticated', 'public.workspace_memberships', 'UPDATE')
+    and not has_table_privilege('authenticated', 'public.workspace_memberships', 'DELETE'),
+  'Authenticated clients cannot mutate workspace memberships'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select lives_ok(
+  format(
+    $$
+      update public.workspaces
+      set name = 'Renamed personal workspace', updated_at = now()
+      where id = %L
+    $$,
+    tests.get_supabase_uid('workspace_owner')
+  ),
+  'Service role can mutate workspace authority rows'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('workspace_owner');
+
+select results_eq(
+  $$select name from public.workspaces where id = auth.uid()$$,
+  array['Renamed personal workspace'::text],
+  'The owner can read the updated personal workspace projection'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('workspace_other');
+
+select results_eq(
+  $$select count(*) from public.workspaces$$,
+  array[1::bigint],
+  'Another user cannot read a workspace they have not joined'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+update public.workspace_memberships
+set deleted_at = now(), updated_at = now()
+where user_id = tests.get_supabase_uid('workspace_owner')
+  and workspace_id = tests.get_supabase_uid('workspace_owner');
+
+select tests.clear_authentication();
+select tests.authenticate_as('workspace_owner');
+
+select results_eq(
+  $$select count(*) from public.workspaces$$,
+  array[0::bigint],
+  'A soft-deleted membership immediately hides its workspace'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+update public.workspace_memberships
+set deleted_at = null, updated_at = now()
+where user_id = tests.get_supabase_uid('workspace_owner')
+  and workspace_id = tests.get_supabase_uid('workspace_owner');
+
+select tests.clear_authentication();
+reset role;
+
+select results_eq(
+  $$
+    select count(*)
+    from auth.users AS auth_user
+    where not exists (
+      select 1
+      from public.workspaces AS workspace
+      join public.workspace_memberships AS membership
+        on membership.workspace_id = workspace.id
+      where workspace.id = auth_user.id
+        and workspace.owner_user_id = auth_user.id
+        and workspace.kind = 'personal'
+        and membership.user_id = auth_user.id
+        and membership.role = 'owner'
+    )
+  $$,
+  array[0::bigint],
+  'Every existing auth user has a personal workspace and owner membership'
+);
+
+select tests.create_supabase_user('workspace_delete', 'workspace-delete@example.com');
+create temporary table workspace_delete_user AS
+select tests.get_supabase_uid('workspace_delete') AS id;
+
+delete from auth.users
+where id = (select id from workspace_delete_user);
+
+select results_eq(
+  $$
+    select count(*)
+    from (
+      select id
+      from public.workspaces
+      where id = (select id from workspace_delete_user)
+      union all
+      select id
+      from public.workspace_memberships
+      where user_id = (select id from workspace_delete_user)
+    ) AS workspace_authority_rows
+  $$,
+  array[0::bigint],
+  'Deleting an auth user cascades their personal workspace authority rows'
+);
+
+select ok(
+  to_regprocedure('private.handle_new_user_workspace()') is not null
+    and not has_function_privilege(
+      'authenticated',
+      'private.handle_new_user_workspace()',
+      'EXECUTE'
+    ),
+  'The signup trigger function is private and unavailable to clients'
+);
+
+select * from finish();
+rollback;

--- a/supabase/tests/008-workspace-invitations.sql
+++ b/supabase/tests/008-workspace-invitations.sql
@@ -1,0 +1,821 @@
+begin;
+select plan(36);
+
+select tests.create_supabase_user('invite_owner', 'invite-owner@example.com');
+select tests.create_supabase_user('invite_recipient', 'invite-recipient@example.com');
+select tests.create_supabase_user('invite_other', 'invite-other@example.com');
+
+create temporary table workspace_invitation_test_state (
+  name text primary key,
+  workspace_id uuid,
+  invitation_id uuid,
+  invite_token text,
+  invitation_expires_at timestamptz,
+  membership_id uuid,
+  was_created boolean
+);
+
+grant all on workspace_invitation_test_state to authenticated, service_role;
+
+insert into workspace_invitation_test_state (name, workspace_id)
+values
+  ('shared_workspace', gen_random_uuid()),
+  ('anonymous_user', gen_random_uuid());
+
+insert into auth.users (
+  id,
+  raw_user_meta_data,
+  raw_app_meta_data,
+  is_anonymous,
+  created_at,
+  updated_at
+)
+select
+  workspace_id,
+  jsonb_build_object('test_identifier', 'invite_anonymous'),
+  '{}'::jsonb,
+  true,
+  now(),
+  now()
+from workspace_invitation_test_state
+where name = 'anonymous_user';
+
+select tests.authenticate_as('invite_anonymous');
+
+select results_eq(
+  $$select count(*) from public.workspaces$$,
+  array[0::bigint],
+  'Anonymous Auth users do not receive workspace authority'
+);
+
+select tests.clear_authentication();
+reset role;
+
+update auth.users
+set
+  email = 'invite-converted@example.com',
+  email_confirmed_at = now(),
+  is_anonymous = false,
+  updated_at = now()
+where id = (
+  select workspace_id
+  from workspace_invitation_test_state
+  where name = 'anonymous_user'
+);
+
+select tests.authenticate_as('invite_anonymous');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspaces as workspace
+    join public.workspace_memberships as membership
+      on membership.workspace_id = workspace.id
+    where workspace.id = auth.uid()
+      and workspace.kind = 'personal'
+      and membership.user_id = auth.uid()
+      and membership.role = 'owner'
+      and membership.deleted_at is null
+  $$,
+  array[1::bigint],
+  'Converting an anonymous account provisions its personal workspace'
+);
+
+select tests.clear_authentication();
+reset role;
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('invite_owner'),
+  tests.get_supabase_uid('invite_recipient'),
+  tests.get_supabase_uid('invite_other')
+);
+
+select tests.authenticate_as_service_role();
+
+insert into public.workspaces (id, owner_user_id, kind, name)
+select
+  workspace_id,
+  tests.get_supabase_uid('invite_owner'),
+  'shared',
+  'Invitation test workspace'
+from workspace_invitation_test_state
+where name = 'shared_workspace';
+
+insert into public.workspace_memberships (workspace_id, user_id, role)
+select
+  workspace_id,
+  tests.get_supabase_uid('invite_owner'),
+  'owner'
+from workspace_invitation_test_state
+where name = 'shared_workspace';
+
+select results_eq(
+  $$
+    select kind
+    from public.workspaces
+    where id = (
+      select workspace_id
+      from workspace_invitation_test_state
+      where name = 'shared_workspace'
+    )
+  $$,
+  array['shared'::text],
+  'Trusted service code can provision a shared workspace'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  not has_table_privilege('authenticated', 'public.workspaces', 'INSERT')
+    and not has_table_privilege(
+      'authenticated',
+      'public.workspace_invitations',
+      'SELECT'
+    )
+    and not has_table_privilege(
+      'authenticated',
+      'public.workspace_invitations',
+      'INSERT'
+    )
+    and not has_table_privilege(
+      'authenticated',
+      'public.workspace_invitations',
+      'UPDATE'
+    ),
+  'Clients cannot create shared workspaces or access invitation rows directly'
+);
+
+select ok(
+  has_function_privilege(
+    'authenticated',
+    'public.create_workspace_invitation(uuid,text)',
+    'EXECUTE'
+  )
+    and has_function_privilege(
+      'authenticated',
+      'public.accept_workspace_invitation(uuid,text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'authenticated',
+      'public.revoke_workspace_invitation(uuid)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'authenticated',
+      'public.revoke_workspace_membership(uuid,uuid)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'authenticated',
+      'public.list_workspace_invitations(uuid)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'authenticated',
+      'public.list_workspace_memberships(uuid)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.create_workspace_invitation(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.accept_workspace_invitation(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.revoke_workspace_invitation(uuid)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.revoke_workspace_membership(uuid,uuid)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.list_workspace_invitations(uuid)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'anon',
+      'public.list_workspace_memberships(uuid)',
+      'EXECUTE'
+    ),
+  'Only authenticated clients can execute invitation RPC wrappers'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where (
+      namespace.nspname = 'private'
+      and proc.proname in (
+        'create_workspace_invitation',
+        'accept_workspace_invitation',
+        'revoke_workspace_invitation',
+        'revoke_workspace_membership',
+        'list_workspace_invitations',
+        'list_workspace_memberships'
+      )
+      and (
+        not proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+    )
+    or (
+      namespace.nspname = 'public'
+      and proc.proname in (
+        'create_workspace_invitation',
+        'accept_workspace_invitation',
+        'revoke_workspace_invitation',
+        'revoke_workspace_membership',
+        'list_workspace_invitations',
+        'list_workspace_memberships'
+      )
+      and (
+        proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+    )
+  ),
+  'Privileged implementations are private and every RPC uses an empty search path'
+);
+
+select tests.authenticate_as('invite_owner');
+
+select lives_ok(
+  $$
+    insert into workspace_invitation_test_state (
+      name,
+      invitation_id,
+      invite_token,
+      invitation_expires_at,
+      was_created
+    )
+    select
+      'first_invite',
+      invitation_id,
+      invite_token,
+      invitation_expires_at,
+      was_created
+    from public.create_workspace_invitation(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      ),
+      '  Invite-Recipient@Example.com  '
+    )
+  $$,
+  'An owner can create a pending member invitation'
+);
+
+select results_eq(
+  $$
+    select invitee_email
+    from public.list_workspace_invitations(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      )
+    )
+  $$,
+  array['invite-recipient@example.com'::text],
+  'Invitation email normalization is visible through the safe manager projection'
+);
+
+select ok(
+  (
+    select was_created
+      and length(invite_token) = 43
+      and invitation_expires_at > now() + interval '29 days'
+      and invitation_expires_at <= now() + interval '30 days 1 minute'
+    from workspace_invitation_test_state
+    where name = 'first_invite'
+  ),
+  'The RPC returns a 256-bit URL-safe token once with a finite expiry'
+);
+
+insert into workspace_invitation_test_state (
+  name,
+  invitation_id,
+  invite_token,
+  invitation_expires_at,
+  was_created
+)
+select
+  'duplicate_invite',
+  invitation_id,
+  invite_token,
+  invitation_expires_at,
+  was_created
+from public.create_workspace_invitation(
+  (
+    select workspace_id
+    from workspace_invitation_test_state
+    where name = 'shared_workspace'
+  ),
+  'invite-recipient@example.com'
+);
+
+select ok(
+  (
+    select duplicate.invitation_id = original.invitation_id
+      and duplicate.invite_token is null
+      and not duplicate.was_created
+    from workspace_invitation_test_state as duplicate
+    join workspace_invitation_test_state as original
+      on original.name = 'first_invite'
+    where duplicate.name = 'duplicate_invite'
+  ),
+  'A duplicate pending invite preserves its id and does not rotate its token'
+);
+
+select results_eq(
+  $$
+    select invitee_user_id
+    from public.list_workspace_invitations(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      )
+    )
+  $$,
+  array[tests.get_supabase_uid('invite_recipient')],
+  'An existing recipient account is bound when the invitation is issued'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_workspace_invitation(
+      tests.get_supabase_uid('invite_owner'),
+      'invite-other@example.com'
+    )
+  $$,
+  '42501',
+  'workspace invitation operation not permitted',
+  'Personal workspaces reject workspace invitations'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_other');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_workspace_invitation(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      ),
+      'someone@example.com'
+    )
+  $$,
+  '42501',
+  'workspace invitation operation not permitted',
+  'A nonmember cannot invite someone to a shared workspace'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      ),
+      (
+        select invite_token
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      )
+    )
+  $$,
+  '22023',
+  'workspace invitation is invalid or unavailable',
+  'A valid token cannot be accepted by an account with the wrong email'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_recipient');
+
+select throws_ok(
+  $$
+    select *
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      ),
+      'AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA'
+    )
+  $$,
+  '22023',
+  'workspace invitation is invalid or unavailable',
+  'A recipient cannot accept with the wrong token'
+);
+
+select lives_ok(
+  $$
+    insert into workspace_invitation_test_state (
+      name,
+      workspace_id,
+      membership_id
+    )
+    select
+      'accepted_membership',
+      workspace_id,
+      membership_id
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      ),
+      (
+        select invite_token
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      )
+    )
+  $$,
+  'The intended recipient can atomically accept the invitation'
+);
+
+select results_eq(
+  $$
+    select role
+    from public.workspace_memberships
+    where workspace_id = (
+      select workspace_id
+      from workspace_invitation_test_state
+      where name = 'shared_workspace'
+    )
+      and user_id = auth.uid()
+  $$,
+  array['member'::text],
+  'Acceptance grants only the member role'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspaces
+    where id = (
+      select workspace_id
+      from workspace_invitation_test_state
+      where name = 'shared_workspace'
+    )
+  $$,
+  array[1::bigint],
+  'The accepted shared workspace immediately appears in the recipient projection'
+);
+
+select results_eq(
+  $$
+    select workspace_id, membership_id
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      ),
+      (
+        select invite_token
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      )
+    )
+  $$,
+  $$
+    select workspace_id, membership_id
+    from workspace_invitation_test_state
+    where name = 'accepted_membership'
+  $$,
+  'Repeating acceptance returns the same active membership'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.list_workspace_memberships(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      )
+    )
+  $$,
+  '42501',
+  'workspace membership operation not permitted',
+  'Members cannot enumerate workspace access'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_owner');
+
+select results_eq(
+  $$
+    select user_email
+    from public.list_workspace_memberships(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      )
+    )
+    where role = 'member' and deleted_at is null
+  $$,
+  array['invite-recipient@example.com'::text],
+  'Managers can list active workspace access without exposing auth tables'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.list_workspace_invitations(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      )
+    )
+    where accepted_at is not null and revoked_at is null
+  $$,
+  array[1::bigint],
+  'Managers can see that an invitation was accepted without seeing its token hash'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.revoke_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      )
+    )
+  $$,
+  '22023',
+  'accepted invitations require membership revocation',
+  'Accepted invitations cannot be cancelled as pending invitations'
+);
+
+select lives_ok(
+  $$
+    select *
+    from public.revoke_workspace_membership(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      ),
+      tests.get_supabase_uid('invite_recipient')
+    )
+  $$,
+  'An owner can revoke an active member'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_recipient');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspaces
+    where id = (
+      select workspace_id
+      from workspace_invitation_test_state
+      where name = 'shared_workspace'
+    )
+  $$,
+  array[0::bigint],
+  'Revocation immediately removes the workspace from the member projection'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      ),
+      (
+        select invite_token
+        from workspace_invitation_test_state
+        where name = 'first_invite'
+      )
+    )
+  $$,
+  '22023',
+  'workspace invitation is invalid or unavailable',
+  'An accepted token cannot restore access after membership revocation'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_owner');
+
+select lives_ok(
+  $$
+    insert into workspace_invitation_test_state (
+      name,
+      invitation_id,
+      invite_token,
+      invitation_expires_at,
+      was_created
+    )
+    select
+      'regrant_invite',
+      invitation_id,
+      invite_token,
+      invitation_expires_at,
+      was_created
+    from public.create_workspace_invitation(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      ),
+      'invite-recipient@example.com'
+    )
+  $$,
+  'Regranting access requires a fresh invitation'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_recipient');
+
+select lives_ok(
+  $$
+    update workspace_invitation_test_state
+    set membership_id = accepted.membership_id,
+        workspace_id = accepted.workspace_id
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'regrant_invite'
+      ),
+      (
+        select invite_token
+        from workspace_invitation_test_state
+        where name = 'regrant_invite'
+      )
+    ) as accepted
+    where name = 'regrant_invite'
+  $$,
+  'The recipient can accept the fresh regrant invitation'
+);
+
+select ok(
+  (
+    select regrant.membership_id = original.membership_id
+    from workspace_invitation_test_state as regrant
+    join workspace_invitation_test_state as original
+      on original.name = 'accepted_membership'
+    where regrant.name = 'regrant_invite'
+  ),
+  'A fresh invitation reactivates the existing member row'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_owner');
+
+select lives_ok(
+  $$
+    insert into workspace_invitation_test_state (
+      name,
+      invitation_id,
+      invite_token,
+      invitation_expires_at,
+      was_created
+    )
+    select
+      'cancelled_invite',
+      invitation_id,
+      invite_token,
+      invitation_expires_at,
+      was_created
+    from public.create_workspace_invitation(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      ),
+      'invite-other@example.com'
+    )
+  $$,
+  'An owner can create another pending invitation'
+);
+
+select lives_ok(
+  $$
+    select *
+    from public.revoke_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'cancelled_invite'
+      )
+    )
+  $$,
+  'An owner can cancel a pending invitation'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_other');
+
+select throws_ok(
+  $$
+    select *
+    from public.accept_workspace_invitation(
+      (
+        select invitation_id
+        from workspace_invitation_test_state
+        where name = 'cancelled_invite'
+      ),
+      (
+        select invite_token
+        from workspace_invitation_test_state
+        where name = 'cancelled_invite'
+      )
+    )
+  $$,
+  '22023',
+  'workspace invitation is invalid or unavailable',
+  'A cancelled invitation can never be accepted'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('invite_owner');
+
+select throws_ok(
+  $$
+    select *
+    from public.revoke_workspace_membership(
+      (
+        select workspace_id
+        from workspace_invitation_test_state
+        where name = 'shared_workspace'
+      ),
+      tests.get_supabase_uid('invite_owner')
+    )
+  $$,
+  '42501',
+  'workspace membership operation not permitted',
+  'The canonical owner cannot be revoked'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select octet_length(token_hash)
+    from public.workspace_invitations
+    order by created_at, id
+  $$,
+  array[32, 32, 32]::integer[],
+  'Only fixed-length SHA-256 token digests are stored'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.workspace_invitations
+    where role <> 'member'
+  $$,
+  array[0::bigint],
+  'Invitation acceptance cannot request an elevated workspace role'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  to_regprocedure('public.create_shared_workspace(text)') is null,
+  'Client shared-workspace creation remains disabled pending ownership lifecycle rules'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 14 in a stack** made with GitButler:
- <kbd>&nbsp;14&nbsp;</kbd> #6104
- <kbd>&nbsp;13&nbsp;</kbd> #6103
- <kbd>&nbsp;12&nbsp;</kbd> #6102
- <kbd>&nbsp;11&nbsp;</kbd> #6101
- <kbd>&nbsp;10&nbsp;</kbd> #6100
- <kbd>&nbsp;9&nbsp;</kbd> #6099
- <kbd>&nbsp;8&nbsp;</kbd> #6109
- <kbd>&nbsp;7&nbsp;</kbd> #6108
- <kbd>&nbsp;6&nbsp;</kbd> #6098
- <kbd>&nbsp;5&nbsp;</kbd> #6093
- <kbd>&nbsp;4&nbsp;</kbd> #6092
- <kbd>&nbsp;3&nbsp;</kbd> #6091
- <kbd>&nbsp;2&nbsp;</kbd> #6090
- <kbd>&nbsp;1&nbsp;</kbd> #6089 👈 
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication-adjacent sync token minting, workspace authorization, replica logout/resync, and local data deletion paths—errors could leak access or drop the wrong session data.
> 
> **Overview**
> Introduces **multi-workspace CloudSync tenancy**: the token exchange loads the user’s workspace memberships from Supabase, validates them server-side, embeds allowed `workspace_ids` on the SQLite Cloud token, and returns expanded credentials (`accountUserId`, `personalWorkspaceId`, `workspaces[]`) instead of only a single `workspaceId`.
> 
> The **desktop auth path** accepts full projected credentials (or legacy core-only payloads), forwards workspace metadata into `configureCloudsyncToken`, tightens credential validation, lengthens the exchange timeout, and after successful configuration **drains a local session-eviction queue** (delete session folders via fs-sync, with retries).
> 
> **Local DB and native plugin** add `workspaces` / `workspace_memberships`, eviction and writable-scope tables, reconciliation that stages revoked-workspace session deletions before committing projections, personal-only **CloudSync write filters**, optional replica reset / full resync on membership changes, and a write barrier during reconciliation. Supabase gets matching personal-workspace tables, RLS, and a signup trigger to provision a personal workspace.
> 
> OpenAPI also documents optional transcription **`num_speakers` / `min_speakers` / `max_speakers`** query params on relevant routes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0dd8b329d96a2ab248958e664f5b3fa5e80cd8d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->