### PR TITLE
refactor/anlg-159-attachment-catalog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -6191,6 +6191,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "sha2 0.11.0",
  "specta",
  "tauri-specta",
  "tempfile",

--- a/apps/desktop/src/audio-player/provider.tsx
+++ b/apps/desktop/src/audio-player/provider.tsx
@@ -15,6 +15,8 @@ import WaveSurfer from "wavesurfer.js";
 import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
 
 import { useBillingAccess } from "~/auth/billing-context";
+import { isSessionAudioIdle } from "~/services/audio-retention";
+import { deleteSessionAudio } from "~/session/attachments";
 
 const TIME_UPDATE_STEP_SECONDS = 0.1;
 
@@ -316,9 +318,11 @@ export function AudioPlayerProvider({
 
   const deleteRecordingMutation = useMutation({
     mutationFn: async () => {
-      const result = await fsSyncCommands.audioDelete(sessionId);
-      if (result.status === "error") {
-        throw new Error(result.error);
+      const deleted = await deleteSessionAudio(sessionId, () =>
+        isSessionAudioIdle(sessionId),
+      );
+      if (!deleted) {
+        throw new Error("audio_session_busy");
       }
     },
     onSuccess: () => {

--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -1,13 +1,16 @@
 import { beforeEach, describe, expect, test, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
-  audioDelete: vi.fn(),
+  cleanupDeletedSessionAudio: vi.fn(),
+  deleteLocalSessionAudio: vi.fn(),
   execute: vi.fn(),
   getSessionMode: vi.fn(),
+  live: { loading: false, sessionId: null as string | null },
 }));
 
-vi.mock("@hypr/plugin-fs-sync", () => ({
-  commands: { audioDelete: mocks.audioDelete },
+vi.mock("~/session/attachments", () => ({
+  cleanupDeletedSessionAudio: mocks.cleanupDeletedSessionAudio,
+  deleteLocalSessionAudio: mocks.deleteLocalSessionAudio,
 }));
 
 vi.mock("~/db", () => ({
@@ -16,7 +19,10 @@ vi.mock("~/db", () => ({
 
 vi.mock("~/store/zustand/listener/instance", () => ({
   listenerStore: {
-    getState: () => ({ getSessionMode: mocks.getSessionMode }),
+    getState: () => ({
+      getSessionMode: mocks.getSessionMode,
+      live: mocks.live,
+    }),
   },
 }));
 
@@ -27,11 +33,26 @@ import {
   sessionAudioExpired,
 } from "./audio-retention";
 
+function mockCleanupRows(
+  sessions: Array<{ id: string; created_at: string; has_words: number }>,
+  logicallyDeleted: Array<{ session_id: string }> = [],
+) {
+  mocks.execute.mockImplementation((sql: string) =>
+    Promise.resolve(
+      sql.includes("FROM session_attachments") ? logicallyDeleted : sessions,
+    ),
+  );
+}
+
 describe("audio retention", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.audioDelete.mockResolvedValue({ status: "ok", data: null });
+    mocks.cleanupDeletedSessionAudio.mockResolvedValue(true);
+    mocks.deleteLocalSessionAudio.mockResolvedValue(true);
     mocks.getSessionMode.mockReturnValue("inactive");
+    mocks.live.loading = false;
+    mocks.live.sessionId = null;
+    mockCleanupRows([]);
   });
 
   test("normalizes current and legacy values", () => {
@@ -61,7 +82,7 @@ describe("audio retention", () => {
   });
 
   test("deletes only expired inactive SQLite sessions", async () => {
-    mocks.execute.mockResolvedValueOnce([
+    mockCleanupRows([
       {
         id: "expired",
         created_at: "2026-05-11T23:59:59.999Z",
@@ -87,13 +108,16 @@ describe("audio retention", () => {
       Date.parse("2026-05-13T00:00:00.000Z"),
     );
 
-    expect(mocks.audioDelete).toHaveBeenCalledTimes(1);
-    expect(mocks.audioDelete).toHaveBeenCalledWith("expired");
+    expect(mocks.deleteLocalSessionAudio).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteLocalSessionAudio).toHaveBeenCalledWith(
+      "expired",
+      expect.any(Function),
+    );
     expect(deleted).toEqual(["expired"]);
   });
 
   test("retention none keeps audio until transcript words exist", async () => {
-    mocks.execute.mockResolvedValueOnce([
+    mockCleanupRows([
       {
         id: "unprocessed",
         created_at: "2026-05-13T00:00:00.000Z",
@@ -109,7 +133,10 @@ describe("audio retention", () => {
     await expect(
       cleanupExpiredAudio("none", Date.parse("2026-05-13T00:00:00.000Z")),
     ).resolves.toEqual(["processed"]);
-    expect(mocks.audioDelete).toHaveBeenCalledWith("processed");
+    expect(mocks.deleteLocalSessionAudio).toHaveBeenCalledWith(
+      "processed",
+      expect.any(Function),
+    );
   });
 
   test("deletes processed audio immediately when retention is none", async () => {
@@ -118,7 +145,10 @@ describe("audio retention", () => {
     await expect(
       deleteProcessedAudioForRetention("none", "processed"),
     ).resolves.toBe(true);
-    expect(mocks.audioDelete).toHaveBeenCalledWith("processed");
+    expect(mocks.deleteLocalSessionAudio).toHaveBeenCalledWith(
+      "processed",
+      expect.any(Function),
+    );
   });
 
   test("keeps unprocessed audio when retention is none", async () => {
@@ -127,7 +157,7 @@ describe("audio retention", () => {
     await expect(
       deleteProcessedAudioForRetention("none", "unprocessed"),
     ).resolves.toBe(false);
-    expect(mocks.audioDelete).not.toHaveBeenCalled();
+    expect(mocks.deleteLocalSessionAudio).not.toHaveBeenCalled();
   });
 
   test("skips immediate deletion for retained audio", async () => {
@@ -135,27 +165,26 @@ describe("audio retention", () => {
       deleteProcessedAudioForRetention("oneDay", "processed"),
     ).resolves.toBe(false);
     expect(mocks.execute).not.toHaveBeenCalled();
-    expect(mocks.audioDelete).not.toHaveBeenCalled();
+    expect(mocks.deleteLocalSessionAudio).not.toHaveBeenCalled();
   });
 
-  test("does not scan SQLite when retention is forever", async () => {
+  test("only scans logical deletions when retention is forever", async () => {
     await expect(cleanupExpiredAudio("forever")).resolves.toEqual([]);
-    expect(mocks.execute).not.toHaveBeenCalled();
-    expect(mocks.audioDelete).not.toHaveBeenCalled();
+    expect(mocks.execute).toHaveBeenCalledTimes(1);
+    expect(mocks.deleteLocalSessionAudio).not.toHaveBeenCalled();
   });
 
   test("does not report failed audio deletions as deleted", async () => {
-    mocks.execute.mockResolvedValueOnce([
+    mockCleanupRows([
       {
         id: "expired",
         created_at: "2026-05-01T00:00:00.000Z",
         has_words: 1,
       },
     ]);
-    mocks.audioDelete.mockResolvedValueOnce({
-      status: "error",
-      error: "disk failure",
-    });
+    mocks.deleteLocalSessionAudio.mockRejectedValueOnce(
+      new Error("disk failure"),
+    );
     const consoleError = vi
       .spyOn(console, "error")
       .mockImplementation(() => {});
@@ -165,5 +194,52 @@ describe("audio retention", () => {
     ).resolves.toEqual([]);
     expect(consoleError).toHaveBeenCalled();
     consoleError.mockRestore();
+  });
+
+  test("does not report a device without local audio as deleted", async () => {
+    mockCleanupRows([
+      {
+        id: "remote-only",
+        created_at: "2026-05-01T00:00:00.000Z",
+        has_words: 1,
+      },
+    ]);
+    mocks.deleteLocalSessionAudio.mockResolvedValueOnce(false);
+
+    await expect(
+      cleanupExpiredAudio("oneDay", Date.parse("2026-05-13T00:00:00.000Z")),
+    ).resolves.toEqual([]);
+  });
+
+  test("retries local cleanup for logically deleted audio", async () => {
+    mockCleanupRows([], [{ session_id: "deleted-session" }]);
+
+    await expect(cleanupExpiredAudio("forever")).resolves.toEqual([
+      "deleted-session",
+    ]);
+    expect(mocks.cleanupDeletedSessionAudio).toHaveBeenCalledWith(
+      "deleted-session",
+      expect.any(Function),
+    );
+    expect(mocks.execute.mock.calls[0]![0]).toContain(
+      "COALESCE(local.availability, 'present') != 'absent'",
+    );
+  });
+
+  test("does not clean a remote tombstone while the session is recording", async () => {
+    mockCleanupRows([], [{ session_id: "active-session" }]);
+    mocks.getSessionMode.mockReturnValue("active");
+
+    await expect(cleanupExpiredAudio("forever")).resolves.toEqual([]);
+    expect(mocks.cleanupDeletedSessionAudio).not.toHaveBeenCalled();
+  });
+
+  test("does not clean audio while capture startup is loading", async () => {
+    mockCleanupRows([], [{ session_id: "starting-session" }]);
+    mocks.live.sessionId = "starting-session";
+    mocks.live.loading = true;
+
+    await expect(cleanupExpiredAudio("forever")).resolves.toEqual([]);
+    expect(mocks.cleanupDeletedSessionAudio).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -1,11 +1,13 @@
-import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
-
 import {
   AUDIO_RETENTION_DURATION_MS,
   type AudioRetentionPolicy,
 } from "./audio-retention-policy";
 
 import { liveQueryClient } from "~/db";
+import {
+  cleanupDeletedSessionAudio,
+  deleteLocalSessionAudio,
+} from "~/session/attachments";
 import { listenerStore } from "~/store/zustand/listener/instance";
 
 export const AUDIO_RETENTION_TASK_ID = "audio-retention-cleanup";
@@ -41,6 +43,14 @@ export function sessionAudioExpired(
   return nowMs >= createdAtMs + AUDIO_RETENTION_DURATION_MS[policy];
 }
 
+export function isSessionAudioIdle(sessionId: string) {
+  const state = listenerStore.getState();
+  return (
+    state.getSessionMode(sessionId) === "inactive" &&
+    !(state.live.sessionId === sessionId && state.live.loading)
+  );
+}
+
 async function sessionHasTranscriptWords(sessionId: string): Promise<boolean> {
   const rows = await liveQueryClient.execute<{ has_words: number }>(
     `
@@ -66,7 +76,7 @@ export async function deleteProcessedAudioForRetention(
     return false;
   }
 
-  if (listenerStore.getState().getSessionMode(sessionId) !== "inactive") {
+  if (!isSessionAudioIdle(sessionId)) {
     return false;
   }
 
@@ -75,16 +85,9 @@ export async function deleteProcessedAudioForRetention(
   }
 
   try {
-    const result = await fsSyncCommands.audioDelete(sessionId);
-    if (result.status === "error") {
-      console.error("[audio-retention] failed to delete audio", {
-        sessionId,
-        error: result.error,
-      });
-      return false;
-    }
-
-    return true;
+    return await deleteLocalSessionAudio(sessionId, () =>
+      isSessionAudioIdle(sessionId),
+    );
   } catch (error) {
     console.error("[audio-retention] failed to delete audio", {
       sessionId,
@@ -98,12 +101,12 @@ export async function cleanupExpiredAudio(
   policy: AudioRetentionPolicy,
   nowMs = Date.now(),
 ) {
+  const deletedSessionIds = await cleanupLogicallyDeletedAudio();
   if (policy === "forever") {
-    return [];
+    return deletedSessionIds;
   }
 
   const deletes: Promise<void>[] = [];
-  const deletedSessionIds: string[] = [];
   const sessions = await liveQueryClient.execute<{
     id: string;
     created_at: string;
@@ -126,7 +129,7 @@ export async function cleanupExpiredAudio(
   `);
 
   for (const session of sessions) {
-    if (listenerStore.getState().getSessionMode(session.id) !== "inactive") {
+    if (!isSessionAudioIdle(session.id)) {
       continue;
     }
 
@@ -139,18 +142,11 @@ export async function cleanupExpiredAudio(
     }
 
     deletes.push(
-      fsSyncCommands
-        .audioDelete(session.id)
-        .then((result) => {
-          if (result.status === "error") {
-            console.error("[audio-retention] failed to delete audio", {
-              sessionId: session.id,
-              error: result.error,
-            });
-            return;
+      deleteLocalSessionAudio(session.id, () => isSessionAudioIdle(session.id))
+        .then((deleted) => {
+          if (deleted) {
+            deletedSessionIds.push(session.id);
           }
-
-          deletedSessionIds.push(session.id);
         })
         .catch((error) => {
           console.error("[audio-retention] failed to delete audio", {
@@ -162,6 +158,46 @@ export async function cleanupExpiredAudio(
   }
 
   await Promise.all(deletes);
+
+  return deletedSessionIds;
+}
+
+async function cleanupLogicallyDeletedAudio() {
+  const rows = await liveQueryClient.execute<{ session_id: string }>(`
+    SELECT DISTINCT attachment.session_id
+    FROM session_attachments AS attachment
+    LEFT JOIN attachment_local_state AS local
+      ON local.attachment_id = attachment.id
+    WHERE attachment.source_type = 'session_audio'
+      AND attachment.source_id = 'primary'
+      AND attachment.deleted_at IS NOT NULL
+      AND COALESCE(local.availability, 'present') != 'absent'
+    ORDER BY attachment.session_id
+  `);
+  const deletedSessionIds: string[] = [];
+
+  await Promise.all(
+    rows.map(async ({ session_id: sessionId }) => {
+      if (!isSessionAudioIdle(sessionId)) {
+        return;
+      }
+
+      try {
+        if (
+          await cleanupDeletedSessionAudio(sessionId, () =>
+            isSessionAudioIdle(sessionId),
+          )
+        ) {
+          deletedSessionIds.push(sessionId);
+        }
+      } catch (error) {
+        console.error("[audio-retention] failed to finish audio deletion", {
+          sessionId,
+          error,
+        });
+      }
+    }),
+  );
 
   return deletedSessionIds;
 }

--- a/apps/desktop/src/session/attachments.test.ts
+++ b/apps/desktop/src/session/attachments.test.ts
@@ -1,26 +1,55 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
 const mocks = vi.hoisted(() => ({
+  audioDelete: vi.fn(),
+  audioMetadata: vi.fn(),
+  execute: vi.fn(),
   executeTransaction: vi.fn().mockResolvedValue([0, 1]),
   enqueueDatabaseWrite: vi.fn(
     async (_key: string, write: () => Promise<number[]>) => write(),
   ),
 }));
 
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: {
+    audioDelete: mocks.audioDelete,
+    audioMetadata: mocks.audioMetadata,
+  },
+}));
+
 vi.mock("~/db", () => ({
   executeTransaction: mocks.executeTransaction,
+  liveQueryClient: { execute: mocks.execute },
 }));
 
 vi.mock("~/db/write-queue", () => ({
   enqueueDatabaseWrite: mocks.enqueueDatabaseWrite,
 }));
 
-import { catalogLocalNoteAttachment, sha256Hex } from "./attachments";
+import {
+  catalogLocalNoteAttachment,
+  catalogLocalSessionAudio,
+  cleanupDeletedSessionAudio,
+  deleteLocalSessionAudio,
+  deleteSessionAudio,
+  sha256Hex,
+} from "./attachments";
 
 describe("attachment catalog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mocks.executeTransaction.mockResolvedValue([0, 1]);
+    mocks.execute.mockResolvedValue([{ is_deleted: 1 }]);
+    mocks.audioDelete.mockResolvedValue({ status: "ok", data: true });
+    mocks.audioMetadata.mockResolvedValue({
+      status: "ok",
+      data: {
+        filename: "audio.mp3",
+        contentType: "audio/mpeg",
+        sizeBytes: 84,
+        sha256: "d".repeat(64),
+      },
+    });
   });
 
   it("inherits workspace ownership and stores only a relative local path", async () => {
@@ -114,5 +143,152 @@ describe("attachment catalog", () => {
     await expect(sha256Hex(bytes)).resolves.toBe(
       "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
     );
+  });
+
+  it("catalogs primary audio with a stable logical identity and root-relative path", async () => {
+    await catalogLocalSessionAudio("session-1");
+
+    expect(mocks.audioMetadata).toHaveBeenCalledWith("session-1");
+    const statements = mocks.executeTransaction.mock.calls[0]![0];
+    expect(statements).toHaveLength(3);
+    expect(statements[0].sql).toContain("WHEN session_attachments.sha256 = ?");
+    expect(statements[0].sql).toContain("source_type = 'session_audio'");
+    expect(statements[1].sql).toContain("session.workspace_id");
+    expect(statements[1].params).toEqual([
+      "session-audio:session-1",
+      "audio.mp3",
+      "audio.mp3",
+      "audio/mpeg",
+      84,
+      "d".repeat(64),
+      "session-1",
+      "session-audio:session-1",
+    ]);
+    expect(statements[2].sql).toContain("attachment_local_state");
+    expect(statements[2].sql).toContain("'present'");
+  });
+
+  it("updates the same audio row when the finalized format changes", async () => {
+    mocks.executeTransaction.mockResolvedValue([1, 0]);
+    mocks.audioMetadata.mockResolvedValue({
+      status: "ok",
+      data: {
+        filename: "audio.wav",
+        contentType: "audio/wav",
+        sizeBytes: 128,
+        sha256: "e".repeat(64),
+      },
+    });
+
+    await catalogLocalSessionAudio("session-1");
+
+    const update = mocks.executeTransaction.mock.calls[0]![0][0];
+    expect(update.params).toEqual([
+      "audio.wav",
+      "audio.wav",
+      "audio/wav",
+      128,
+      "e".repeat(64),
+      "e".repeat(64),
+      "session-audio:session-1",
+      "session-1",
+      "session-1",
+    ]);
+  });
+
+  it("keeps canonical metadata when retention deletes only local audio bytes", async () => {
+    await expect(
+      deleteLocalSessionAudio("session-1", () => true),
+    ).resolves.toBe(true);
+    expect(mocks.audioDelete).toHaveBeenCalledWith("session-1");
+    const localState = mocks.executeTransaction.mock.calls[0]![0][0];
+    expect(localState.sql).toContain("attachment_local_state");
+    expect(localState.params).toEqual([
+      "session-audio:session-1",
+      "session-1",
+      "absent",
+    ]);
+    expect(localState.sql).not.toContain("UPDATE session_attachments");
+  });
+
+  it("tombstones logical audio before deleting local bytes", async () => {
+    mocks.executeTransaction.mockResolvedValue([1]);
+
+    await expect(deleteSessionAudio("session-1", () => true)).resolves.toBe(
+      true,
+    );
+
+    expect(mocks.executeTransaction.mock.calls[0]![0][0].params).toEqual([
+      "session-audio:session-1",
+      "session-1",
+    ]);
+    expect(mocks.executeTransaction.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.audioDelete.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.audioDelete.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.executeTransaction.mock.invocationCallOrder[1]!,
+    );
+  });
+
+  it("does not delete bytes when the logical tombstone fails", async () => {
+    mocks.executeTransaction.mockRejectedValueOnce(
+      new Error("database locked"),
+    );
+
+    await expect(deleteSessionAudio("session-1", () => true)).rejects.toThrow(
+      "database locked",
+    );
+    expect(mocks.audioDelete).not.toHaveBeenCalled();
+  });
+
+  it("completes logical deletion when local audio is already absent", async () => {
+    mocks.executeTransaction.mockResolvedValue([1]);
+    mocks.audioDelete.mockResolvedValue({ status: "ok", data: false });
+
+    await expect(deleteSessionAudio("session-1", () => true)).resolves.toBe(
+      true,
+    );
+    expect(mocks.executeTransaction).toHaveBeenCalledTimes(2);
+  });
+
+  it("records local absence when retention finds no local audio", async () => {
+    mocks.audioDelete.mockResolvedValue({ status: "ok", data: false });
+
+    await expect(
+      deleteLocalSessionAudio("session-1", () => true),
+    ).resolves.toBe(false);
+    expect(mocks.executeTransaction.mock.calls[0]![0][0].params).toEqual([
+      "session-audio:session-1",
+      "session-1",
+      "absent",
+    ]);
+  });
+
+  it("revalidates a logical tombstone before retrying file cleanup", async () => {
+    await expect(
+      cleanupDeletedSessionAudio("session-1", () => true),
+    ).resolves.toBe(true);
+    expect(mocks.execute).toHaveBeenCalledWith(
+      expect.stringMatching(
+        /deleted_at IS NOT NULL[\s\S]*attachment_local_state[\s\S]*availability = 'absent'/,
+      ),
+      ["session-audio:session-1", "session-1"],
+    );
+    expect(mocks.audioDelete).toHaveBeenCalledWith("session-1");
+
+    vi.clearAllMocks();
+    mocks.execute.mockResolvedValue([{ is_deleted: 0 }]);
+    await expect(
+      cleanupDeletedSessionAudio("session-1", () => true),
+    ).resolves.toBe(false);
+    expect(mocks.audioDelete).not.toHaveBeenCalled();
+  });
+
+  it("rechecks capture safety inside the serialized delete operation", async () => {
+    await expect(deleteSessionAudio("session-1", () => false)).resolves.toBe(
+      false,
+    );
+    expect(mocks.executeTransaction).not.toHaveBeenCalled();
+    expect(mocks.audioDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/desktop/src/session/attachments.test.ts
+++ b/apps/desktop/src/session/attachments.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  executeTransaction: vi.fn().mockResolvedValue([0, 1]),
+  enqueueDatabaseWrite: vi.fn(
+    async (_key: string, write: () => Promise<number[]>) => write(),
+  ),
+}));
+
+vi.mock("~/db", () => ({
+  executeTransaction: mocks.executeTransaction,
+}));
+
+vi.mock("~/db/write-queue", () => ({
+  enqueueDatabaseWrite: mocks.enqueueDatabaseWrite,
+}));
+
+import { catalogLocalNoteAttachment, sha256Hex } from "./attachments";
+
+describe("attachment catalog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.executeTransaction.mockResolvedValue([0, 1]);
+  });
+
+  it("inherits workspace ownership and stores only a relative local path", async () => {
+    await catalogLocalNoteAttachment({
+      sessionId: "session-1",
+      attachmentId: "diagram 1.png",
+      filename: "diagram.png",
+      contentType: "image/png",
+      sizeBytes: 42,
+      sha256: "a".repeat(64),
+    });
+
+    expect(mocks.enqueueDatabaseWrite).toHaveBeenCalledWith(
+      "session:session-1",
+      expect.any(Function),
+    );
+    const statements = mocks.executeTransaction.mock.calls[0]![0];
+    expect(statements).toHaveLength(2);
+    expect(statements[1].sql).toContain("session.workspace_id");
+    expect(statements[1].sql).toContain("session.deleted_at IS NULL");
+    expect(statements[1].sql).not.toContain("/vault/");
+    expect(statements[1].params).toEqual([
+      expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+      ),
+      "diagram.png",
+      "attachments/diagram 1.png",
+      "image/png",
+      42,
+      "a".repeat(64),
+      "diagram 1.png",
+      "session-1",
+      "attachments/diagram 1.png",
+    ]);
+  });
+
+  it("updates an existing physical attachment without creating a duplicate", async () => {
+    mocks.executeTransaction.mockResolvedValue([1, 0]);
+
+    await expect(
+      catalogLocalNoteAttachment({
+        sessionId: "session-1",
+        attachmentId: "diagram.png",
+        filename: "diagram.png",
+        contentType: "image/png",
+        sizeBytes: 42,
+        sha256: "b".repeat(64),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("rejects missing or deleted sessions and unsafe attachment IDs", async () => {
+    mocks.executeTransaction.mockResolvedValue([0, 0]);
+    await expect(
+      catalogLocalNoteAttachment({
+        sessionId: "missing-session",
+        attachmentId: "diagram.png",
+        filename: "diagram.png",
+        contentType: "image/png",
+        sizeBytes: 42,
+        sha256: "c".repeat(64),
+      }),
+    ).rejects.toThrow("session is unavailable");
+
+    await expect(
+      catalogLocalNoteAttachment({
+        sessionId: "session-1",
+        attachmentId: "../diagram.png",
+        filename: "diagram.png",
+        contentType: "image/png",
+        sizeBytes: 42,
+        sha256: "c".repeat(64),
+      }),
+    ).rejects.toThrow("attachment ID");
+
+    await expect(
+      catalogLocalNoteAttachment({
+        sessionId: "session-1",
+        attachmentId: "diagram.png",
+        filename: "/vault/private/diagram.png",
+        contentType: "image/png",
+        sizeBytes: 42,
+        sha256: "c".repeat(64),
+      }),
+    ).rejects.toThrow("attachment filename");
+  });
+
+  it("computes a stable lowercase SHA-256 checksum", async () => {
+    const bytes = new TextEncoder().encode("hello").buffer;
+
+    await expect(sha256Hex(bytes)).resolves.toBe(
+      "2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824",
+    );
+  });
+});

--- a/apps/desktop/src/session/attachments.ts
+++ b/apps/desktop/src/session/attachments.ts
@@ -1,4 +1,8 @@
-import { executeTransaction } from "~/db";
+import { commands as fsSyncCommands } from "@hypr/plugin-fs-sync";
+
+import { enqueueSessionAudioOperation } from "./audio-operations";
+
+import { executeTransaction, liveQueryClient } from "~/db";
 import { enqueueDatabaseWrite } from "~/db/write-queue";
 import { id } from "~/shared/utils";
 
@@ -134,6 +138,284 @@ export async function catalogLocalNoteAttachment(input: {
   if ((results[0] ?? 0) + (results[1] ?? 0) !== 1) {
     throw new Error("attachment session is unavailable");
   }
+}
+
+export async function catalogLocalSessionAudio(
+  inputSessionId: string,
+): Promise<void> {
+  const sessionId = requireText(inputSessionId, "session ID", 512);
+  await enqueueDatabaseWrite(`session:${sessionId}`, async () => {
+    const result = await fsSyncCommands.audioMetadata(sessionId);
+    if (result.status === "error") {
+      throw new Error(result.error);
+    }
+    if (!result.data) {
+      throw new Error("audio_path_not_found");
+    }
+
+    const filename = requireBasename(result.data.filename, "audio filename");
+    const contentType = requireText(
+      result.data.contentType,
+      "audio content type",
+      512,
+    );
+    if (
+      !Number.isSafeInteger(result.data.sizeBytes) ||
+      result.data.sizeBytes < 0
+    ) {
+      throw new Error("invalid audio size");
+    }
+    if (!SHA256_PATTERN.test(result.data.sha256)) {
+      throw new Error("invalid audio checksum");
+    }
+
+    const attachmentId = `session-audio:${sessionId}`;
+    const results = await executeTransaction([
+      {
+        sql: `
+          UPDATE session_attachments
+          SET
+            filename = ?,
+            relative_path = ?,
+            content_type = ?,
+            size_bytes = ?,
+            cloud_object_key = CASE
+              WHEN session_attachments.sha256 = ? THEN cloud_object_key
+              ELSE ''
+            END,
+            sha256 = ?,
+            storage_kind = 'local_file',
+            source_type = 'session_audio',
+            source_id = 'primary',
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+            deleted_at = NULL
+          WHERE id = ?
+            AND session_id = ?
+            AND EXISTS (
+              SELECT 1
+              FROM sessions AS session
+              WHERE session.id = ?
+                AND session.deleted_at IS NULL
+            )
+        `,
+        params: [
+          filename,
+          filename,
+          contentType,
+          result.data.sizeBytes,
+          result.data.sha256,
+          result.data.sha256,
+          attachmentId,
+          sessionId,
+          sessionId,
+        ],
+      },
+      {
+        sql: `
+          INSERT INTO session_attachments (
+            id,
+            workspace_id,
+            session_id,
+            filename,
+            relative_path,
+            content_type,
+            size_bytes,
+            sha256,
+            storage_kind,
+            cloud_object_key,
+            source_type,
+            source_id,
+            metadata_json
+          )
+          SELECT
+            ?,
+            session.workspace_id,
+            session.id,
+            ?,
+            ?,
+            ?,
+            ?,
+            ?,
+            'local_file',
+            '',
+            'session_audio',
+            'primary',
+            '{}'
+          FROM sessions AS session
+          WHERE session.id = ?
+            AND session.deleted_at IS NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM session_attachments AS attachment
+              WHERE attachment.id = ?
+            )
+        `,
+        params: [
+          attachmentId,
+          filename,
+          filename,
+          contentType,
+          result.data.sizeBytes,
+          result.data.sha256,
+          sessionId,
+          attachmentId,
+        ],
+      },
+      {
+        sql: `
+          INSERT INTO attachment_local_state (
+            attachment_id,
+            session_id,
+            relative_path,
+            availability,
+            updated_at
+          )
+          SELECT
+            attachment.id,
+            attachment.session_id,
+            attachment.relative_path,
+            'present',
+            strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          FROM session_attachments AS attachment
+          WHERE attachment.id = ?
+            AND attachment.session_id = ?
+            AND attachment.deleted_at IS NULL
+          ON CONFLICT(attachment_id) DO UPDATE SET
+            session_id = excluded.session_id,
+            relative_path = excluded.relative_path,
+            availability = excluded.availability,
+            updated_at = excluded.updated_at
+        `,
+        params: [attachmentId, sessionId],
+      },
+    ]);
+
+    if ((results[0] ?? 0) + (results[1] ?? 0) !== 1) {
+      throw new Error("audio session is unavailable");
+    }
+  });
+}
+
+export async function deleteLocalSessionAudio(
+  inputSessionId: string,
+  canDelete: () => boolean,
+): Promise<boolean> {
+  return deleteSessionAudioWithMode(inputSessionId, false, canDelete);
+}
+
+export async function deleteSessionAudio(
+  inputSessionId: string,
+  canDelete: () => boolean,
+): Promise<boolean> {
+  return deleteSessionAudioWithMode(inputSessionId, true, canDelete);
+}
+
+export async function cleanupDeletedSessionAudio(
+  inputSessionId: string,
+  canDelete: () => boolean,
+): Promise<boolean> {
+  const sessionId = requireText(inputSessionId, "session ID", 512);
+  return enqueueSessionAudioOperation(sessionId, () =>
+    enqueueDatabaseWrite(`session:${sessionId}`, async () => {
+      if (!canDelete()) {
+        return false;
+      }
+
+      const rows = await liveQueryClient.execute<{ is_deleted: number }>(
+        `
+          SELECT EXISTS(
+            SELECT 1
+            FROM session_attachments
+            WHERE id = ?
+              AND session_id = ?
+              AND deleted_at IS NOT NULL
+              AND NOT EXISTS (
+                SELECT 1
+                FROM attachment_local_state AS local
+                WHERE local.attachment_id = session_attachments.id
+                  AND local.availability = 'absent'
+              )
+          ) AS is_deleted
+        `,
+        [`session-audio:${sessionId}`, sessionId],
+      );
+      if (rows[0]?.is_deleted !== 1) {
+        return false;
+      }
+
+      return deleteSessionAudioFile(sessionId);
+    }),
+  );
+}
+
+async function deleteSessionAudioWithMode(
+  inputSessionId: string,
+  deleteMetadata: boolean,
+  canDelete: () => boolean,
+): Promise<boolean> {
+  const sessionId = requireText(inputSessionId, "session ID", 512);
+  return enqueueSessionAudioOperation(sessionId, () =>
+    enqueueDatabaseWrite(`session:${sessionId}`, async () => {
+      if (!canDelete()) {
+        return false;
+      }
+      if (deleteMetadata) {
+        await tombstoneSessionAudioMetadata(sessionId);
+      }
+      const deletedLocalFile = await deleteSessionAudioFile(sessionId);
+      return deleteMetadata || deletedLocalFile;
+    }),
+  );
+}
+
+async function deleteSessionAudioFile(sessionId: string): Promise<boolean> {
+  const result = await fsSyncCommands.audioDelete(sessionId);
+  if (result.status === "error") {
+    throw new Error(result.error);
+  }
+  await markSessionAudioAvailability(sessionId, "absent");
+  return result.data;
+}
+
+async function markSessionAudioAvailability(
+  sessionId: string,
+  availability: "present" | "absent",
+): Promise<void> {
+  await executeTransaction([
+    {
+      sql: `
+        INSERT INTO attachment_local_state (
+          attachment_id,
+          session_id,
+          relative_path,
+          availability,
+          updated_at
+        ) VALUES (?, ?, '', ?, strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+        ON CONFLICT(attachment_id) DO UPDATE SET
+          session_id = excluded.session_id,
+          availability = excluded.availability,
+          updated_at = excluded.updated_at
+      `,
+      params: [`session-audio:${sessionId}`, sessionId, availability],
+    },
+  ]);
+}
+
+async function tombstoneSessionAudioMetadata(sessionId: string): Promise<void> {
+  await executeTransaction([
+    {
+      sql: `
+        UPDATE session_attachments
+        SET
+          updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+          deleted_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+        WHERE id = ?
+          AND session_id = ?
+          AND deleted_at IS NULL
+      `,
+      params: [`session-audio:${sessionId}`, sessionId],
+    },
+  ]);
 }
 
 export async function sha256Hex(bytes: ArrayBuffer): Promise<string> {

--- a/apps/desktop/src/session/attachments.ts
+++ b/apps/desktop/src/session/attachments.ts
@@ -1,0 +1,176 @@
+import { executeTransaction } from "~/db";
+import { enqueueDatabaseWrite } from "~/db/write-queue";
+import { id } from "~/shared/utils";
+
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
+export async function catalogLocalNoteAttachment(input: {
+  sessionId: string;
+  attachmentId: string;
+  filename: string;
+  contentType: string;
+  sizeBytes: number;
+  sha256: string;
+}): Promise<void> {
+  const sessionId = requireText(input.sessionId, "session ID", 512);
+  const attachmentId = requireBasename(input.attachmentId, "attachment ID");
+  const filename = requireBasename(input.filename, "attachment filename");
+  const contentType = requireText(
+    input.contentType,
+    "attachment content type",
+    512,
+    true,
+  );
+  if (!Number.isSafeInteger(input.sizeBytes) || input.sizeBytes < 0) {
+    throw new Error("invalid attachment size");
+  }
+  if (!SHA256_PATTERN.test(input.sha256)) {
+    throw new Error("invalid attachment checksum");
+  }
+
+  const relativePath = `attachments/${attachmentId}`;
+  const metadataId = id();
+  const results = await enqueueDatabaseWrite(`session:${sessionId}`, () =>
+    executeTransaction([
+      {
+        sql: `
+          UPDATE session_attachments
+          SET
+            filename = ?,
+            content_type = ?,
+            size_bytes = ?,
+            cloud_object_key = CASE
+              WHEN session_attachments.sha256 = ? THEN cloud_object_key
+              ELSE ''
+            END,
+            sha256 = ?,
+            storage_kind = 'local_file',
+            source_type = 'note_upload',
+            source_id = ?,
+            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
+            deleted_at = NULL
+          WHERE id = (
+            SELECT attachment.id
+            FROM session_attachments AS attachment
+            JOIN sessions AS session
+              ON session.id = attachment.session_id
+              AND session.deleted_at IS NULL
+            WHERE attachment.session_id = ?
+              AND attachment.relative_path = ?
+            ORDER BY attachment.deleted_at IS NULL DESC,
+              attachment.updated_at DESC,
+              attachment.id
+            LIMIT 1
+          )
+        `,
+        params: [
+          filename,
+          contentType,
+          input.sizeBytes,
+          input.sha256,
+          input.sha256,
+          attachmentId,
+          sessionId,
+          relativePath,
+        ],
+      },
+      {
+        sql: `
+          INSERT INTO session_attachments (
+            id,
+            workspace_id,
+            session_id,
+            filename,
+            relative_path,
+            content_type,
+            size_bytes,
+            sha256,
+            storage_kind,
+            cloud_object_key,
+            source_type,
+            source_id,
+            metadata_json
+          )
+          SELECT
+            ?,
+            session.workspace_id,
+            session.id,
+            ?,
+            ?,
+            ?,
+            ?,
+            ?,
+            'local_file',
+            '',
+            'note_upload',
+            ?,
+            '{}'
+          FROM sessions AS session
+          WHERE session.id = ?
+            AND session.deleted_at IS NULL
+            AND NOT EXISTS (
+              SELECT 1
+              FROM session_attachments AS attachment
+              WHERE attachment.session_id = session.id
+                AND attachment.relative_path = ?
+                AND attachment.deleted_at IS NULL
+            )
+        `,
+        params: [
+          metadataId,
+          filename,
+          relativePath,
+          contentType,
+          input.sizeBytes,
+          input.sha256,
+          attachmentId,
+          sessionId,
+          relativePath,
+        ],
+      },
+    ]),
+  );
+
+  if ((results[0] ?? 0) + (results[1] ?? 0) !== 1) {
+    throw new Error("attachment session is unavailable");
+  }
+}
+
+export async function sha256Hex(bytes: ArrayBuffer): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", bytes);
+  return Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+function requireBasename(value: unknown, label: string) {
+  const basename = requireText(value, label, 1024);
+  if (
+    basename === "." ||
+    basename === ".." ||
+    basename.includes("/") ||
+    basename.includes("\\") ||
+    basename.includes("\0")
+  ) {
+    throw new Error(`invalid ${label}`);
+  }
+  return basename;
+}
+
+function requireText(
+  value: unknown,
+  label: string,
+  maxLength: number,
+  allowEmpty = false,
+) {
+  if (
+    typeof value !== "string" ||
+    (!allowEmpty && value.length === 0) ||
+    value.length > maxLength ||
+    value.trim() !== value ||
+    /[\u0000-\u001f\u007f]/.test(value)
+  ) {
+    throw new Error(`invalid ${label}`);
+  }
+  return value;
+}

--- a/apps/desktop/src/session/audio-operations.test.ts
+++ b/apps/desktop/src/session/audio-operations.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { enqueueSessionAudioOperation } from "./audio-operations";
+
+describe("session audio operations", () => {
+  it("serializes operations for the same session after failures", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const calls: string[] = [];
+    const first = enqueueSessionAudioOperation("session-1", async () => {
+      calls.push("first:start");
+      await new Promise<void>((resolve) => {
+        releaseFirst = resolve;
+      });
+      calls.push("first:end");
+      throw new Error("failed");
+    });
+    const secondOperation = vi.fn(async () => {
+      calls.push("second");
+    });
+    const second = enqueueSessionAudioOperation("session-1", secondOperation);
+
+    await vi.waitFor(() => expect(releaseFirst).toBeTypeOf("function"));
+    expect(secondOperation).not.toHaveBeenCalled();
+    releaseFirst?.();
+
+    await expect(first).rejects.toThrow("failed");
+    await expect(second).resolves.toBeUndefined();
+    expect(calls).toEqual(["first:start", "first:end", "second"]);
+  });
+
+  it("does not block a different session", async () => {
+    let releaseFirst: (() => void) | undefined;
+    const first = enqueueSessionAudioOperation(
+      "session-1",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseFirst = resolve;
+        }),
+    );
+
+    await expect(
+      enqueueSessionAudioOperation("session-2", async () => "ready"),
+    ).resolves.toBe("ready");
+    releaseFirst?.();
+    await first;
+  });
+});

--- a/apps/desktop/src/session/audio-operations.ts
+++ b/apps/desktop/src/session/audio-operations.ts
@@ -1,0 +1,22 @@
+const tails = new Map<string, Promise<unknown>>();
+
+export function enqueueSessionAudioOperation<T>(
+  sessionId: string,
+  operation: () => Promise<T>,
+): Promise<T> {
+  const previous = tails.get(sessionId) ?? Promise.resolve();
+  const next = previous.catch(() => {}).then(operation);
+
+  tails.set(sessionId, next);
+  next.then(
+    () => finishOperation(sessionId, next),
+    () => finishOperation(sessionId, next),
+  );
+  return next;
+}
+
+function finishOperation(sessionId: string, operation: Promise<unknown>) {
+  if (tails.get(sessionId) === operation) {
+    tails.delete(sessionId);
+  }
+}

--- a/apps/desktop/src/shared/hooks/useFileUpload.test.tsx
+++ b/apps/desktop/src/shared/hooks/useFileUpload.test.tsx
@@ -1,0 +1,107 @@
+import { act, renderHook } from "@testing-library/react";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  attachmentRemove: vi.fn(),
+  attachmentSave: vi.fn(),
+  catalogLocalNoteAttachment: vi.fn(),
+  convertFileSrc: vi.fn((path: string) => `asset:${path}`),
+  sha256Hex: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  convertFileSrc: mocks.convertFileSrc,
+}));
+
+vi.mock("@hypr/plugin-fs-sync", () => ({
+  commands: {
+    attachmentRemove: mocks.attachmentRemove,
+    attachmentSave: mocks.attachmentSave,
+  },
+}));
+
+vi.mock("~/session/attachments", () => ({
+  catalogLocalNoteAttachment: mocks.catalogLocalNoteAttachment,
+  sha256Hex: mocks.sha256Hex,
+}));
+
+import { useFileUpload } from "./useFileUpload";
+
+function uploadFile() {
+  const bytes = new TextEncoder().encode("image bytes").buffer;
+  return {
+    name: "diagram.png",
+    type: "image/png",
+    size: bytes.byteLength,
+    arrayBuffer: vi.fn().mockResolvedValue(bytes),
+  } as unknown as File;
+}
+
+describe("useFileUpload", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.sha256Hex.mockResolvedValue("a".repeat(64));
+    mocks.attachmentSave.mockResolvedValue({
+      status: "ok",
+      data: {
+        path: "/vault/sessions/session-1/attachments/diagram 1.png",
+        attachmentId: "diagram 1.png",
+      },
+    });
+    mocks.attachmentRemove.mockResolvedValue({ status: "ok", data: null });
+    mocks.catalogLocalNoteAttachment.mockResolvedValue(undefined);
+  });
+
+  it("hashes, saves, and catalogs the final physical attachment before returning", async () => {
+    const file = uploadFile();
+    const { result } = renderHook(() => useFileUpload("session-1"));
+    let uploaded: Awaited<ReturnType<typeof result.current>> | undefined;
+
+    await act(async () => {
+      uploaded = await result.current(file);
+    });
+
+    expect(uploaded).toEqual({
+      path: "/vault/sessions/session-1/attachments/diagram 1.png",
+      attachmentId: "diagram 1.png",
+      url: "asset:/vault/sessions/session-1/attachments/diagram 1.png",
+    });
+    expect(mocks.catalogLocalNoteAttachment).toHaveBeenCalledWith({
+      sessionId: "session-1",
+      attachmentId: "diagram 1.png",
+      filename: "diagram.png",
+      contentType: "image/png",
+      sizeBytes: 11,
+      sha256: "a".repeat(64),
+    });
+    expect(mocks.sha256Hex.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.attachmentSave.mock.invocationCallOrder[0]!,
+    );
+    expect(mocks.attachmentSave.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.catalogLocalNoteAttachment.mock.invocationCallOrder[0]!,
+    );
+  });
+
+  it("removes the exact newly saved file when catalog persistence fails", async () => {
+    const catalogError = new Error("catalog unavailable");
+    mocks.catalogLocalNoteAttachment.mockRejectedValue(catalogError);
+    const { result } = renderHook(() => useFileUpload("session-1"));
+
+    await expect(result.current(uploadFile())).rejects.toBe(catalogError);
+    expect(mocks.attachmentRemove).toHaveBeenCalledWith(
+      "session-1",
+      "diagram 1.png",
+    );
+  });
+
+  it("does not write a file when checksum generation fails", async () => {
+    mocks.sha256Hex.mockRejectedValue(new Error("checksum unavailable"));
+    const { result } = renderHook(() => useFileUpload("session-1"));
+
+    await expect(result.current(uploadFile())).rejects.toThrow(
+      "checksum unavailable",
+    );
+    expect(mocks.attachmentSave).not.toHaveBeenCalled();
+    expect(mocks.catalogLocalNoteAttachment).not.toHaveBeenCalled();
+  });
+});

--- a/apps/desktop/src/shared/hooks/useFileUpload.ts
+++ b/apps/desktop/src/shared/hooks/useFileUpload.ts
@@ -6,6 +6,8 @@ import {
   commands as fsSyncCommands,
 } from "@hypr/plugin-fs-sync";
 
+import { catalogLocalNoteAttachment, sha256Hex } from "~/session/attachments";
+
 export type FileUploadResult = AttachmentSaveResult & {
   url: string;
 };
@@ -15,6 +17,7 @@ export function useFileUpload(sessionId: string) {
     async (file: File): Promise<FileUploadResult> => {
       const filename = file.name;
       const arrayBuffer = await file.arrayBuffer();
+      const sha256 = await sha256Hex(arrayBuffer);
       const data = Array.from(new Uint8Array(arrayBuffer));
 
       const result = await fsSyncCommands.attachmentSave(
@@ -28,6 +31,29 @@ export function useFileUpload(sessionId: string) {
       }
 
       const { path, attachmentId } = result.data;
+      try {
+        await catalogLocalNoteAttachment({
+          sessionId,
+          attachmentId,
+          filename,
+          contentType: file.type,
+          sizeBytes: arrayBuffer.byteLength,
+          sha256,
+        });
+      } catch (error) {
+        try {
+          const cleanup = await fsSyncCommands.attachmentRemove(
+            sessionId,
+            attachmentId,
+          );
+          if (cleanup.status === "error") {
+            console.error("[attachment] failed to roll back local file");
+          }
+        } catch {
+          console.error("[attachment] failed to roll back local file");
+        }
+        throw error;
+      }
       return { path, attachmentId, url: convertFileSrc(path) };
     },
     [sessionId],

--- a/apps/desktop/src/store/zustand/listener/general.test.ts
+++ b/apps/desktop/src/store/zustand/listener/general.test.ts
@@ -7,8 +7,10 @@ const {
   listenCaptureDataMock,
   listenCaptureLifecycleMock,
   listenCaptureStatusMock,
+  listMicUsingApplicationsMock,
   runEventHooksMock,
   setRecordingIndicatorMock,
+  startCaptureMock,
   stopCaptureMock,
   vaultBaseMock,
 } = vi.hoisted(() => ({
@@ -17,8 +19,10 @@ const {
   listenCaptureDataMock: vi.fn(),
   listenCaptureLifecycleMock: vi.fn(),
   listenCaptureStatusMock: vi.fn(),
+  listMicUsingApplicationsMock: vi.fn(),
   runEventHooksMock: vi.fn(),
   setRecordingIndicatorMock: vi.fn(),
+  startCaptureMock: vi.fn(),
   stopCaptureMock: vi.fn(),
   vaultBaseMock: vi.fn(),
 }));
@@ -29,7 +33,7 @@ vi.mock("@tauri-apps/api/app", () => ({
 
 vi.mock("@hypr/plugin-detect", () => ({
   commands: {
-    listMicUsingApplications: vi.fn(),
+    listMicUsingApplications: listMicUsingApplicationsMock,
   },
 }));
 
@@ -55,7 +59,7 @@ vi.mock("@hypr/plugin-transcription", () => ({
   commands: {
     getCaptureSnapshot: getCaptureSnapshotMock,
     setMicMuted: vi.fn(),
-    startCapture: vi.fn(),
+    startCapture: startCaptureMock,
     startTranscription: vi.fn(),
     stopCapture: stopCaptureMock,
     stopTranscription: vi.fn(),
@@ -82,6 +86,8 @@ import {
   updateLiveProgress,
 } from "./general-shared";
 
+import { enqueueSessionAudioOperation } from "~/session/audio-operations";
+
 let store: ReturnType<typeof createListenerStore>;
 
 describe("General Listener Slice", () => {
@@ -102,8 +108,10 @@ describe("General Listener Slice", () => {
     listenCaptureDataMock.mockResolvedValue(() => {});
     listenCaptureLifecycleMock.mockResolvedValue(() => {});
     listenCaptureStatusMock.mockResolvedValue(() => {});
+    listMicUsingApplicationsMock.mockResolvedValue({ status: "ok", data: [] });
     runEventHooksMock.mockResolvedValue({ status: "ok", data: null });
     setRecordingIndicatorMock.mockResolvedValue({ status: "ok", data: null });
+    startCaptureMock.mockResolvedValue({ status: "ok", data: null });
     stopCaptureMock.mockResolvedValue({ status: "ok", data: null });
     vaultBaseMock.mockResolvedValue({ status: "ok", data: "/tmp/anarlog" });
   });
@@ -994,6 +1002,36 @@ describe("General Listener Slice", () => {
 
       expect(result).toBe(false);
       expect(store.getState().live.sessionId).toBe("session-a");
+    });
+
+    test("holds the session audio lock until capture startup finishes", async () => {
+      let resolveStart:
+        | ((value: { status: "ok"; data: null }) => void)
+        | undefined;
+      startCaptureMock.mockReturnValueOnce(
+        new Promise((resolve) => {
+          resolveStart = resolve;
+        }),
+      );
+      const start = store.getState().start({
+        session_id: "session-a",
+        languages: [],
+        onboarding: false,
+        model: "test-model",
+        base_url: "http://localhost",
+        api_key: "test-key",
+        keywords: [],
+      });
+
+      await vi.waitFor(() => expect(startCaptureMock).toHaveBeenCalled());
+      const nextOperation = vi.fn(async () => {});
+      const queued = enqueueSessionAudioOperation("session-a", nextOperation);
+      expect(nextOperation).not.toHaveBeenCalled();
+
+      resolveStart?.({ status: "ok", data: null });
+      await expect(start).resolves.toBe(true);
+      await queued;
+      expect(nextOperation).toHaveBeenCalledOnce();
     });
 
     test("getSessionMode returns finalizing for non-active finalizing sessions", () => {

--- a/apps/desktop/src/store/zustand/listener/general.ts
+++ b/apps/desktop/src/store/zustand/listener/general.ts
@@ -31,6 +31,8 @@ import type {
   TranscriptState,
 } from "./transcript";
 
+import { enqueueSessionAudioOperation } from "~/session/audio-operations";
+
 export type { GeneralState, SessionMode } from "./general-shared";
 
 export type GeneralActions = {
@@ -80,42 +82,44 @@ export const createGeneralSlice = <
       return false;
     }
 
-    const currentMode = get().getSessionMode(targetSessionId);
-    if (currentMode === "running_batch") {
-      console.warn(
-        `[listener] cannot start live session while batch processing session ${targetSessionId}`,
-      );
-      return false;
-    }
+    return enqueueSessionAudioOperation(targetSessionId, async () => {
+      const currentMode = get().getSessionMode(targetSessionId);
+      if (currentMode === "running_batch") {
+        console.warn(
+          `[listener] cannot start live session while batch processing session ${targetSessionId}`,
+        );
+        return false;
+      }
 
-    const blockReason = getLiveStartBlockReason(get().live, targetSessionId);
-    if (blockReason) {
-      console.warn(`[listener] cannot start live session: ${blockReason}`);
-      return false;
-    }
+      const blockReason = getLiveStartBlockReason(get().live, targetSessionId);
+      if (blockReason) {
+        console.warn(`[listener] cannot start live session: ${blockReason}`);
+        return false;
+      }
 
-    setLiveState(set, (live) => {
-      markLiveStartRequested(live, targetSessionId);
-    });
+      setLiveState(set, (live) => {
+        markLiveStartRequested(live, targetSessionId);
+      });
 
-    if (options?.handlePersist) {
-      get().setTranscriptPersist(targetSessionId, options.handlePersist);
-    }
-    if (options?.onStopped) {
-      get().setOnStopped(targetSessionId, options.onStopped);
-    }
-
-    const started = await startLiveSession(set, get, targetSessionId, params);
-    if (!started) {
       if (options?.handlePersist) {
-        get().setTranscriptPersist(targetSessionId, undefined);
+        get().setTranscriptPersist(targetSessionId, options.handlePersist);
       }
       if (options?.onStopped) {
-        get().setOnStopped(targetSessionId, undefined);
+        get().setOnStopped(targetSessionId, options.onStopped);
       }
-    }
 
-    return started;
+      const started = await startLiveSession(set, get, targetSessionId, params);
+      if (!started) {
+        if (options?.handlePersist) {
+          get().setTranscriptPersist(targetSessionId, undefined);
+        }
+        if (options?.onStopped) {
+          get().setOnStopped(targetSessionId, undefined);
+        }
+      }
+
+      return started;
+    });
   },
   stop: () => {
     stopLiveSession(set, get);

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -8,6 +8,8 @@ import {
   useStartListening,
 } from "./useStartListening";
 
+import { enqueueSessionAudioOperation } from "~/session/audio-operations";
+
 const {
   queueAutoEnhanceMock,
   queueAutoEnhanceIfSummaryEmptyMock,
@@ -33,6 +35,7 @@ const {
   sonnerToastWarningMock,
   startMeetingChatCaptureMock,
   stopMeetingChatCaptureMock,
+  catalogLocalSessionAudioMock,
 } = vi.hoisted(() => ({
   queueAutoEnhanceMock: vi.fn(),
   queueAutoEnhanceIfSummaryEmptyMock: vi.fn(),
@@ -58,6 +61,7 @@ const {
   sonnerToastWarningMock: vi.fn(),
   startMeetingChatCaptureMock: vi.fn(),
   stopMeetingChatCaptureMock: vi.fn(),
+  catalogLocalSessionAudioMock: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-transcription", () => ({
@@ -117,6 +121,10 @@ vi.mock("~/services/audio-retention", () => ({
   deleteProcessedAudioForRetention: deleteProcessedAudioForRetentionMock,
   normalizeAudioRetention: (value: unknown) =>
     typeof value === "string" ? value : "forever",
+}));
+
+vi.mock("~/session/attachments", () => ({
+  catalogLocalSessionAudio: catalogLocalSessionAudioMock,
 }));
 
 vi.mock("~/contexts/shell", () => ({
@@ -247,6 +255,7 @@ describe("useStartListening", () => {
     createLiveTranscriptMock.mockResolvedValue(undefined);
     applyLiveTranscriptDeltaToDatabaseMock.mockResolvedValue(undefined);
     softDeleteTranscriptMock.mockResolvedValue(undefined);
+    catalogLocalSessionAudioMock.mockResolvedValue(undefined);
     useConfigValueMock.mockImplementation((key) =>
       key === "ai_language"
         ? "en"
@@ -370,6 +379,10 @@ describe("useStartListening", () => {
     });
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(
+      catalogLocalSessionAudioMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(runBatchMock.mock.invocationCallOrder[0]!);
     expect(queueAutoEnhanceIfSummaryEmptyMock).toHaveBeenCalledWith(
       "session-1",
     );
@@ -377,6 +390,100 @@ describe("useStartListening", () => {
       "forever",
       "session-1",
     );
+  });
+
+  test("skips audio cataloging when capture produces no final file", async () => {
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+    await act(async () => {
+      await onStopped?.("session-1", {
+        durationSeconds: 0,
+        audioPath: null,
+        requestedLiveTranscription: false,
+        liveTranscriptionActive: false,
+        needsBatchRepair: false,
+      });
+    });
+
+    expect(catalogLocalSessionAudioMock).not.toHaveBeenCalled();
+  });
+
+  test("catalogs finalized audio even when transcript persistence fails", async () => {
+    createLiveTranscriptMock.mockRejectedValueOnce(new Error("write failed"));
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const callbacks = startMock.mock.calls[0]?.[1];
+    callbacks?.handlePersist?.({
+      new_words: [
+        {
+          id: "word-1",
+          text: "hello",
+          start_ms: 0,
+          end_ms: 100,
+          channel: 0,
+        },
+      ],
+      replaced_ids: [],
+      partials: [],
+    });
+
+    await act(async () => {
+      await callbacks?.onStopped?.("session-1", {
+        durationSeconds: 1,
+        audioPath: "/tmp/session.wav",
+        requestedLiveTranscription: true,
+        liveTranscriptionActive: true,
+        needsBatchRepair: false,
+      });
+    });
+
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(runBatchMock).not.toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  test("catalogs finalized audio through the session audio queue", async () => {
+    let releaseBlocker: (() => void) | undefined;
+    const blocker = enqueueSessionAudioOperation(
+      "session-1",
+      () =>
+        new Promise<void>((resolve) => {
+          releaseBlocker = resolve;
+        }),
+    );
+    const { result } = renderHook(() => useStartListening("session-1"));
+
+    await act(async () => {
+      await result.current();
+    });
+
+    const onStopped = startMock.mock.calls[0]?.[1]?.onStopped;
+    const stopped = onStopped?.("session-1", {
+      durationSeconds: 1,
+      audioPath: "/tmp/session.wav",
+      requestedLiveTranscription: true,
+      liveTranscriptionActive: true,
+      needsBatchRepair: false,
+    });
+    await Promise.resolve();
+    expect(catalogLocalSessionAudioMock).not.toHaveBeenCalled();
+
+    releaseBlocker?.();
+    await blocker;
+    await act(async () => await stopped);
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
   });
 
   test("cleans up processed audio after live capture stops", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -20,6 +20,8 @@ import {
   normalizeAudioRetention,
 } from "~/services/audio-retention";
 import { getEnhancerService } from "~/services/enhancer";
+import { catalogLocalSessionAudio } from "~/session/attachments";
+import { enqueueSessionAudioOperation } from "~/session/audio-operations";
 import { useSession, useSessionHasTranscript } from "~/session/queries";
 import { getSessionEvent } from "~/session/utils";
 import { useConfigValue } from "~/shared/config";
@@ -303,6 +305,15 @@ export function useStartListening(sessionId: string) {
     const onStopped: OnStoppedCallback = async (_sessionId, details) => {
       cancelMeetingRecordingDisclosure(sessionId);
       stopMeetingChatTasks();
+      if (details.audioPath) {
+        try {
+          await enqueueSessionAudioOperation(sessionId, () =>
+            catalogLocalSessionAudio(sessionId),
+          );
+        } catch (error) {
+          console.error("[listener] failed to catalog recorded audio", error);
+        }
+      }
       await lastTranscriptWrite;
       if (transcriptWriteError) return;
 

--- a/apps/desktop/src/stt/useUploadFile.test.tsx
+++ b/apps/desktop/src/stt/useUploadFile.test.tsx
@@ -16,6 +16,7 @@ const {
   handleBatchStartedMock,
   updateBatchProgressMock,
   clearBatchSessionMock,
+  catalogLocalSessionAudioMock,
   runBatchMock,
   useSessionMock,
   updateSessionMock,
@@ -32,6 +33,7 @@ const {
   handleBatchStartedMock: vi.fn(),
   updateBatchProgressMock: vi.fn(),
   clearBatchSessionMock: vi.fn(),
+  catalogLocalSessionAudioMock: vi.fn(),
   runBatchMock: vi.fn(),
   useSessionMock: vi.fn(),
   updateSessionMock: vi.fn(),
@@ -92,6 +94,10 @@ vi.mock("~/services/enhancer", () => ({
   })),
 }));
 
+vi.mock("~/session/attachments", () => ({
+  catalogLocalSessionAudio: catalogLocalSessionAudioMock,
+}));
+
 vi.mock("~/session/queries", () => ({
   useSession: useSessionMock,
   useUpdateSession: () => updateSessionMock,
@@ -124,6 +130,7 @@ describe("useUploadFile", () => {
       data: "/vault/sessions/session-1/audio.wav",
     });
     audioImportListenMock.mockResolvedValue(vi.fn());
+    catalogLocalSessionAudioMock.mockResolvedValue(undefined);
     runBatchMock.mockResolvedValue(undefined);
     createTranscriptMock.mockResolvedValue(undefined);
     enhanceMock.mockResolvedValue({ type: "started", noteId: "note-1" });
@@ -158,9 +165,7 @@ describe("useUploadFile", () => {
       result.current.processAudioFile(file);
     });
 
-    await waitFor(() => {
-      expect(audioImportDataMock).toHaveBeenCalled();
-    });
+    await waitFor(() => expect(runBatchMock).toHaveBeenCalled());
     expect(audioImportDataMock).toHaveBeenCalledWith(
       "session-1",
       [1, 2, 3],
@@ -170,6 +175,13 @@ describe("useUploadFile", () => {
     expect(runBatchMock).toHaveBeenCalledWith(
       "/vault/sessions/session-1/audio.wav",
     );
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(audioImportDataMock.mock.invocationCallOrder[0]).toBeLessThan(
+      catalogLocalSessionAudioMock.mock.invocationCallOrder[0]!,
+    );
+    expect(
+      catalogLocalSessionAudioMock.mock.invocationCallOrder[0],
+    ).toBeLessThan(runBatchMock.mock.invocationCallOrder[0]!);
     expect(handleBatchFailedMock).not.toHaveBeenCalled();
   });
 
@@ -203,6 +215,34 @@ describe("useUploadFile", () => {
       );
     },
   );
+
+  test("continues transcription when imported audio cataloging fails", async () => {
+    catalogLocalSessionAudioMock.mockRejectedValueOnce(
+      new Error("catalog unavailable"),
+    );
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const { result } = renderHook(() => useUploadFile("session-1"), {
+      wrapper: createWrapper(),
+    });
+    const file = new File([new Uint8Array([1, 2, 3])], "drop.wav", {
+      type: "audio/wav",
+    });
+    Object.defineProperty(file, "arrayBuffer", {
+      value: vi.fn().mockResolvedValue(new Uint8Array([1, 2, 3]).buffer),
+    });
+
+    act(() => result.current.processAudioFile(file));
+
+    await waitFor(() => expect(runBatchMock).toHaveBeenCalled());
+    expect(handleBatchFailedMock).not.toHaveBeenCalled();
+    expect(consoleError).toHaveBeenCalledWith(
+      "[upload] failed to catalog imported audio",
+      expect.any(Error),
+    );
+    consoleError.mockRestore();
+  });
 
   test("persists imported subtitles before enhancing", async () => {
     let resolveWrite: (() => void) | undefined;

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -18,6 +18,8 @@ import { ChannelProfile } from "./segment";
 import { isStoppedTranscriptionError, useRunBatch } from "./useRunBatch";
 
 import { getEnhancerService } from "~/services/enhancer";
+import { catalogLocalSessionAudio } from "~/session/attachments";
+import { enqueueSessionAudioOperation } from "~/session/audio-operations";
 import { useSession, useUpdateSession } from "~/session/queries";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { createTranscript } from "~/stt/queries";
@@ -155,26 +157,32 @@ export function useUploadFile(sessionId: string) {
             error: string;
           }
       >,
-    ) => {
-      const unlisten = await fsSyncEvents.audioImportEvent.listen((e) => {
-        if (
-          e.payload.type === "audioImportProgress" &&
-          e.payload.session_id === sessionId
-        ) {
-          updateBatchProgress(sessionId, e.payload.percentage);
-        }
-      });
+    ) =>
+      enqueueSessionAudioOperation(sessionId, async () => {
+        const unlisten = await fsSyncEvents.audioImportEvent.listen((e) => {
+          if (
+            e.payload.type === "audioImportProgress" &&
+            e.payload.session_id === sessionId
+          ) {
+            updateBatchProgress(sessionId, e.payload.percentage);
+          }
+        });
 
-      try {
-        const result = await runImport();
-        if (result.status === "error") {
-          throw new Error(result.error);
+        try {
+          const result = await runImport();
+          if (result.status === "error") {
+            throw new Error(result.error);
+          }
+          try {
+            await catalogLocalSessionAudio(sessionId);
+          } catch (error) {
+            console.error("[upload] failed to catalog imported audio", error);
+          }
+          return result.data;
+        } finally {
+          unlisten();
         }
-        return result.data;
-      } finally {
-        unlisten();
-      }
-    },
+      }),
     [sessionId, updateBatchProgress],
   );
 

--- a/crates/db-app/migrations/20260717140000_attachment_local_state.sql
+++ b/crates/db-app/migrations/20260717140000_attachment_local_state.sql
@@ -1,0 +1,11 @@
+CREATE TABLE IF NOT EXISTS attachment_local_state (
+  attachment_id  TEXT PRIMARY KEY NOT NULL,
+  session_id     TEXT NOT NULL DEFAULT '',
+  relative_path  TEXT NOT NULL DEFAULT '',
+  availability   TEXT NOT NULL DEFAULT 'present'
+                 CHECK (availability IN ('present', 'absent')),
+  updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))
+) STRICT;
+
+CREATE INDEX IF NOT EXISTS idx_attachment_local_state_session_id
+ON attachment_local_state(session_id);

--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -754,6 +754,16 @@ mod tests {
         .execute(source.pool())
         .await
         .unwrap();
+        sqlx::query(
+            "INSERT INTO attachment_local_state (
+               attachment_id, session_id, relative_path, availability
+             ) VALUES (
+               'attachment-1', 'session-1', 'local-only-secret.png', 'present'
+             )",
+        )
+        .execute(source.pool())
+        .await
+        .unwrap();
 
         encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
             .await
@@ -768,6 +778,7 @@ mod tests {
         assert!(payloads.iter().all(|payload| {
             !payload.contains("secret-diagram.png")
                 && !payload.contains("attachments/secret-diagram.png")
+                && !payload.contains("local-only-secret.png")
                 && !payload
                     .contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
         }));
@@ -794,6 +805,12 @@ mod tests {
                 "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
             )
         );
+        let local_state_count: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM attachment_local_state")
+                .fetch_one(target.pool())
+                .await
+                .unwrap();
+        assert_eq!(local_state_count, 0);
     }
 
     #[tokio::test]

--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -737,6 +737,66 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn encrypts_and_reconstructs_attachment_metadata() {
+        let workspace_keys = keys("workspace-a");
+        let source = test_db().await;
+        sqlx::query(
+            "INSERT INTO session_attachments (
+               id, workspace_id, session_id, filename, relative_path,
+               content_type, size_bytes, sha256, source_type, source_id
+             ) VALUES (
+               'attachment-1', 'workspace-a', 'session-1', 'secret-diagram.png',
+               'attachments/secret-diagram.png', 'image/png', 42,
+               'aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa',
+               'note_upload', 'secret-diagram.png'
+             )",
+        )
+        .execute(source.pool())
+        .await
+        .unwrap();
+
+        encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+            .await
+            .unwrap();
+        let payloads: Vec<String> = sqlx::query_scalar(
+            "SELECT payload FROM e2ee_records WHERE workspace_id = 'workspace-a'",
+        )
+        .fetch_all(source.pool())
+        .await
+        .unwrap();
+        assert!(!payloads.is_empty());
+        assert!(payloads.iter().all(|payload| {
+            !payload.contains("secret-diagram.png")
+                && !payload.contains("attachments/secret-diagram.png")
+                && !payload
+                    .contains("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
+        }));
+
+        let target = test_db().await;
+        copy_replica(source.pool(), target.pool()).await;
+        apply_e2ee_replica_changes(target.pool(), &workspace_keys)
+            .await
+            .unwrap();
+        let attachment: (String, String, String, i64, String) = sqlx::query_as(
+            "SELECT filename, relative_path, content_type, size_bytes, sha256
+             FROM session_attachments WHERE id = 'attachment-1'",
+        )
+        .fetch_one(target.pool())
+        .await
+        .unwrap();
+        assert_eq!(
+            attachment,
+            (
+                "secret-diagram.png".to_string(),
+                "attachments/secret-diagram.png".to_string(),
+                "image/png".to_string(),
+                42,
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa".to_string(),
+            )
+        );
+    }
+
+    #[tokio::test]
     async fn reconstructs_every_protected_table_and_applies_deletions() {
         let workspace_keys = keys("workspace-a");
         let source = test_db().await;

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -132,6 +132,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260717120000_e2ee_replica.sql"),
     },
+    hypr_db_migrate::MigrationStep {
+        id: "20260717140000_attachment_local_state",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260717140000_attachment_local_state.sql"),
+    },
 ];
 
 pub fn schema() -> hypr_db_migrate::DbSchema {
@@ -340,6 +345,7 @@ mod tests {
                 "_sqlx_migrations",
                 "action_items",
                 "app_settings",
+                "attachment_local_state",
                 "calendars",
                 "chat_groups",
                 "chat_messages",
@@ -742,6 +748,23 @@ mod tests {
                 .any(|table| table.table_name == "shared_session_cache")
         );
         assert!(!cloudsync_alter_guard_required("shared_session_cache"));
+    }
+
+    #[test]
+    fn attachment_local_state_is_plain_and_excluded_from_cloudsync() {
+        let migration = APP_MIGRATION_STEPS
+            .iter()
+            .find(|step| step.id == "20260717140000_attachment_local_state")
+            .unwrap();
+
+        assert_eq!(migration.scope, hypr_db_migrate::MigrationScope::Plain);
+        assert!(
+            !cloudsync_table_registry()
+                .iter()
+                .any(|table| table.table_name == "attachment_local_state")
+        );
+        assert!(!E2EE_DOMAIN_TABLES.contains(&"attachment_local_state"));
+        assert!(!cloudsync_alter_guard_required("attachment_local_state"));
     }
 
     #[tokio::test]

--- a/crates/fs-sync-core/Cargo.toml
+++ b/crates/fs-sync-core/Cargo.toml
@@ -17,6 +17,7 @@ hypr-tiptap = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+sha2 = { workspace = true }
 specta = { workspace = true, features = ["derive", "serde_json"] }
 tauri-specta = { workspace = true, optional = true, features = ["derive"] }
 

--- a/crates/fs-sync-core/src/audio/mod.rs
+++ b/crates/fs-sync-core/src/audio/mod.rs
@@ -1,4 +1,6 @@
 use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::io::Read;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, UNIX_EPOCH};
 
@@ -6,6 +8,7 @@ use crate::error::AudioImportError;
 use crate::path::is_uuid;
 use crate::runtime::{AudioImportEvent, AudioImportRuntime};
 use chrono::{DateTime, Utc};
+use sha2::{Digest, Sha256};
 
 const AUDIO_FORMATS: [&str; 3] = ["audio.mp3", "audio.wav", "audio.ogg"];
 const AUDIO_ARTIFACTS: [&str; 7] = [
@@ -26,6 +29,15 @@ pub struct AudioSourceMetadata {
     pub duration_ms: Option<u64>,
 }
 
+#[derive(Clone, Debug, PartialEq, Eq, serde::Serialize, specta::Type)]
+#[serde(rename_all = "camelCase")]
+pub struct AudioFileMetadata {
+    pub filename: String,
+    pub content_type: String,
+    pub size_bytes: u64,
+    pub sha256: String,
+}
+
 pub fn exists(session_dir: &Path) -> std::io::Result<bool> {
     AUDIO_FORMATS
         .iter()
@@ -35,14 +47,8 @@ pub fn exists(session_dir: &Path) -> std::io::Result<bool> {
         })
 }
 
-pub fn delete(session_dir: &Path) -> std::io::Result<()> {
-    for artifact in AUDIO_ARTIFACTS {
-        let path = session_dir.join(artifact);
-        if std::fs::exists(&path).unwrap_or(false) {
-            std::fs::remove_file(&path)?;
-        }
-    }
-    Ok(())
+pub fn delete(session_dir: &Path) -> std::io::Result<bool> {
+    delete_with(session_dir, |path| std::fs::remove_file(path))
 }
 
 pub fn path(session_dir: &Path) -> Option<PathBuf> {
@@ -50,6 +56,76 @@ pub fn path(session_dir: &Path) -> Option<PathBuf> {
         .iter()
         .map(|format| session_dir.join(format))
         .find(|path| path.exists())
+}
+
+pub fn metadata(session_dir: &Path) -> std::io::Result<Option<AudioFileMetadata>> {
+    let Some(path) = path(session_dir) else {
+        return Ok(None);
+    };
+    let Some(filename) = path.file_name().and_then(|filename| filename.to_str()) else {
+        return Ok(None);
+    };
+
+    let content_type = match filename {
+        "audio.mp3" => "audio/mpeg",
+        "audio.wav" => "audio/wav",
+        "audio.ogg" => "audio/ogg",
+        _ => return Ok(None),
+    };
+
+    let mut file = std::fs::File::open(&path)?;
+    let mut hasher = Sha256::new();
+    let mut buffer = [0_u8; 64 * 1024];
+    let mut size_bytes = 0_u64;
+
+    loop {
+        let bytes_read = file.read(&mut buffer)?;
+        if bytes_read == 0 {
+            break;
+        }
+        hasher.update(&buffer[..bytes_read]);
+        size_bytes = size_bytes
+            .checked_add(bytes_read as u64)
+            .ok_or_else(|| std::io::Error::other("audio_file_too_large"))?;
+    }
+
+    let sha256 = hasher
+        .finalize()
+        .iter()
+        .fold(String::with_capacity(64), |mut output, byte| {
+            write!(&mut output, "{byte:02x}").unwrap();
+            output
+        });
+
+    Ok(Some(AudioFileMetadata {
+        filename: filename.to_string(),
+        content_type: content_type.to_string(),
+        size_bytes,
+        sha256,
+    }))
+}
+
+fn delete_with(
+    session_dir: &Path,
+    mut remove_file: impl FnMut(&Path) -> std::io::Result<()>,
+) -> std::io::Result<bool> {
+    let primary_path = path(session_dir);
+
+    for artifact in AUDIO_ARTIFACTS {
+        let artifact_path = session_dir.join(artifact);
+        if primary_path.as_ref() == Some(&artifact_path) {
+            continue;
+        }
+        if std::fs::exists(&artifact_path)? {
+            remove_file(&artifact_path)?;
+        }
+    }
+
+    let Some(primary_path) = primary_path else {
+        return Ok(false);
+    };
+    remove_file(&primary_path)?;
+    Ok(true)
 }
 
 pub fn delete_orphaned_expired(
@@ -272,12 +348,95 @@ mod tests {
         let note_path = session_dir.join("note.md");
         std::fs::write(&note_path, b"keep").unwrap();
 
-        delete(session_dir).unwrap();
+        assert!(delete(session_dir).unwrap());
 
         for artifact in AUDIO_ARTIFACTS {
             assert!(!session_dir.join(artifact).exists());
         }
         assert!(note_path.exists());
+    }
+
+    #[test]
+    fn metadata_hashes_the_selected_final_audio_file() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("audio.mp3"), b"abc").unwrap();
+
+        let metadata = metadata(temp.path()).unwrap().unwrap();
+
+        assert_eq!(
+            metadata,
+            AudioFileMetadata {
+                filename: "audio.mp3".to_string(),
+                content_type: "audio/mpeg".to_string(),
+                size_bytes: 3,
+                sha256: "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad"
+                    .to_string(),
+            }
+        );
+    }
+
+    #[test]
+    fn metadata_falls_back_to_supported_final_audio_formats() {
+        let cases = [("audio.wav", "audio/wav"), ("audio.ogg", "audio/ogg")];
+
+        for (filename, content_type) in cases {
+            let temp = TempDir::new().unwrap();
+            std::fs::write(temp.path().join(filename), b"audio").unwrap();
+
+            let metadata = metadata(temp.path()).unwrap().unwrap();
+
+            assert_eq!(metadata.filename, filename);
+            assert_eq!(metadata.content_type, content_type);
+        }
+    }
+
+    #[test]
+    fn metadata_ignores_audio_artifacts() {
+        let temp = TempDir::new().unwrap();
+        for artifact in [
+            "audio.mp3.tmp",
+            "audio.wav.tmp",
+            "audio_mic.wav",
+            "audio_spk.wav",
+        ] {
+            write_audio(&temp.path().join(artifact));
+        }
+
+        assert_eq!(metadata(temp.path()).unwrap(), None);
+    }
+
+    #[test]
+    fn delete_without_final_audio_returns_false() {
+        let temp = TempDir::new().unwrap();
+        write_audio(&temp.path().join("audio.mp3.tmp"));
+
+        assert!(!delete(temp.path()).unwrap());
+        assert!(!temp.path().join("audio.mp3.tmp").exists());
+    }
+
+    #[test]
+    fn delete_preserves_primary_audio_when_auxiliary_deletion_fails() {
+        let temp = TempDir::new().unwrap();
+        let primary_path = temp.path().join("audio.mp3");
+        let auxiliary_path = temp.path().join("audio.mp3.tmp");
+        write_audio(&primary_path);
+        write_audio(&auxiliary_path);
+
+        let result = delete_with(temp.path(), |path| {
+            if path == auxiliary_path {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::PermissionDenied,
+                    "blocked auxiliary deletion",
+                ));
+            }
+            std::fs::remove_file(path)
+        });
+
+        assert_eq!(
+            result.unwrap_err().kind(),
+            std::io::ErrorKind::PermissionDenied
+        );
+        assert!(primary_path.exists());
     }
 
     #[test]

--- a/crates/fs-sync-core/src/lib.rs
+++ b/crates/fs-sync-core/src/lib.rs
@@ -323,8 +323,18 @@ fn write_unique_file(
     filename: &str,
     data: &[u8],
 ) -> Result<(PathBuf, String)> {
-    use std::fs::OpenOptions;
     use std::io::Write;
+
+    write_unique_file_with(dir, filename, data, |file, bytes| file.write_all(bytes))
+}
+
+fn write_unique_file_with(
+    dir: &std::path::Path,
+    filename: &str,
+    data: &[u8],
+    mut write_data: impl FnMut(&mut std::fs::File, &[u8]) -> std::io::Result<()>,
+) -> Result<(PathBuf, String)> {
+    use std::fs::OpenOptions;
 
     let path = std::path::Path::new(filename);
     let stem = path
@@ -352,7 +362,16 @@ fn write_unique_file(
             .open(&candidate_path)
         {
             Ok(mut file) => {
-                file.write_all(data)?;
+                if let Err(error) = write_data(&mut file, data) {
+                    drop(file);
+                    if let Err(cleanup_error) = std::fs::remove_file(&candidate_path) {
+                        tracing::warn!(
+                            error = %cleanup_error,
+                            "Failed to remove partially written attachment"
+                        );
+                    }
+                    return Err(error.into());
+                }
                 return Ok((candidate_path, candidate_filename));
             }
             Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
@@ -488,7 +507,7 @@ mod tests {
         let core = FsSyncCore::new(temp.path().to_path_buf());
         let result = core.rename_folder("old", "new");
 
-        assert!(result.is_err());
+        assert!(matches!(result, Err(Error::Path(message)) if message == "folder_target_exists"));
     }
 
     #[test]
@@ -630,6 +649,32 @@ mod tests {
             .child("attachments")
             .child("file 1.txt")
             .assert(predicates::path::exists());
+    }
+
+    #[test]
+    fn attachment_save_removes_a_partial_candidate_after_write_failure() {
+        let temp = TempDir::new().unwrap();
+        let attachments_dir = temp.path().join("attachments");
+        std::fs::create_dir_all(&attachments_dir).unwrap();
+
+        let result =
+            write_unique_file_with(&attachments_dir, "file.txt", b"partial", |file, bytes| {
+                use std::io::Write;
+
+                file.write_all(&bytes[..3])?;
+                Err(std::io::Error::new(
+                    std::io::ErrorKind::StorageFull,
+                    "disk full",
+                ))
+            });
+
+        assert!(matches!(
+            result,
+            Err(Error::Io(error)) if error.kind() == std::io::ErrorKind::StorageFull
+        ));
+        assert!(!attachments_dir.join("file.txt").exists());
+        let saved = write_unique_file(&attachments_dir, "file.txt", b"complete").unwrap();
+        assert_eq!(saved.1, "file.txt");
     }
 
     #[test]

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -339,6 +339,20 @@ export const sessionAttachments = sqliteTable(
   (table) => [index("idx_session_attachments_session_id").on(table.sessionId)],
 );
 
+export const attachmentLocalState = sqliteTable(
+  "attachment_local_state",
+  {
+    attachmentId: text("attachment_id").primaryKey().notNull(),
+    sessionId: text("session_id").notNull().default(""),
+    relativePath: text("relative_path").notNull().default(""),
+    availability: text("availability").notNull().default("present"),
+    updatedAt: text("updated_at").notNull().default(currentTimestamp),
+  },
+  (table) => [
+    index("idx_attachment_local_state_session_id").on(table.sessionId),
+  ],
+);
+
 export const tags = sqliteTable(
   "tags",
   {

--- a/plugins/fs-sync/build.rs
+++ b/plugins/fs-sync/build.rs
@@ -10,6 +10,7 @@ const COMMANDS: &[&str] = &[
     "delete_folder",
     "audio_exist",
     "audio_delete",
+    "audio_metadata",
     "audio_delete_orphaned_expired",
     "audio_import",
     "audio_import_data",

--- a/plugins/fs-sync/js/bindings.gen.ts
+++ b/plugins/fs-sync/js/bindings.gen.ts
@@ -86,9 +86,17 @@ async audioExist(sessionId: string) : Promise<Result<boolean, string>> {
     else return { status: "error", error: e  as any };
 }
 },
-async audioDelete(sessionId: string) : Promise<Result<null, string>> {
+async audioDelete(sessionId: string) : Promise<Result<boolean, string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:fs-sync|audio_delete", { sessionId }) };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
+async audioMetadata(sessionId: string) : Promise<Result<AudioFileMetadata | null, string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:fs-sync|audio_metadata", { sessionId }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -233,6 +241,7 @@ audioImportEvent: "plugin:fs-sync:audio-import-event"
 
 export type AttachmentInfo = { attachmentId: string; path: string; extension: string; modifiedAt: string }
 export type AttachmentSaveResult = { path: string; attachmentId: string }
+export type AudioFileMetadata = { filename: string; contentType: string; sizeBytes: number; sha256: string }
 export type AudioImportEvent = { type: "audioImportStarted"; session_id: string } | { type: "audioImportProgress"; session_id: string; percentage: number } | { type: "audioImportCompleted"; session_id: string } | { type: "audioImportFailed"; session_id: string; error: string }
 export type AudioSourceMetadata = { createdAt: string | null; modifiedAt: string | null; durationMs: number | null }
 export type FolderInfo = { name: string; parent_folder_id: string | null }

--- a/plugins/fs-sync/permissions/autogenerated/commands/audio_metadata.toml
+++ b/plugins/fs-sync/permissions/autogenerated/commands/audio_metadata.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-audio-metadata"
+description = "Enables the audio_metadata command without any pre-configured scope."
+commands.allow = ["audio_metadata"]
+
+[[permission]]
+identifier = "deny-audio-metadata"
+description = "Denies the audio_metadata command without any pre-configured scope."
+commands.deny = ["audio_metadata"]

--- a/plugins/fs-sync/permissions/autogenerated/reference.md
+++ b/plugins/fs-sync/permissions/autogenerated/reference.md
@@ -15,6 +15,7 @@ Default permissions for the fs-sync plugin
 - `allow-delete-folder`
 - `allow-audio-exist`
 - `allow-audio-delete`
+- `allow-audio-metadata`
 - `allow-audio-delete-orphaned-expired`
 - `allow-audio-import`
 - `allow-audio-import-data`
@@ -270,6 +271,32 @@ Enables the audio_import_data command without any pre-configured scope.
 <td>
 
 Denies the audio_import_data command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:allow-audio-metadata`
+
+</td>
+<td>
+
+Enables the audio_metadata command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`fs-sync:deny-audio-metadata`
+
+</td>
+<td>
+
+Denies the audio_metadata command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/fs-sync/permissions/default.toml
+++ b/plugins/fs-sync/permissions/default.toml
@@ -12,6 +12,7 @@ permissions = [
     "allow-delete-folder",
     "allow-audio-exist",
     "allow-audio-delete",
+    "allow-audio-metadata",
     "allow-audio-delete-orphaned-expired",
     "allow-audio-import",
     "allow-audio-import-data",

--- a/plugins/fs-sync/permissions/schemas/schema.json
+++ b/plugins/fs-sync/permissions/schemas/schema.json
@@ -403,6 +403,18 @@
           "markdownDescription": "Denies the audio_import_data command without any pre-configured scope."
         },
         {
+          "description": "Enables the audio_metadata command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-audio-metadata",
+          "markdownDescription": "Enables the audio_metadata command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the audio_metadata command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-audio-metadata",
+          "markdownDescription": "Denies the audio_metadata command without any pre-configured scope."
+        },
+        {
           "description": "Enables the audio_path command without any pre-configured scope.",
           "type": "string",
           "const": "allow-audio-path",
@@ -619,10 +631,10 @@
           "markdownDescription": "Denies the write_json_batch command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-import-data`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`",
+          "description": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-metadata`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-import-data`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-import-data`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`"
+          "markdownDescription": "Default permissions for the fs-sync plugin\n#### This default permission set includes:\n\n- `allow-deserialize`\n- `allow-write-json-batch`\n- `allow-write-document-batch`\n- `allow-read-document-batch`\n- `allow-list-folders`\n- `allow-move-session`\n- `allow-create-folder`\n- `allow-rename-folder`\n- `allow-delete-folder`\n- `allow-audio-exist`\n- `allow-audio-delete`\n- `allow-audio-metadata`\n- `allow-audio-delete-orphaned-expired`\n- `allow-audio-import`\n- `allow-audio-import-data`\n- `allow-audio-source-metadata`\n- `allow-audio-path`\n- `allow-session-dir`\n- `allow-load-session-content`\n- `allow-delete-session-folder`\n- `allow-scan-and-read`\n- `allow-chat-dir`\n- `allow-entity-dir`\n- `allow-attachment-save`\n- `allow-attachment-list`\n- `allow-attachment-read`\n- `allow-attachment-remove`"
         }
       ]
     }

--- a/plugins/fs-sync/src/commands.rs
+++ b/plugins/fs-sync/src/commands.rs
@@ -235,9 +235,19 @@ pub(crate) async fn audio_exist<R: tauri::Runtime>(
 pub(crate) async fn audio_delete<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
     session_id: String,
-) -> Result<(), String> {
+) -> Result<bool, String> {
     let session_dir = resolve_session_dir(&app, &session_id)?;
     crate::audio::delete(&session_dir).map_err(|e| e.to_string())
+}
+
+#[tauri::command]
+#[specta::specta]
+pub(crate) async fn audio_metadata<R: tauri::Runtime>(
+    app: tauri::AppHandle<R>,
+    session_id: String,
+) -> Result<Option<crate::audio::AudioFileMetadata>, String> {
+    let session_dir = resolve_session_dir(&app, &session_id)?;
+    spawn_blocking!({ crate::audio::metadata(&session_dir).map_err(|e| e.to_string()) })
 }
 
 #[tauri::command]

--- a/plugins/fs-sync/src/lib.rs
+++ b/plugins/fs-sync/src/lib.rs
@@ -22,6 +22,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
             commands::delete_folder::<tauri::Wry>,
             commands::audio_exist::<tauri::Wry>,
             commands::audio_delete::<tauri::Wry>,
+            commands::audio_metadata::<tauri::Wry>,
             commands::audio_delete_orphaned_expired::<tauri::Wry>,
             commands::audio_import::<tauri::Wry>,
             commands::audio_import_data::<tauri::Wry>,


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 14 in a stack** made with GitButler:
- <kbd>&nbsp;14&nbsp;</kbd> #6104
- <kbd>&nbsp;13&nbsp;</kbd> #6103
- <kbd>&nbsp;12&nbsp;</kbd> #6102
- <kbd>&nbsp;11&nbsp;</kbd> #6101
- <kbd>&nbsp;10&nbsp;</kbd> #6100
- <kbd>&nbsp;9&nbsp;</kbd> #6099
- <kbd>&nbsp;8&nbsp;</kbd> #6109
- <kbd>&nbsp;7&nbsp;</kbd> #6108
- <kbd>&nbsp;6&nbsp;</kbd> #6098
- <kbd>&nbsp;5&nbsp;</kbd> #6093 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #6092
- <kbd>&nbsp;3&nbsp;</kbd> #6091
- <kbd>&nbsp;2&nbsp;</kbd> #6090
- <kbd>&nbsp;1&nbsp;</kbd> #6089
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches capture/import/delete ordering, retention, and new DB state alongside fs-sync audio APIs—incorrect idle/queue logic could delete or catalog audio during recording.
> 
> **Overview**
> Adds a **session attachment catalog** that persists note uploads and primary session audio in `session_attachments`, with a new **`attachment_local_state`** table marking whether local bytes are **present** or **absent** (retention can drop files without erasing canonical metadata).
> 
> **Note uploads** now SHA-256 hash before save, **catalog** after `attachmentSave`, and **roll back** the file if DB cataloging fails. **Recorded/imported audio** is cataloged via new **`audio_metadata`** (checksum, size, MIME) after capture or import, queued behind **`enqueueSessionAudioOperation`** so capture start, import, catalog, and delete do not race.
> 
> **Deletion** is split: user/player delete **tombstones** metadata then removes bytes; retention uses **local-only** delete and records absence. **Audio retention** and **forever** policy still **retry cleanup** for logically deleted audio whose local files remain; work is skipped while the session is recording or capture startup is **loading** (`isSessionAudioIdle`). The audio player surfaces **`audio_session_busy`** when delete is blocked.
> 
> **fs-sync** `audio_delete` returns whether a primary file existed; Rust computes metadata with SHA-256 and tightens delete/attachment write failure handling. Schema/E2EE: local state stays device-local; attachment metadata remains in the encrypted replica path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c51474c1c9c8f690a3f1573970edf58d351cdd3b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->