### PR TITLE
feat(sharing): add authenticated collaboration

### DIFF
--- a/apps/desktop/src/session-sharing/index.test.tsx
+++ b/apps/desktop/src/session-sharing/index.test.tsx
@@ -168,6 +168,7 @@ const SHARE_ID = "33333333-3333-4333-8333-333333333333";
 const LINK_ID = "44444444-4444-4444-8444-444444444444";
 const INVITATION_ID = "55555555-5555-4555-8555-555555555555";
 const GRANT_ID = "66666666-6666-4666-8666-666666666666";
+const REQUEST_ID = "88888888-8888-4888-8888-888888888888";
 const TOKEN = "t".repeat(43);
 const PUBLIC_SLUG = `s_${"a".repeat(32)}`;
 
@@ -778,6 +779,87 @@ describe("SessionShareButton", () => {
     );
     expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
     expect(mocks.events[0]).toBe("revoke-grant");
+  });
+
+  it("publishes before approving a pending access request", async () => {
+    mocks.access = [
+      {
+        entryType: "request",
+        entryId: REQUEST_ID,
+        userId: OTHER_USER_ID,
+        userEmail: "requester@example.com",
+        capability: "commenter",
+        status: "pending",
+        createdAt: "2026-07-17T00:00:00Z",
+        expiresAt: null,
+      },
+    ];
+    mocks.reviewSessionAccessRequest.mockImplementation(
+      async (_context: unknown, input: { decision: "approve" | "deny" }) => {
+        mocks.events.push(`${input.decision}-request`);
+      },
+    );
+    renderShareButton();
+    await openShareDialog();
+    expect(screen.getByText("Requested can comment")).not.toBeNull();
+    mocks.events = [];
+    mocks.publishSessionShareSnapshot.mockClear();
+    mocks.reviewSessionAccessRequest.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Approve" }));
+
+    await waitFor(() =>
+      expect(mocks.reviewSessionAccessRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        {
+          requestId: REQUEST_ID,
+          decision: "approve",
+          capability: "commenter",
+        },
+      ),
+    );
+    expect(mocks.publishSessionShareSnapshot).toHaveBeenCalledOnce();
+    expect(mocks.events.indexOf("publish")).toBeGreaterThanOrEqual(0);
+    expect(mocks.events.indexOf("approve-request")).toBeGreaterThan(
+      mocks.events.indexOf("publish"),
+    );
+  });
+
+  it("denies a pending access request without publishing", async () => {
+    mocks.access = [
+      {
+        entryType: "request",
+        entryId: REQUEST_ID,
+        userId: OTHER_USER_ID,
+        userEmail: "requester@example.com",
+        capability: "editor",
+        status: "pending",
+        createdAt: "2026-07-17T00:00:00Z",
+        expiresAt: null,
+      },
+    ];
+    mocks.reviewSessionAccessRequest.mockImplementation(
+      async (_context: unknown, input: { decision: "approve" | "deny" }) => {
+        mocks.events.push(`${input.decision}-request`);
+      },
+    );
+    renderShareButton();
+    await openShareDialog();
+    expect(screen.getByText("Requested can edit")).not.toBeNull();
+    mocks.events = [];
+    mocks.publishSessionShareSnapshot.mockClear();
+    mocks.reviewSessionAccessRequest.mockClear();
+
+    fireEvent.click(screen.getByRole("button", { name: "Deny" }));
+
+    await waitFor(() =>
+      expect(mocks.reviewSessionAccessRequest).toHaveBeenCalledWith(
+        expect.anything(),
+        { requestId: REQUEST_ID, decision: "deny" },
+      ),
+    );
+    expect(mocks.publishSessionShareSnapshot).not.toHaveBeenCalled();
+    expect(mocks.events[0]).toBe("deny-request");
   });
 
   it("lets an expired Pro user reopen an existing share to revoke access", async () => {

--- a/apps/web/src/components/share-route-continuation.ts
+++ b/apps/web/src/components/share-route-continuation.ts
@@ -1,0 +1,44 @@
+import { useQuery } from "@tanstack/react-query";
+
+import {
+  persistShareRouteContinuation,
+  restoreShareRouteContinuation,
+} from "@/functions/share-route-continuation";
+import {
+  clearPersistedShareRouteToken,
+  getShareRouteToken,
+  loadShareRouteContinuation,
+  retainShareRouteToken,
+} from "@/lib/share-route-privacy";
+
+export function useShareRouteContinuation(pathname: string) {
+  const localToken = getShareRouteToken(pathname);
+  const continuationQuery = useQuery({
+    queryKey: ["share-route-continuation", pathname],
+    queryFn: ({ signal }) =>
+      loadShareRouteContinuation({
+        clearPersisted: () => clearPersistedShareRouteToken(pathname),
+        localToken,
+        persist: (token) =>
+          persistShareRouteContinuation({
+            data: { pathname, token },
+          }),
+        restore: () =>
+          restoreShareRouteContinuation({
+            data: pathname,
+          }),
+        retain: (token) => retainShareRouteToken(pathname, token),
+        signal,
+      }),
+    gcTime: 0,
+    retry: false,
+    staleTime: Infinity,
+  });
+
+  return {
+    isError: continuationQuery.isError,
+    isPending: continuationQuery.isPending,
+    retry: continuationQuery.refetch,
+    token: continuationQuery.data ?? null,
+  };
+}

--- a/apps/web/src/components/shared-note-collaboration.tsx
+++ b/apps/web/src/components/shared-note-collaboration.tsx
@@ -1,0 +1,804 @@
+import { useForm } from "@tanstack/react-form";
+import {
+  useInfiniteQuery,
+  useMutation,
+  useQuery,
+  useQueryClient,
+} from "@tanstack/react-query";
+import {
+  CheckIcon,
+  Clock3Icon,
+  LoaderCircleIcon,
+  LogInIcon,
+  MessageSquareIcon,
+  SendIcon,
+  Trash2Icon,
+  XIcon,
+} from "lucide-react";
+
+import { cn } from "@hypr/utils";
+
+import {
+  sharedPrimaryButtonClassName,
+  sharedSecondaryButtonClassName,
+} from "@/components/shared-note-viewer";
+import {
+  cancelMySharedNoteAccessRequest,
+  createSharedNoteComment,
+  deleteSharedNoteComment,
+  getMySharedNoteAccessRequest,
+  listSharedNoteComments,
+  listSharedNoteManagerAccess,
+  requestSharedNoteCommentAccess,
+  reviewSharedNoteAccessRequest,
+} from "@/functions/shared-notes";
+import {
+  canComposeSharedNoteComments,
+  formatSharedNoteAccessRequestDescription,
+  hasSharedNoteCollaborationAccess,
+  MAX_SHARED_NOTE_COMMENT_BYTES,
+  validateSharedNoteCommentBody,
+} from "@/lib/shared-note-collaboration";
+import type {
+  SessionAccessRequestState,
+  SessionShareAccessCursor,
+  SharedNoteCommentCursor,
+  SharedNoteCapability,
+} from "@/lib/shared-notes";
+
+const commentsQueryKey = (shareId: string) => ["shared-note-comments", shareId];
+const accessRequestQueryKey = (shareId: string) => [
+  "shared-note-access-request",
+  shareId,
+];
+const managerAccessQueryKey = (shareId: string) => [
+  "shared-note-manager-access",
+  shareId,
+];
+
+export function SharedNoteCollaboration({
+  capability,
+  currentUserId,
+  manageAccess,
+  returnPath,
+  shareId,
+}: {
+  capability: SharedNoteCapability;
+  currentUserId: string | null;
+  manageAccess: boolean;
+  returnPath: string;
+  shareId: string;
+}) {
+  const queryClient = useQueryClient();
+  const signedIn = currentUserId !== null;
+  const commentsQuery = useInfiniteQuery({
+    queryKey: commentsQueryKey(shareId),
+    queryFn: async ({ pageParam }) => {
+      const result = await listSharedNoteComments({
+        data: {
+          shareId,
+          beforeCreatedAt: pageParam?.beforeCreatedAt ?? null,
+          beforeCommentId: pageParam?.beforeCommentId ?? null,
+        },
+      });
+      if (result.status === "error") {
+        throw new Error("comments unavailable");
+      }
+      return result;
+    },
+    enabled: signedIn,
+    initialPageParam: null as SharedNoteCommentCursor | null,
+    getNextPageParam: (lastPage) =>
+      lastPage.status === "ready"
+        ? (lastPage.nextCursor ?? undefined)
+        : undefined,
+    retry: false,
+  });
+  const accessRequestQuery = useQuery({
+    queryKey: accessRequestQueryKey(shareId),
+    queryFn: async () => {
+      const result = await getMySharedNoteAccessRequest({ data: shareId });
+      if (result.status !== "ready") {
+        throw new Error("access request unavailable");
+      }
+      return result.request;
+    },
+    enabled: signedIn && !manageAccess,
+    retry: false,
+  });
+  const managerAccessQuery = useInfiniteQuery({
+    queryKey: managerAccessQueryKey(shareId),
+    queryFn: async ({ pageParam }) => {
+      const result = await listSharedNoteManagerAccess({
+        data: {
+          shareId,
+          beforeCreatedAt: pageParam?.beforeCreatedAt ?? null,
+          beforeEntryId: pageParam?.beforeEntryId ?? null,
+        },
+      });
+      if (result.status !== "ready") {
+        throw new Error("manager access unavailable");
+      }
+      return result;
+    },
+    enabled: signedIn && manageAccess,
+    initialPageParam: null as SessionShareAccessCursor | null,
+    getNextPageParam: (lastPage) => lastPage.nextCursor ?? undefined,
+    retry: false,
+  });
+  const createMutation = useMutation({
+    mutationFn: async (body: string) => {
+      const result = await createSharedNoteComment({
+        data: { shareId, body },
+      });
+      if (result.status !== "ready") {
+        throw new Error("comment unavailable");
+      }
+      return result.comment;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: commentsQueryKey(shareId),
+      });
+    },
+  });
+  const deleteMutation = useMutation({
+    mutationFn: async (commentId: string) => {
+      const result = await deleteSharedNoteComment({ data: commentId });
+      if (result.status !== "ready") {
+        throw new Error("comment unavailable");
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: commentsQueryKey(shareId),
+      });
+    },
+  });
+  const requestMutation = useMutation({
+    mutationFn: async () => {
+      const result = await requestSharedNoteCommentAccess({ data: shareId });
+      if (result.status !== "ready") {
+        throw new Error("access request unavailable");
+      }
+      return result.request;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: accessRequestQueryKey(shareId),
+      });
+    },
+  });
+  const cancelRequestMutation = useMutation({
+    mutationFn: async (requestId: string) => {
+      const result = await cancelMySharedNoteAccessRequest({ data: requestId });
+      if (result.status !== "ready") {
+        throw new Error("access request unavailable");
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: accessRequestQueryKey(shareId),
+      });
+    },
+  });
+  const reviewMutation = useMutation({
+    mutationFn: async ({
+      decision,
+      capability,
+      requestId,
+    }: {
+      decision: "approved" | "denied";
+      capability: SharedNoteCapability;
+      requestId: string;
+    }) => {
+      const result = await reviewSharedNoteAccessRequest({
+        data:
+          decision === "approved"
+            ? { capability, decision, requestId }
+            : { decision, requestId },
+      });
+      if (result.status !== "ready") {
+        throw new Error("access request unavailable");
+      }
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: managerAccessQueryKey(shareId),
+      });
+    },
+  });
+  const commentForm = useForm({
+    defaultValues: { body: "" },
+    onSubmit: async ({ formApi, value }) => {
+      const comment = validateSharedNoteCommentBody(value.body);
+      if (!comment.valid) return;
+      await createMutation.mutateAsync(comment.body);
+      formApi.reset();
+    },
+  });
+
+  const hasCollaborationAccess = hasSharedNoteCollaborationAccess(
+    commentsQuery.data?.pages[0],
+  );
+  const canCompose = canComposeSharedNoteComments({
+    capability,
+    hasCollaborationAccess,
+    manageAccess,
+  });
+  const comments = [...(commentsQuery.data?.pages ?? [])]
+    .reverse()
+    .flatMap((page) => (page.status === "ready" ? page.comments : []));
+  const accessRequest = accessRequestQuery.data ?? null;
+  const pendingManagerRequests = (managerAccessQuery.data?.pages ?? [])
+    .flatMap((page) => page.entries)
+    .filter(
+      (entry) => entry.entryType === "request" && entry.status === "pending",
+    );
+
+  return (
+    <section
+      aria-labelledby="shared-note-comments-heading"
+      className="surface border-color-subtle mt-6 rounded-3xl border px-6 py-7 shadow-sm sm:px-10"
+    >
+      <div className="flex items-start justify-between gap-5">
+        <div>
+          <div className="text-color flex items-center gap-2">
+            <MessageSquareIcon className="size-5" aria-hidden="true" />
+            <h2
+              id="shared-note-comments-heading"
+              className="font-mono text-lg font-medium"
+            >
+              Comments
+            </h2>
+          </div>
+          <p className="text-color-muted mt-1 text-sm leading-6">
+            A private conversation for people with access to this note.
+          </p>
+        </div>
+        {hasCollaborationAccess && commentsQuery.isSuccess && (
+          <span className="surface-subtle text-color-muted rounded-full px-3 py-1 font-mono text-xs">
+            {comments.length}
+            {commentsQuery.hasNextPage ? "+" : ""}
+          </span>
+        )}
+      </div>
+
+      {!signedIn ? (
+        <SignInToCollaborate returnPath={returnPath} />
+      ) : (
+        <>
+          {commentsQuery.isPending ||
+          commentsQuery.isError ||
+          hasCollaborationAccess ? (
+            <CommentList
+              comments={comments}
+              error={
+                (commentsQuery.isError &&
+                  !commentsQuery.isFetchNextPageError) ||
+                deleteMutation.isError
+              }
+              hasEarlier={commentsQuery.hasNextPage}
+              loading={commentsQuery.isPending}
+              loadingEarlier={commentsQuery.isFetchingNextPage}
+              loadEarlierError={commentsQuery.isFetchNextPageError}
+              manageAccess={manageAccess}
+              deletingCommentId={deleteMutation.variables ?? null}
+              deletePending={deleteMutation.isPending}
+              onDelete={(commentId) => deleteMutation.mutate(commentId)}
+              onLoadEarlier={() => void commentsQuery.fetchNextPage()}
+            />
+          ) : (
+            <p className="surface-subtle text-color-muted mt-6 rounded-2xl px-4 py-4 text-sm leading-6">
+              Comments are available after the note owner grants your account
+              access.
+            </p>
+          )}
+
+          {canCompose && (
+            <form
+              className="border-color-subtle mt-6 border-t pt-5"
+              onSubmit={(event) => {
+                event.preventDefault();
+                event.stopPropagation();
+                void commentForm.handleSubmit();
+              }}
+            >
+              <commentForm.Field name="body">
+                {(field) => {
+                  const comment = validateSharedNoteCommentBody(
+                    field.state.value,
+                  );
+                  const tooLong =
+                    comment.byteLength > MAX_SHARED_NOTE_COMMENT_BYTES;
+                  const errorId = "shared-note-comment-body-error";
+                  return (
+                    <>
+                      <label
+                        htmlFor="shared-note-comment-body"
+                        className="text-color font-mono text-sm font-medium"
+                      >
+                        Add a comment
+                      </label>
+                      <textarea
+                        id="shared-note-comment-body"
+                        className={cn([
+                          "surface-subtle border-color-subtle text-color mt-2 min-h-24 w-full resize-y rounded-2xl border px-4 py-3",
+                          "placeholder:text-color-muted text-sm leading-6 focus:border-stone-400 focus:ring-2 focus:ring-stone-300 focus:outline-hidden",
+                        ])}
+                        aria-describedby={tooLong ? errorId : undefined}
+                        aria-invalid={tooLong}
+                        placeholder="Share a thought about this note…"
+                        required
+                        value={field.state.value}
+                        onBlur={field.handleBlur}
+                        onChange={(event) =>
+                          field.handleChange(event.target.value)
+                        }
+                      />
+                      {tooLong && (
+                        <p
+                          id={errorId}
+                          className="mt-2 text-sm text-red-700"
+                          role="alert"
+                        >
+                          Comment is too long (
+                          {comment.byteLength.toLocaleString()}/
+                          {MAX_SHARED_NOTE_COMMENT_BYTES.toLocaleString()}{" "}
+                          bytes).
+                        </p>
+                      )}
+                      <div className="mt-3 flex items-center justify-between gap-4">
+                        <p className="text-color-muted text-xs">
+                          Visible only to people who can open this note.
+                        </p>
+                        <button
+                          type="submit"
+                          className={sharedPrimaryButtonClassName}
+                          disabled={createMutation.isPending || !comment.valid}
+                        >
+                          {createMutation.isPending ? (
+                            <LoaderCircleIcon
+                              className="mr-2 size-4 animate-spin"
+                              aria-hidden="true"
+                            />
+                          ) : (
+                            <SendIcon
+                              className="mr-2 size-4"
+                              aria-hidden="true"
+                            />
+                          )}
+                          Comment
+                        </button>
+                      </div>
+                    </>
+                  );
+                }}
+              </commentForm.Field>
+              {createMutation.isError && (
+                <p className="mt-3 text-sm text-red-700" role="status">
+                  Your comment couldn’t be added. Try again.
+                </p>
+              )}
+            </form>
+          )}
+
+          {!canCompose &&
+            !manageAccess &&
+            !commentsQuery.isPending &&
+            !commentsQuery.isError && (
+              <AccessRequestPanel
+                request={accessRequest}
+                error={
+                  accessRequestQuery.isError ||
+                  requestMutation.isError ||
+                  cancelRequestMutation.isError
+                }
+                loading={accessRequestQuery.isPending}
+                pending={
+                  requestMutation.isPending || cancelRequestMutation.isPending
+                }
+                onCancel={(requestId) =>
+                  cancelRequestMutation.mutate(requestId)
+                }
+                onRequest={() => requestMutation.mutate()}
+              />
+            )}
+
+          {manageAccess && (
+            <ManagerRequests
+              error={
+                managerAccessQuery.isError ||
+                managerAccessQuery.isFetchNextPageError ||
+                reviewMutation.isError
+              }
+              hasEarlierRequests={managerAccessQuery.hasNextPage}
+              loading={managerAccessQuery.isPending}
+              loadingEarlier={managerAccessQuery.isFetchingNextPage}
+              pendingRequestId={
+                reviewMutation.isPending
+                  ? (reviewMutation.variables?.requestId ?? null)
+                  : null
+              }
+              requests={pendingManagerRequests}
+              onLoadEarlier={() => managerAccessQuery.fetchNextPage()}
+              onReview={(requestId, decision, capability) =>
+                reviewMutation.mutate({ capability, decision, requestId })
+              }
+            />
+          )}
+        </>
+      )}
+    </section>
+  );
+}
+
+function CommentList({
+  comments,
+  deletePending,
+  deletingCommentId,
+  error,
+  hasEarlier,
+  loading,
+  loadingEarlier,
+  loadEarlierError,
+  manageAccess,
+  onDelete,
+  onLoadEarlier,
+}: {
+  comments: Array<{
+    body: string;
+    commentId: string;
+    createdAt: string;
+    isAuthor: boolean;
+  }>;
+  deletePending: boolean;
+  deletingCommentId: string | null;
+  error: boolean;
+  hasEarlier: boolean;
+  loading: boolean;
+  loadingEarlier: boolean;
+  loadEarlierError: boolean;
+  manageAccess: boolean;
+  onDelete: (commentId: string) => void;
+  onLoadEarlier: () => void;
+}) {
+  if (loading) {
+    return (
+      <div className="text-color-muted mt-6 flex items-center gap-2 text-sm">
+        <LoaderCircleIcon className="size-4 animate-spin" aria-hidden="true" />
+        Loading comments…
+      </div>
+    );
+  }
+  if (error) {
+    return (
+      <p className="mt-6 text-sm text-red-700" role="status">
+        Comments couldn’t be loaded right now.
+      </p>
+    );
+  }
+  if (!comments.length) {
+    return (
+      <p className="surface-subtle text-color-muted mt-6 rounded-2xl px-4 py-4 text-sm leading-6">
+        No comments yet.
+      </p>
+    );
+  }
+
+  return (
+    <>
+      {hasEarlier && (
+        <button
+          type="button"
+          className={cn([sharedSecondaryButtonClassName, "mt-6"])}
+          disabled={loadingEarlier}
+          onClick={onLoadEarlier}
+        >
+          {loadingEarlier && (
+            <LoaderCircleIcon
+              className="size-4 animate-spin"
+              aria-hidden="true"
+            />
+          )}
+          Load earlier comments
+        </button>
+      )}
+      {loadEarlierError && (
+        <p className="mt-3 text-sm text-red-700" role="status">
+          Earlier comments couldn’t be loaded. Please try again.
+        </p>
+      )}
+      <ol className="border-color-subtle mt-6 divide-y border-y">
+        {comments.map((comment) => {
+          const canDelete = comment.isAuthor || manageAccess;
+          const deleting =
+            deletePending && deletingCommentId === comment.commentId;
+          return (
+            <li key={comment.commentId} className="py-5">
+              <div className="flex items-start justify-between gap-4">
+                <div>
+                  <p className="text-color font-mono text-sm font-medium">
+                    {comment.isAuthor ? "You" : "Collaborator"}
+                  </p>
+                  <time
+                    className="text-color-muted mt-0.5 block text-xs"
+                    dateTime={comment.createdAt}
+                  >
+                    {formatCommentDate(comment.createdAt)}
+                  </time>
+                </div>
+                {canDelete && (
+                  <button
+                    type="button"
+                    className="text-color-muted hover:text-color rounded-full p-2 transition-colors focus-visible:ring-2 focus-visible:ring-stone-500 focus-visible:outline-hidden disabled:opacity-50"
+                    aria-label="Delete comment"
+                    disabled={deletePending}
+                    onClick={() => onDelete(comment.commentId)}
+                  >
+                    {deleting ? (
+                      <LoaderCircleIcon
+                        className="size-4 animate-spin"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <Trash2Icon className="size-4" aria-hidden="true" />
+                    )}
+                  </button>
+                )}
+              </div>
+              <p className="text-color mt-3 text-sm leading-6 whitespace-pre-wrap">
+                {comment.body}
+              </p>
+            </li>
+          );
+        })}
+      </ol>
+    </>
+  );
+}
+
+function SignInToCollaborate({ returnPath }: { returnPath: string }) {
+  const search = new URLSearchParams({
+    flow: "web",
+    redirect: returnPath,
+  });
+  return (
+    <div className="surface-subtle border-color-subtle mt-6 rounded-2xl border px-4 py-5 sm:flex sm:items-center sm:justify-between sm:gap-5">
+      <div>
+        <p className="text-color font-mono text-sm font-medium">
+          Sign in to join the conversation
+        </p>
+        <p className="text-color-muted mt-1 text-sm leading-6">
+          Sign in to view comments or request permission to comment.
+        </p>
+      </div>
+      <a
+        href={`/auth/?${search.toString()}`}
+        className={cn([sharedPrimaryButtonClassName, "mt-4 sm:mt-0"])}
+      >
+        <LogInIcon className="mr-2 size-4" aria-hidden="true" />
+        Sign in
+      </a>
+    </div>
+  );
+}
+
+function AccessRequestPanel({
+  error,
+  loading,
+  onCancel,
+  onRequest,
+  pending,
+  request,
+}: {
+  error: boolean;
+  loading: boolean;
+  onCancel: (requestId: string) => void;
+  onRequest: () => void;
+  pending: boolean;
+  request: SessionAccessRequestState | null;
+}) {
+  if (loading) {
+    return (
+      <div className="border-color-subtle text-color-muted mt-6 flex items-center gap-2 border-t pt-5 text-sm">
+        <LoaderCircleIcon className="size-4 animate-spin" aria-hidden="true" />
+        Checking comment access…
+      </div>
+    );
+  }
+
+  const isPending = request?.status === "pending";
+  const isApproved = request?.status === "approved";
+  const description = isPending
+    ? "The note owner can approve or decline your request."
+    : isApproved
+      ? "Your request was approved. Reload this note to use your new access."
+      : request?.status === "denied"
+        ? "Your previous request was declined. You can send a new request if needed."
+        : request?.status === "cancelled"
+          ? "Your previous request was cancelled."
+          : "Ask the note owner for permission to join the conversation.";
+
+  return (
+    <div className="border-color-subtle mt-6 border-t pt-5">
+      <div className="sm:flex sm:items-center sm:justify-between sm:gap-5">
+        <div>
+          <p className="text-color flex items-center gap-2 font-mono text-sm font-medium">
+            {isPending && <Clock3Icon className="size-4" aria-hidden="true" />}
+            {isApproved ? "Comment access approved" : "Want to comment?"}
+          </p>
+          <p className="text-color-muted mt-1 text-sm leading-6">
+            {description}
+          </p>
+        </div>
+        <div className="mt-4 flex shrink-0 gap-2 sm:mt-0">
+          {isPending ? (
+            <button
+              type="button"
+              className={sharedSecondaryButtonClassName}
+              disabled={pending}
+              onClick={() => onCancel(request.requestId)}
+            >
+              Cancel request
+            </button>
+          ) : isApproved ? (
+            <button
+              type="button"
+              className={sharedPrimaryButtonClassName}
+              onClick={() => window.location.reload()}
+            >
+              Reload note
+            </button>
+          ) : (
+            <button
+              type="button"
+              className={sharedPrimaryButtonClassName}
+              disabled={pending}
+              onClick={onRequest}
+            >
+              {pending ? "Requesting…" : "Request comment access"}
+            </button>
+          )}
+        </div>
+      </div>
+      {error && (
+        <p className="mt-3 text-sm text-red-700" role="status">
+          Comment access couldn’t be updated. Try again.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function ManagerRequests({
+  error,
+  hasEarlierRequests,
+  loading,
+  loadingEarlier,
+  onLoadEarlier,
+  onReview,
+  pendingRequestId,
+  requests,
+}: {
+  error: boolean;
+  hasEarlierRequests: boolean;
+  loading: boolean;
+  loadingEarlier: boolean;
+  onLoadEarlier: () => void;
+  onReview: (
+    requestId: string,
+    decision: "approved" | "denied",
+    capability: SharedNoteCapability,
+  ) => void;
+  pendingRequestId: string | null;
+  requests: Array<{
+    capability: SharedNoteCapability;
+    entryId: string;
+    userEmail: string;
+  }>;
+}) {
+  if (loading) {
+    return null;
+  }
+  if (!requests.length && !hasEarlierRequests && !error) {
+    return null;
+  }
+
+  return (
+    <div className="border-color-subtle mt-6 border-t pt-5">
+      <h3 className="text-color font-mono text-sm font-medium">
+        Access requests
+      </h3>
+      {requests.length > 0 && (
+        <ul className="mt-3 space-y-2">
+          {requests.map((request) => {
+            const pending = pendingRequestId === request.entryId;
+            return (
+              <li
+                key={request.entryId}
+                className="surface-subtle rounded-2xl px-4 py-3 sm:flex sm:items-center sm:justify-between sm:gap-4"
+              >
+                <div>
+                  <p className="text-color text-sm font-medium">
+                    {request.userEmail}
+                  </p>
+                  <p className="text-color-muted mt-0.5 text-xs">
+                    {formatSharedNoteAccessRequestDescription(
+                      request.capability,
+                    )}
+                  </p>
+                </div>
+                <div className="mt-3 flex gap-2 sm:mt-0">
+                  <button
+                    type="button"
+                    className={cn([
+                      sharedSecondaryButtonClassName,
+                      "min-h-9 px-3",
+                    ])}
+                    disabled={pendingRequestId !== null}
+                    onClick={() =>
+                      onReview(request.entryId, "denied", request.capability)
+                    }
+                  >
+                    <XIcon className="mr-1.5 size-4" aria-hidden="true" />
+                    Deny
+                  </button>
+                  <button
+                    type="button"
+                    className={cn([
+                      sharedPrimaryButtonClassName,
+                      "min-h-9 px-3",
+                    ])}
+                    disabled={pendingRequestId !== null}
+                    onClick={() =>
+                      onReview(request.entryId, "approved", request.capability)
+                    }
+                  >
+                    {pending ? (
+                      <LoaderCircleIcon
+                        className="mr-1.5 size-4 animate-spin"
+                        aria-hidden="true"
+                      />
+                    ) : (
+                      <CheckIcon className="mr-1.5 size-4" aria-hidden="true" />
+                    )}
+                    Approve
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+      {hasEarlierRequests && (
+        <button
+          type="button"
+          className={cn([sharedSecondaryButtonClassName, "mt-3"])}
+          disabled={loadingEarlier}
+          onClick={onLoadEarlier}
+        >
+          {loadingEarlier && (
+            <LoaderCircleIcon
+              className="mr-2 size-4 animate-spin"
+              aria-hidden="true"
+            />
+          )}
+          {loadingEarlier ? "Loading…" : "Load earlier requests"}
+        </button>
+      )}
+      {error && (
+        <p className="mt-3 text-sm text-red-700" role="status">
+          Access requests couldn’t be updated. Try again.
+        </p>
+      )}
+    </div>
+  );
+}
+
+function formatCommentDate(value: string) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(new Date(value));
+}

--- a/apps/web/src/components/shared-note-viewer.tsx
+++ b/apps/web/src/components/shared-note-viewer.tsx
@@ -34,11 +34,13 @@ export const sharedSecondaryButtonClassName = cn([
 export function SharedNoteViewer({
   accessLabel,
   actions,
+  collaboration,
   resolveAttachment,
   snapshot,
 }: {
   accessLabel: string;
   actions?: React.ReactNode;
+  collaboration?: React.ReactNode;
   resolveAttachment?: SharedAttachmentResolver;
   snapshot: SharedNoteSnapshot;
 }) {
@@ -69,6 +71,8 @@ export function SharedNoteViewer({
           />
         </div>
       </article>
+
+      {collaboration}
 
       {actions && (
         <aside className="surface-subtle border-color-subtle mt-6 rounded-2xl border p-5 sm:flex sm:items-center sm:justify-between sm:gap-6">

--- a/apps/web/src/functions/share-route-continuation.ts
+++ b/apps/web/src/functions/share-route-continuation.ts
@@ -1,0 +1,136 @@
+import { createServerFn } from "@tanstack/react-start";
+import {
+  deleteCookie,
+  getCookie,
+  getRequestHeaders,
+  setCookie,
+  setResponseHeader,
+} from "@tanstack/react-start/server";
+import { z } from "zod";
+
+import { getRequestAppOrigin } from "@/functions/app-origin";
+import {
+  isCapabilityShareRoutePathname,
+  isShareRouteToken,
+  readShareRouteContinuationCookie,
+} from "@/lib/share-route-privacy";
+
+const COOKIE_PREFIX = "anarlog-share-continuation-";
+const COOKIE_MAX_AGE_SECONDS = 15 * 60;
+
+const inputSchema = z
+  .object({
+    pathname: z.string().min(1).max(256),
+    token: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+  })
+  .strict();
+
+const pathnameSchema = z.string().min(1).max(256);
+
+export const persistShareRouteContinuation = createServerFn({ method: "POST" })
+  .inputValidator(inputSchema)
+  .handler(async ({ data }) => {
+    setPrivateContinuationResponseHeaders();
+    if (!isSameOriginContinuationRequest()) {
+      return false;
+    }
+
+    const pathname = canonicalCapabilityPathname(data.pathname);
+    if (!pathname || !isShareRouteToken(data.token)) {
+      return false;
+    }
+
+    const options = continuationCookieOptions();
+    setCookie(await continuationCookieName(pathname), data.token, options);
+    return true;
+  });
+
+export const restoreShareRouteContinuation = createServerFn({ method: "POST" })
+  .inputValidator(pathnameSchema)
+  .handler(async ({ data }) => {
+    setPrivateContinuationResponseHeaders();
+    if (!isSameOriginContinuationRequest()) {
+      return null;
+    }
+
+    const requestedPathname = canonicalCapabilityPathname(data);
+    if (!requestedPathname) {
+      return null;
+    }
+
+    const cookieName = await continuationCookieName(requestedPathname);
+    return readShareRouteContinuationCookie(getCookie(cookieName), () => {
+      clearContinuationCookie(cookieName);
+    });
+  });
+
+export const clearShareRouteContinuation = createServerFn({
+  method: "POST",
+})
+  .inputValidator(pathnameSchema)
+  .handler(async ({ data }) => {
+    setPrivateContinuationResponseHeaders();
+    if (!isSameOriginContinuationRequest()) {
+      return false;
+    }
+
+    const pathname = canonicalCapabilityPathname(data);
+    if (!pathname) {
+      return false;
+    }
+
+    clearContinuationCookie(await continuationCookieName(pathname));
+    return true;
+  });
+
+function canonicalCapabilityPathname(pathname: string) {
+  const canonical =
+    pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+  return isCapabilityShareRoutePathname(canonical) ? canonical : null;
+}
+
+function continuationCookieOptions() {
+  return {
+    httpOnly: true,
+    maxAge: COOKIE_MAX_AGE_SECONDS,
+    path: "/",
+    sameSite: "lax" as const,
+    secure: getRequestAppOrigin().startsWith("https://"),
+  };
+}
+
+function clearContinuationCookie(cookieName: string) {
+  const options = { path: "/" };
+  deleteCookie(cookieName, options);
+}
+
+async function continuationCookieName(pathname: string) {
+  const digest = await crypto.subtle.digest(
+    "SHA-256",
+    new TextEncoder().encode(pathname),
+  );
+  const suffix = Array.from(new Uint8Array(digest), (byte) =>
+    byte.toString(16).padStart(2, "0"),
+  ).join("");
+  return `${COOKIE_PREFIX}${suffix}`;
+}
+
+function isSameOriginContinuationRequest() {
+  const headers = getRequestHeaders();
+  const origin = headers.get("origin");
+  if (origin) {
+    try {
+      return new URL(origin).origin === getRequestAppOrigin();
+    } catch {
+      return false;
+    }
+  }
+
+  return headers.get("sec-fetch-site") === "same-origin";
+}
+
+function setPrivateContinuationResponseHeaders() {
+  setResponseHeader("Cache-Control", "private, no-store");
+  setResponseHeader("Referrer-Policy", "no-referrer");
+  setResponseHeader("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
+}

--- a/apps/web/src/functions/shared-notes.ts
+++ b/apps/web/src/functions/shared-notes.ts
@@ -9,11 +9,25 @@ import {
   type SharedNoteReadResult,
 } from "@/lib/shared-note-api";
 import {
+  MAX_SHARED_NOTE_COMMENT_BYTES,
+  validateSharedNoteCommentBody,
+} from "@/lib/shared-note-collaboration";
+import {
   type AuthenticatedSharedNote,
+  parseSessionAccessRequestState,
+  parseSessionInvitationState,
+  parseSessionShareAccessPage,
   parseAuthenticatedSharedNote,
+  parseSharedNoteComment,
+  parseSharedNoteCommentPage,
   parseSharedNoteAttachmentDownload,
   publicShareSlugSchema,
+  type SessionAccessRequestState,
+  type SessionInvitationState,
+  type SessionShareAccessPage,
   shareIdSchema,
+  type SharedNoteComment,
+  type SharedNoteCommentPage,
 } from "@/lib/shared-notes";
 
 export type AuthenticatedSharedNoteReadResult =
@@ -27,6 +41,121 @@ const attachmentDownloadInputSchema = z
     attachmentId: shareIdSchema,
   })
   .strict();
+
+const sharedNoteCommentInputSchema = z
+  .object({
+    shareId: shareIdSchema,
+    body: z.string().max(MAX_SHARED_NOTE_COMMENT_BYTES),
+  })
+  .strict();
+
+const listSharedNoteCommentsInputSchema = z
+  .object({
+    shareId: shareIdSchema,
+    beforeCreatedAt: z.iso.datetime({ offset: true }).max(64).nullable(),
+    beforeCommentId: shareIdSchema.nullable(),
+  })
+  .strict()
+  .refine(
+    ({ beforeCreatedAt, beforeCommentId }) =>
+      (beforeCreatedAt === null) === (beforeCommentId === null),
+  );
+
+const reviewSharedNoteAccessRequestInputSchema = z.discriminatedUnion(
+  "decision",
+  [
+    z
+      .object({
+        requestId: shareIdSchema,
+        decision: z.literal("approved"),
+        capability: z.enum(["viewer", "commenter", "editor"]),
+      })
+      .strict(),
+    z
+      .object({
+        requestId: shareIdSchema,
+        decision: z.literal("denied"),
+      })
+      .strict(),
+  ],
+);
+
+const listSharedNoteManagerAccessInputSchema = z
+  .object({
+    shareId: shareIdSchema,
+    beforeCreatedAt: z.iso.datetime({ offset: true }).max(64).nullable(),
+    beforeEntryId: shareIdSchema.nullable(),
+  })
+  .strict()
+  .refine(
+    ({ beforeCreatedAt, beforeEntryId }) =>
+      (beforeCreatedAt === null) === (beforeEntryId === null),
+  );
+
+const invitationActionInputSchema = z
+  .object({
+    invitationId: shareIdSchema,
+    token: z.string().regex(/^[A-Za-z0-9_-]{43}$/),
+  })
+  .strict();
+
+const requestSessionAccessRowSchema = z
+  .object({
+    request_id: shareIdSchema,
+    requested_capability: z.literal("commenter"),
+    was_created: z.boolean(),
+  })
+  .strict();
+
+const deletedCommentRowSchema = z
+  .object({
+    comment_id: shareIdSchema,
+    deleted_at: z.iso.datetime({ offset: true }).max(64),
+  })
+  .strict();
+
+const cancelledAccessRequestRowSchema = z
+  .object({
+    request_id: shareIdSchema,
+    status: z.literal("cancelled"),
+  })
+  .strict();
+
+const reviewedAccessRequestRowSchema = z.discriminatedUnion("status", [
+  z
+    .object({
+      request_id: shareIdSchema,
+      status: z.literal("approved"),
+      grant_id: shareIdSchema,
+      capability: z.enum(["viewer", "commenter", "editor"]),
+    })
+    .strict(),
+  z
+    .object({
+      request_id: shareIdSchema,
+      status: z.literal("denied"),
+      grant_id: z.null(),
+      capability: z.null(),
+    })
+    .strict(),
+]);
+
+const acceptedInvitationRowSchema = z
+  .object({
+    share_id: shareIdSchema,
+    grant_id: shareIdSchema,
+    capability: z.enum(["viewer", "commenter", "editor"]),
+  })
+  .strict();
+
+type SharedNoteOperationStatus =
+  | { status: "ready" }
+  | { status: "unavailable" }
+  | { status: "error" };
+
+type SharedNoteAccessRequestResult =
+  | { status: "ready"; request: SessionAccessRequestState | null }
+  | { status: "error" };
 
 export const readAuthenticatedSharedNote = createServerFn({ method: "GET" })
   .inputValidator(shareIdSchema)
@@ -64,6 +193,312 @@ export const readPublicSharedNote = createServerFn({ method: "GET" })
     setResponseHeader("Referrer-Policy", "no-referrer");
     return fetchPublicSharedNoteResult(publicSlug);
   });
+
+export const listSharedNoteComments = createServerFn({ method: "GET" })
+  .inputValidator(listSharedNoteCommentsInputSchema)
+  .handler(
+    async ({
+      data: input,
+    }): Promise<
+      | ({ status: "ready" } & SharedNoteCommentPage)
+      | { status: "unavailable" }
+      | { status: "error" }
+    > => {
+      setPrivateShareResponseHeaders();
+
+      const supabase = getSupabaseServerClient();
+      const { data, error } = await supabase.rpc(
+        "list_session_share_comments",
+        {
+          p_share_id: input.shareId,
+          p_before_created_at: input.beforeCreatedAt,
+          p_before_comment_id: input.beforeCommentId,
+          p_limit: 101,
+        },
+      );
+      if (error) return unavailableOrError(error.code);
+
+      try {
+        return {
+          status: "ready",
+          ...parseSharedNoteCommentPage(data),
+        };
+      } catch {
+        return { status: "error" };
+      }
+    },
+  );
+
+export const createSharedNoteComment = createServerFn({ method: "POST" })
+  .inputValidator(sharedNoteCommentInputSchema)
+  .handler(
+    async ({
+      data,
+    }): Promise<
+      | { status: "ready"; comment: SharedNoteComment }
+      | { status: "unavailable" }
+      | { status: "error" }
+    > => {
+      setPrivateShareResponseHeaders();
+      const comment = validateSharedNoteCommentBody(data.body);
+      if (!comment.valid) {
+        return { status: "unavailable" };
+      }
+
+      const supabase = getSupabaseServerClient();
+      const { data: commentRows, error } = await supabase.rpc(
+        "create_session_share_comment",
+        {
+          p_share_id: data.shareId,
+          p_body: comment.body,
+        },
+      );
+      if (error) return unavailableOrError(error.code);
+      if (!Array.isArray(commentRows) || commentRows.length === 0) {
+        return { status: "unavailable" };
+      }
+      if (commentRows.length !== 1) return { status: "error" };
+
+      try {
+        return {
+          status: "ready",
+          comment: parseSharedNoteComment(commentRows[0]),
+        };
+      } catch {
+        return { status: "error" };
+      }
+    },
+  );
+
+export const deleteSharedNoteComment = createServerFn({ method: "POST" })
+  .inputValidator(shareIdSchema)
+  .handler(async ({ data: commentId }): Promise<SharedNoteOperationStatus> => {
+    setPrivateShareResponseHeaders();
+
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase.rpc("delete_session_share_comment", {
+      p_comment_id: commentId,
+    });
+    if (error) return unavailableOrError(error.code);
+    if (!Array.isArray(data) || data.length === 0) {
+      return { status: "unavailable" };
+    }
+    if (data.length !== 1) return { status: "error" };
+
+    try {
+      const parsed = deletedCommentRowSchema.parse(data[0]);
+      return parsed.comment_id === commentId
+        ? { status: "ready" }
+        : { status: "error" };
+    } catch {
+      return { status: "error" };
+    }
+  });
+
+export const getMySharedNoteAccessRequest = createServerFn({ method: "GET" })
+  .inputValidator(shareIdSchema)
+  .handler(
+    async ({ data: shareId }): Promise<SharedNoteAccessRequestResult> => {
+      setPrivateShareResponseHeaders();
+      return loadMySharedNoteAccessRequest(shareId);
+    },
+  );
+
+export const requestSharedNoteCommentAccess = createServerFn({ method: "POST" })
+  .inputValidator(shareIdSchema)
+  .handler(
+    async ({ data: shareId }): Promise<SharedNoteAccessRequestResult> => {
+      setPrivateShareResponseHeaders();
+
+      const supabase = getSupabaseServerClient();
+      const { data, error } = await supabase.rpc("request_session_access", {
+        p_share_id: shareId,
+        p_requested_capability: "commenter",
+      });
+      if (error || !Array.isArray(data) || data.length !== 1) {
+        return { status: "error" };
+      }
+
+      try {
+        const requested = requestSessionAccessRowSchema.parse(data[0]);
+        const result = await loadMySharedNoteAccessRequest(shareId);
+        if (
+          result.status !== "ready" ||
+          result.request?.requestId !== requested.request_id ||
+          result.request.requestedCapability !== "commenter" ||
+          result.request.status !== "pending"
+        ) {
+          return { status: "error" };
+        }
+        return result;
+      } catch {
+        return { status: "error" };
+      }
+    },
+  );
+
+export const cancelMySharedNoteAccessRequest = createServerFn({
+  method: "POST",
+})
+  .inputValidator(shareIdSchema)
+  .handler(async ({ data: requestId }): Promise<SharedNoteOperationStatus> => {
+    setPrivateShareResponseHeaders();
+
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase.rpc(
+      "cancel_session_access_request",
+      { p_request_id: requestId },
+    );
+    if (error) return unavailableOrError(error.code);
+    if (!Array.isArray(data) || data.length === 0) {
+      return { status: "unavailable" };
+    }
+    if (data.length !== 1) return { status: "error" };
+
+    try {
+      const parsed = cancelledAccessRequestRowSchema.parse(data[0]);
+      return parsed.request_id === requestId
+        ? { status: "ready" }
+        : { status: "error" };
+    } catch {
+      return { status: "error" };
+    }
+  });
+
+export const listSharedNoteManagerAccess = createServerFn({ method: "GET" })
+  .inputValidator(listSharedNoteManagerAccessInputSchema)
+  .handler(
+    async ({
+      data: input,
+    }): Promise<
+      | ({ status: "ready" } & SessionShareAccessPage)
+      | { status: "unavailable" }
+      | { status: "error" }
+    > => {
+      setPrivateShareResponseHeaders();
+
+      const supabase = getSupabaseServerClient();
+      const { data, error } = await supabase.rpc(
+        "list_session_share_access_page",
+        {
+          p_share_id: input.shareId,
+          p_before_created_at: input.beforeCreatedAt,
+          p_before_entry_id: input.beforeEntryId,
+          p_limit: 101,
+        },
+      );
+      if (error) return unavailableOrError(error.code);
+
+      try {
+        return { status: "ready", ...parseSessionShareAccessPage(data) };
+      } catch {
+        return { status: "error" };
+      }
+    },
+  );
+
+export const reviewSharedNoteAccessRequest = createServerFn({ method: "POST" })
+  .inputValidator(reviewSharedNoteAccessRequestInputSchema)
+  .handler(async ({ data: input }): Promise<SharedNoteOperationStatus> => {
+    setPrivateShareResponseHeaders();
+
+    const supabase = getSupabaseServerClient();
+    const { data, error } = await supabase.rpc(
+      "review_session_access_request",
+      {
+        p_request_id: input.requestId,
+        p_decision: input.decision,
+        p_capability: input.decision === "approved" ? input.capability : null,
+      },
+    );
+    if (error) return unavailableOrError(error.code);
+    if (!Array.isArray(data) || data.length === 0) {
+      return { status: "unavailable" };
+    }
+    if (data.length !== 1) return { status: "error" };
+
+    try {
+      const parsed = reviewedAccessRequestRowSchema.parse(data[0]);
+      return parsed.request_id === input.requestId &&
+        parsed.status === input.decision
+        ? { status: "ready" }
+        : { status: "error" };
+    } catch {
+      return { status: "error" };
+    }
+  });
+
+export const inspectMySharedNoteInvitation = createServerFn({ method: "POST" })
+  .inputValidator(invitationActionInputSchema)
+  .handler(
+    async ({
+      data: input,
+    }): Promise<
+      | { status: "ready"; invitation: SessionInvitationState }
+      | { status: "unavailable" }
+      | { status: "error" }
+    > => {
+      setPrivateShareResponseHeaders();
+
+      const supabase = getSupabaseServerClient();
+      const { data, error } = await supabase.rpc(
+        "inspect_my_session_access_invitation",
+        {
+          p_invitation_id: input.invitationId,
+          p_invite_token: input.token,
+        },
+      );
+      if (error) return unavailableOrError(error.code);
+      if (!Array.isArray(data) || data.length === 0) {
+        return { status: "unavailable" };
+      }
+      if (data.length !== 1) return { status: "error" };
+
+      try {
+        return {
+          status: "ready",
+          invitation: parseSessionInvitationState(data[0]),
+        };
+      } catch {
+        return { status: "error" };
+      }
+    },
+  );
+
+export const acceptSharedNoteInvitation = createServerFn({ method: "POST" })
+  .inputValidator(invitationActionInputSchema)
+  .handler(
+    async ({
+      data: input,
+    }): Promise<
+      | { status: "ready"; shareId: string }
+      | { status: "unavailable" }
+      | { status: "error" }
+    > => {
+      setPrivateShareResponseHeaders();
+
+      const supabase = getSupabaseServerClient();
+      const { data, error } = await supabase.rpc(
+        "accept_session_access_invitation",
+        {
+          p_invitation_id: input.invitationId,
+          p_invite_token: input.token,
+        },
+      );
+      if (error) return unavailableOrError(error.code);
+      if (!Array.isArray(data) || data.length === 0) {
+        return { status: "unavailable" };
+      }
+      if (data.length !== 1) return { status: "error" };
+
+      try {
+        const accepted = acceptedInvitationRowSchema.parse(data[0]);
+        return { status: "ready", shareId: accepted.share_id };
+      } catch {
+        return { status: "error" };
+      }
+    },
+  );
 
 export const createAuthenticatedSharedAttachmentDownload = createServerFn({
   method: "POST",
@@ -104,6 +539,38 @@ function setPrivateShareResponseHeaders() {
   setResponseHeader("Cache-Control", "private, no-store");
   setResponseHeader("Referrer-Policy", "no-referrer");
   setResponseHeader("X-Robots-Tag", "noindex, nofollow, noarchive, nosnippet");
+}
+
+async function loadMySharedNoteAccessRequest(
+  shareId: string,
+): Promise<SharedNoteAccessRequestResult> {
+  const supabase = getSupabaseServerClient();
+  const { data, error } = await supabase.rpc("get_my_session_access_request", {
+    p_share_id: shareId,
+  });
+  if (error || !Array.isArray(data) || data.length > 1) {
+    return { status: "error" };
+  }
+  if (data.length === 0) {
+    return { status: "ready", request: null };
+  }
+
+  try {
+    return {
+      status: "ready",
+      request: parseSessionAccessRequestState(data[0]),
+    };
+  } catch {
+    return { status: "error" };
+  }
+}
+
+function unavailableOrError(
+  code: string | undefined,
+): { status: "unavailable" } | { status: "error" } {
+  return code === "22023" || code === "42501"
+    ? { status: "unavailable" }
+    : { status: "error" };
 }
 
 function apiBaseUrl() {

--- a/apps/web/src/lib/share-route-privacy.test.ts
+++ b/apps/web/src/lib/share-route-privacy.test.ts
@@ -2,12 +2,16 @@ import assert from "node:assert/strict";
 import test from "node:test";
 
 import {
+  clearPersistedShareRouteToken,
   clearShareRouteToken,
   getShareRouteToken,
   isCapabilityShareRoutePathname,
   isShareRoutePathname,
+  loadShareRouteContinuation,
   parseShareFragmentToken,
   prepareShareRoutePrivacy,
+  readShareRouteContinuationCookie,
+  retainShareRouteToken,
 } from "./share-route-privacy.ts";
 
 const TOKEN = "a".repeat(43);
@@ -37,6 +41,78 @@ test("accepts one valid fragment token and rejects ambiguous fragments", () => {
   assert.equal(parseShareFragmentToken(`#other=${TOKEN}`), null);
   assert.equal(parseShareFragmentToken("#token=short"), null);
   assert.equal(parseShareFragmentToken(`?token=${TOKEN}`), null);
+});
+
+test("reads a valid continuation cookie without consuming it", () => {
+  let clearCount = 0;
+  const clearInvalid = () => {
+    clearCount += 1;
+  };
+
+  assert.equal(readShareRouteContinuationCookie(TOKEN, clearInvalid), TOKEN);
+  assert.equal(clearCount, 0);
+  assert.equal(readShareRouteContinuationCookie("short", clearInvalid), null);
+  assert.equal(clearCount, 1);
+});
+
+test("preserves recovery state across cancellation and persistence failure", async () => {
+  const controller = new AbortController();
+  let retainedToken: string | null = null;
+  let clearedPersisted = 0;
+
+  await assert.rejects(
+    loadShareRouteContinuation({
+      clearPersisted: () => {
+        clearedPersisted += 1;
+      },
+      localToken: null,
+      persist: async () => true,
+      restore: async () => {
+        controller.abort();
+        return TOKEN;
+      },
+      retain: (token) => {
+        retainedToken = token;
+        return true;
+      },
+      signal: controller.signal,
+    }),
+    { name: "AbortError" },
+  );
+  assert.equal(retainedToken, null);
+  assert.equal(clearedPersisted, 0);
+
+  await assert.rejects(
+    loadShareRouteContinuation({
+      clearPersisted: () => {
+        clearedPersisted += 1;
+      },
+      localToken: null,
+      persist: async () => false,
+      restore: async () => TOKEN,
+      retain: (token) => {
+        retainedToken = token;
+        return true;
+      },
+    }),
+    /share continuation unavailable/,
+  );
+  assert.equal(retainedToken, TOKEN);
+  assert.equal(clearedPersisted, 0);
+
+  assert.equal(
+    await loadShareRouteContinuation({
+      clearPersisted: () => {
+        clearedPersisted += 1;
+      },
+      localToken: retainedToken,
+      persist: async () => true,
+      restore: async () => null,
+      retain: () => false,
+    }),
+    TOKEN,
+  );
+  assert.equal(clearedPersisted, 1);
 });
 
 test("scrubs a capability fragment before retaining it for the current tab", () => {
@@ -70,6 +146,10 @@ test("scrubs a capability fragment before retaining it for the current tab", () 
     prepareShareRoutePrivacy();
     assert.equal(replacedUrl, pathname);
     assert.equal(replacedUrl.includes(TOKEN), false);
+    assert.equal(getShareRouteToken(pathname), TOKEN);
+    assert.equal(storage.size, 1);
+    clearPersistedShareRouteToken(pathname);
+    assert.equal(storage.size, 0);
     assert.equal(getShareRouteToken(pathname), TOKEN);
     clearShareRouteToken(pathname);
     assert.equal(getShareRouteToken(pathname), null);
@@ -119,5 +199,34 @@ test("retains capability tokens across trailing-slash normalization", () => {
     } finally {
       Reflect.deleteProperty(globalThis, "window");
     }
+  }
+});
+
+test("restores only valid capability tokens for their exact route", () => {
+  const pathname = "/share/invite/00000000-0000-4000-8000-000000000001/";
+  const storage = new Map<string, string>();
+
+  Object.defineProperty(globalThis, "window", {
+    configurable: true,
+    value: {
+      sessionStorage: {
+        getItem: (key: string) => storage.get(key) ?? null,
+        removeItem: (key: string) => storage.delete(key),
+        setItem: (key: string, value: string) => storage.set(key, value),
+      },
+    },
+  });
+
+  try {
+    assert.equal(retainShareRouteToken(pathname, TOKEN), true);
+    assert.equal(getShareRouteToken(pathname), TOKEN);
+    assert.equal(
+      retainShareRouteToken("/share/public/s_example/", TOKEN),
+      false,
+    );
+    assert.equal(retainShareRouteToken(pathname, "short"), false);
+  } finally {
+    clearShareRouteToken(pathname);
+    Reflect.deleteProperty(globalThis, "window");
   }
 });

--- a/apps/web/src/lib/share-route-privacy.ts
+++ b/apps/web/src/lib/share-route-privacy.ts
@@ -32,6 +32,58 @@ export function isShareRouteToken(value: string) {
   return SHARE_TOKEN_PATTERN.test(value);
 }
 
+export function readShareRouteContinuationCookie(
+  value: string | undefined,
+  clearInvalid: () => void,
+) {
+  if (!value) {
+    return null;
+  }
+  if (!isShareRouteToken(value)) {
+    clearInvalid();
+    return null;
+  }
+  return value;
+}
+
+export async function loadShareRouteContinuation({
+  clearPersisted,
+  localToken,
+  persist,
+  restore,
+  retain,
+  signal,
+}: {
+  clearPersisted: () => void;
+  localToken: string | null;
+  persist: (token: string) => Promise<boolean>;
+  restore: () => Promise<string | null>;
+  retain: (token: string) => boolean;
+  signal?: AbortSignal;
+}) {
+  signal?.throwIfAborted();
+  let token = localToken;
+  if (!token) {
+    token = await restore();
+    signal?.throwIfAborted();
+    if (!token) {
+      return null;
+    }
+    if (!retain(token)) {
+      throw new Error("share continuation unavailable");
+    }
+  }
+
+  const persisted = await persist(token);
+  signal?.throwIfAborted();
+  if (!persisted) {
+    throw new Error("share continuation unavailable");
+  }
+
+  clearPersisted();
+  return token;
+}
+
 export function prepareShareRoutePrivacy() {
   if (typeof window === "undefined") {
     return;
@@ -75,11 +127,39 @@ export function getShareRouteToken(pathname: string): string | null {
   return inMemoryToken?.token ?? null;
 }
 
+export function retainShareRouteToken(pathname: string, token: string) {
+  if (typeof window === "undefined" || !isShareRouteToken(token)) {
+    return false;
+  }
+
+  const tokenPathname = canonicalShareRoutePathname(pathname);
+  if (!isCapabilityShareRoutePathname(tokenPathname)) {
+    return false;
+  }
+
+  inMemoryToken = { pathname: tokenPathname, token };
+  try {
+    window.sessionStorage.setItem(
+      SHARE_TOKEN_STORAGE_KEY,
+      JSON.stringify(inMemoryToken),
+    );
+  } catch {
+    // The in-memory copy still supports the current page when storage is unavailable.
+  }
+  return true;
+}
+
 export function clearShareRouteToken(pathname: string) {
   const tokenPathname = canonicalShareRoutePathname(pathname);
   if (inMemoryToken?.pathname === tokenPathname) {
     inMemoryToken = null;
   }
+
+  clearPersistedShareRouteToken(pathname);
+}
+
+export function clearPersistedShareRouteToken(pathname: string) {
+  const tokenPathname = canonicalShareRoutePathname(pathname);
 
   if (typeof window === "undefined") {
     return;

--- a/apps/web/src/lib/shared-note-collaboration.test.ts
+++ b/apps/web/src/lib/shared-note-collaboration.test.ts
@@ -1,0 +1,161 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  canComposeSharedNoteComments,
+  formatAuthenticatedSharedNoteAccessLabel,
+  formatSharedNoteAccessRequestDescription,
+  hasSharedNoteCollaborationAccess,
+  MAX_SHARED_NOTE_COMMENT_BYTES,
+  shouldUseAuthenticatedSharedNoteAccessLabel,
+  validateSharedNoteCommentBody,
+} from "./shared-note-collaboration.ts";
+
+test("general viewer access never implies comment access", () => {
+  assert.equal(
+    canComposeSharedNoteComments({
+      capability: "commenter",
+      hasCollaborationAccess: false,
+      manageAccess: false,
+    }),
+    false,
+  );
+  assert.equal(
+    canComposeSharedNoteComments({
+      capability: "viewer",
+      hasCollaborationAccess: true,
+      manageAccess: false,
+    }),
+    false,
+  );
+});
+
+test("named commenters, editors, and managers can compose", () => {
+  for (const capability of ["commenter", "editor"] as const) {
+    assert.equal(
+      canComposeSharedNoteComments({
+        capability,
+        hasCollaborationAccess: true,
+        manageAccess: false,
+      }),
+      true,
+    );
+  }
+  assert.equal(
+    canComposeSharedNoteComments({
+      capability: "viewer",
+      hasCollaborationAccess: true,
+      manageAccess: true,
+    }),
+    true,
+  );
+});
+
+test("only an authorized comment feed grants collaboration access", () => {
+  assert.equal(hasSharedNoteCollaborationAccess({ status: "ready" }), true);
+  assert.equal(
+    hasSharedNoteCollaborationAccess({ status: "unavailable" }),
+    false,
+  );
+  assert.equal(hasSharedNoteCollaborationAccess({ status: "error" }), false);
+  assert.equal(hasSharedNoteCollaborationAccess(undefined), false);
+});
+
+test("comment validation uses the normalized UTF-8 byte length", () => {
+  assert.deepEqual(validateSharedNoteCommentBody(" \n\t "), {
+    body: "",
+    byteLength: 0,
+    valid: false,
+  });
+  assert.deepEqual(validateSharedNoteCommentBody("  hello  "), {
+    body: "hello",
+    byteLength: 5,
+    valid: true,
+  });
+  assert.equal(
+    validateSharedNoteCommentBody("x".repeat(MAX_SHARED_NOTE_COMMENT_BYTES))
+      .valid,
+    true,
+  );
+  assert.equal(
+    validateSharedNoteCommentBody("x".repeat(MAX_SHARED_NOTE_COMMENT_BYTES + 1))
+      .valid,
+    false,
+  );
+  assert.deepEqual(validateSharedNoteCommentBody("字".repeat(5_461)), {
+    body: "字".repeat(5_461),
+    byteLength: 16_383,
+    valid: true,
+  });
+  assert.equal(validateSharedNoteCommentBody("字".repeat(5_462)).valid, false);
+});
+
+test("access labels match the authenticated capability", () => {
+  assert.equal(
+    formatAuthenticatedSharedNoteAccessLabel({
+      capability: "viewer",
+      manageAccess: false,
+    }),
+    "Shared with you · View only",
+  );
+  assert.equal(
+    formatAuthenticatedSharedNoteAccessLabel({
+      capability: "commenter",
+      manageAccess: false,
+    }),
+    "Shared with you · Can comment",
+  );
+  assert.equal(
+    formatAuthenticatedSharedNoteAccessLabel({
+      capability: "editor",
+      manageAccess: true,
+    }),
+    "You manage this note · Can edit and comment",
+  );
+});
+
+test("general viewers keep the route-level access label", () => {
+  assert.equal(
+    shouldUseAuthenticatedSharedNoteAccessLabel({
+      capability: "viewer",
+      manageAccess: false,
+    }),
+    false,
+  );
+  assert.equal(
+    shouldUseAuthenticatedSharedNoteAccessLabel({
+      capability: "commenter",
+      manageAccess: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseAuthenticatedSharedNoteAccessLabel({
+      capability: "editor",
+      manageAccess: false,
+    }),
+    true,
+  );
+  assert.equal(
+    shouldUseAuthenticatedSharedNoteAccessLabel({
+      capability: "viewer",
+      manageAccess: true,
+    }),
+    true,
+  );
+});
+
+test("access request descriptions preserve the requested capability", () => {
+  assert.equal(
+    formatSharedNoteAccessRequestDescription("viewer"),
+    "Requested permission to view",
+  );
+  assert.equal(
+    formatSharedNoteAccessRequestDescription("commenter"),
+    "Requested permission to comment",
+  );
+  assert.equal(
+    formatSharedNoteAccessRequestDescription("editor"),
+    "Requested permission to edit",
+  );
+});

--- a/apps/web/src/lib/shared-note-collaboration.ts
+++ b/apps/web/src/lib/shared-note-collaboration.ts
@@ -1,0 +1,69 @@
+import type { SharedNoteCapability } from "@/lib/shared-notes";
+
+export const MAX_SHARED_NOTE_COMMENT_BYTES = 16_384;
+
+export function validateSharedNoteCommentBody(value: string) {
+  const body = value.trim();
+  const byteLength = new TextEncoder().encode(body).byteLength;
+  return {
+    body,
+    byteLength,
+    valid: body.length > 0 && byteLength <= MAX_SHARED_NOTE_COMMENT_BYTES,
+  };
+}
+
+export function formatAuthenticatedSharedNoteAccessLabel({
+  capability,
+  manageAccess,
+}: {
+  capability: SharedNoteCapability;
+  manageAccess: boolean;
+}) {
+  if (manageAccess) return "You manage this note · Can edit and comment";
+  if (capability === "editor") return "Shared with you · Can edit and comment";
+  if (capability === "commenter") return "Shared with you · Can comment";
+  return "Shared with you · View only";
+}
+
+export function shouldUseAuthenticatedSharedNoteAccessLabel({
+  capability,
+  manageAccess,
+}: {
+  capability: SharedNoteCapability;
+  manageAccess: boolean;
+}) {
+  return manageAccess || capability !== "viewer";
+}
+
+export function canComposeSharedNoteComments({
+  capability,
+  hasCollaborationAccess,
+  manageAccess,
+}: {
+  capability: SharedNoteCapability;
+  hasCollaborationAccess: boolean;
+  manageAccess: boolean;
+}) {
+  return (
+    hasCollaborationAccess &&
+    (manageAccess || capability === "commenter" || capability === "editor")
+  );
+}
+
+export function hasSharedNoteCollaborationAccess(
+  result:
+    | { status: "ready" }
+    | { status: "unavailable" }
+    | { status: "error" }
+    | undefined,
+) {
+  return result?.status === "ready";
+}
+
+export function formatSharedNoteAccessRequestDescription(
+  capability: SharedNoteCapability,
+) {
+  if (capability === "editor") return "Requested permission to edit";
+  if (capability === "commenter") return "Requested permission to comment";
+  return "Requested permission to view";
+}

--- a/apps/web/src/lib/shared-note-route-state.test.ts
+++ b/apps/web/src/lib/shared-note-route-state.test.ts
@@ -1,0 +1,67 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+
+import {
+  getInvitationRouteFailure,
+  getLinkSharedNoteRouteGate,
+} from "./shared-note-route-state.ts";
+
+test("keeps failed invitation acceptance retryable", () => {
+  assert.equal(
+    getInvitationRouteFailure({
+      acceptanceFailed: true,
+      inspectionFailed: false,
+      inspectionReady: true,
+    }),
+    "accept-retry",
+  );
+  assert.equal(
+    getInvitationRouteFailure({
+      acceptanceFailed: false,
+      inspectionFailed: false,
+      inspectionReady: true,
+    }),
+    null,
+  );
+  assert.equal(
+    getInvitationRouteFailure({
+      acceptanceFailed: true,
+      inspectionFailed: true,
+      inspectionReady: false,
+    }),
+    "unavailable",
+  );
+});
+
+test("authenticated access outranks continuation failures", () => {
+  assert.equal(
+    getLinkSharedNoteRouteGate({
+      authenticatedNotePending: false,
+      continuationFailed: true,
+      continuationPending: false,
+      hasAuthenticatedNote: true,
+      linkSnapshotPending: false,
+    }),
+    null,
+  );
+  assert.equal(
+    getLinkSharedNoteRouteGate({
+      authenticatedNotePending: true,
+      continuationFailed: true,
+      continuationPending: false,
+      hasAuthenticatedNote: false,
+      linkSnapshotPending: false,
+    }),
+    "loading",
+  );
+  assert.equal(
+    getLinkSharedNoteRouteGate({
+      authenticatedNotePending: false,
+      continuationFailed: true,
+      continuationPending: false,
+      hasAuthenticatedNote: false,
+      linkSnapshotPending: false,
+    }),
+    "continuation-error",
+  );
+});

--- a/apps/web/src/lib/shared-note-route-state.ts
+++ b/apps/web/src/lib/shared-note-route-state.ts
@@ -1,0 +1,42 @@
+export function getInvitationRouteFailure({
+  acceptanceFailed,
+  inspectionFailed,
+  inspectionReady,
+}: {
+  acceptanceFailed: boolean;
+  inspectionFailed: boolean;
+  inspectionReady: boolean;
+}): "accept-retry" | "unavailable" | null {
+  if (inspectionFailed || !inspectionReady) {
+    return "unavailable";
+  }
+  return acceptanceFailed ? "accept-retry" : null;
+}
+
+export function getLinkSharedNoteRouteGate({
+  authenticatedNotePending,
+  continuationFailed,
+  continuationPending,
+  hasAuthenticatedNote,
+  linkSnapshotPending,
+}: {
+  authenticatedNotePending: boolean;
+  continuationFailed: boolean;
+  continuationPending: boolean;
+  hasAuthenticatedNote: boolean;
+  linkSnapshotPending: boolean;
+}): "continuation-error" | "loading" | null {
+  if (hasAuthenticatedNote) {
+    return null;
+  }
+  if (authenticatedNotePending) {
+    return "loading";
+  }
+  if (continuationFailed) {
+    return "continuation-error";
+  }
+  if (continuationPending || linkSnapshotPending) {
+    return "loading";
+  }
+  return null;
+}

--- a/apps/web/src/lib/shared-notes.test.ts
+++ b/apps/web/src/lib/shared-notes.test.ts
@@ -9,8 +9,14 @@ import {
   getSharedNoteDescription,
   parseAuthenticatedSharedNote,
   parseGatewaySharedNote,
+  parseSessionAccessRequestState,
+  parseSessionInvitationState,
+  parseSessionShareAccessEntry,
+  parseSessionShareAccessPage,
   parseShareHandoff,
   parseSharedNoteAttachmentDownload,
+  parseSharedNoteComment,
+  parseSharedNoteCommentPage,
   withoutDuplicateLeadingTitle,
 } from "./shared-notes.ts";
 
@@ -92,10 +98,14 @@ test("maps authenticated snake-case RPC rows without internal identifiers", () =
     body_json: BODY,
     attachments_json: [],
     capability: "commenter",
+    manage_access: true,
+    access_version: 7,
     published_at: "2026-07-17T12:00:00Z",
   });
 
   assert.equal(result.capability, "commenter");
+  assert.equal(result.manageAccess, true);
+  assert.equal(result.accessVersion, 7);
   assert.equal("workspaceId" in result.snapshot, false);
   assert.equal("sessionId" in result.snapshot, false);
   assert.throws(() =>
@@ -109,6 +119,264 @@ test("maps authenticated snake-case RPC rows without internal identifiers", () =
       published_at: "2026-07-17T12:00:00Z",
     }),
   );
+
+  assert.throws(() =>
+    parseAuthenticatedSharedNote({
+      share_id: "00000000-0000-4000-8000-000000000001",
+      schema_version: 1,
+      content_revision: 3,
+      title: "Weekly sync",
+      body_json: BODY,
+      capability: "commenter",
+      manage_access: true,
+      access_version: 0,
+      published_at: "2026-07-17T12:00:00Z",
+    }),
+  );
+});
+
+test("parses bounded shared-note comment rows", () => {
+  assert.deepEqual(
+    parseSharedNoteComment({
+      comment_id: "00000000-0000-4000-8000-000000000002",
+      is_author: true,
+      body: "Looks good to me.",
+      snapshot_content_revision: 4,
+      created_at: "2026-07-17T12:00:00Z",
+    }),
+    {
+      commentId: "00000000-0000-4000-8000-000000000002",
+      isAuthor: true,
+      body: "Looks good to me.",
+      snapshotRevision: 4,
+      createdAt: "2026-07-17T12:00:00Z",
+    },
+  );
+
+  const valid = {
+    comment_id: "00000000-0000-4000-8000-000000000002",
+    is_author: false,
+    body: "Looks good to me.",
+    snapshot_content_revision: 4,
+    created_at: "2026-07-17T12:00:00Z",
+  };
+  assert.throws(() => parseSharedNoteComment({ ...valid, body: "" }));
+  assert.throws(() =>
+    parseSharedNoteComment({ ...valid, body: "a".repeat(16385) }),
+  );
+  assert.throws(() => parseSharedNoteComment({ ...valid, is_author: "yes" }));
+  assert.throws(() =>
+    parseSharedNoteComment({ ...valid, snapshot_content_revision: 0 }),
+  );
+  assert.throws(() => parseSharedNoteComment({ ...valid, private_note: true }));
+});
+
+test("bounds comment pages and derives an older-history cursor", () => {
+  const rows = Array.from({ length: 101 }, (_, index) => ({
+    comment_id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    is_author: index === 0,
+    body: `Comment ${index}`,
+    snapshot_content_revision: 4,
+    created_at: new Date(
+      Date.UTC(2026, 6, 17, 12, 0, 101 - index),
+    ).toISOString(),
+  }));
+
+  const page = parseSharedNoteCommentPage(rows);
+  assert.equal(page.comments.length, 100);
+  assert.equal(page.comments[0]?.commentId, rows[99]?.comment_id);
+  assert.equal(page.comments.at(-1)?.commentId, rows[0]?.comment_id);
+  assert.deepEqual(page.nextCursor, {
+    beforeCreatedAt: rows[99]?.created_at,
+    beforeCommentId: rows[99]?.comment_id,
+  });
+  assert.equal(
+    page.comments.some(
+      (comment) => comment.commentId === rows[100]?.comment_id,
+    ),
+    false,
+  );
+  assert.equal(parseSharedNoteCommentPage(rows.slice(0, 100)).nextCursor, null);
+  assert.throws(() => parseSharedNoteCommentPage([...rows, rows[0]]));
+});
+
+test("parses access request state and enforces reviewed-state invariants", () => {
+  const pending = {
+    request_id: "00000000-0000-4000-8000-000000000003",
+    requested_capability: "commenter",
+    status: "pending",
+    created_at: "2026-07-17T12:00:00Z",
+    reviewed_at: null,
+  };
+  assert.deepEqual(parseSessionAccessRequestState(pending), {
+    requestId: pending.request_id,
+    requestedCapability: "commenter",
+    status: "pending",
+    createdAt: pending.created_at,
+    reviewedAt: null,
+  });
+  assert.throws(() =>
+    parseSessionAccessRequestState({
+      ...pending,
+      status: "approved",
+      reviewed_at: null,
+    }),
+  );
+  assert.throws(() =>
+    parseSessionAccessRequestState({
+      ...pending,
+      reviewed_at: "2026-07-17T12:01:00Z",
+    }),
+  );
+  assert.throws(() =>
+    parseSessionAccessRequestState({ ...pending, status: "unknown" }),
+  );
+});
+
+test("parses invitation states without exposing unrelated fields", () => {
+  assert.deepEqual(
+    parseSessionInvitationState({
+      status: "accepted",
+      capability: "editor",
+      share_id: "00000000-0000-4000-8000-000000000001",
+    }),
+    {
+      status: "accepted",
+      capability: "editor",
+      shareId: "00000000-0000-4000-8000-000000000001",
+    },
+  );
+  assert.throws(() =>
+    parseSessionInvitationState({
+      status: "accepted",
+      capability: "owner",
+      share_id: null,
+    }),
+  );
+  assert.throws(() =>
+    parseSessionInvitationState({
+      status: "pending",
+      capability: "viewer",
+      share_id: null,
+      token_hash: "private",
+    }),
+  );
+});
+
+test("parses only valid manager access entry variants", () => {
+  const grant = {
+    entry_type: "grant",
+    entry_id: "00000000-0000-4000-8000-000000000006",
+    user_id: "00000000-0000-4000-8000-000000000007",
+    user_email: "grantee@example.com",
+    capability: "editor",
+    status: "active",
+    created_at: "2026-07-17T12:00:00Z",
+    expires_at: null,
+  };
+  const invitation = {
+    entry_type: "invitation",
+    entry_id: "00000000-0000-4000-8000-000000000004",
+    user_id: null,
+    user_email: "ada@example.com",
+    capability: "commenter",
+    status: "pending",
+    created_at: "2026-07-17T12:00:00Z",
+    expires_at: "2026-07-24T12:00:00Z",
+  };
+  const request = {
+    entry_type: "request",
+    entry_id: "00000000-0000-4000-8000-000000000008",
+    user_id: "00000000-0000-4000-8000-000000000009",
+    user_email: "requester@example.com",
+    capability: "viewer",
+    status: "pending",
+    created_at: "2026-07-17T12:00:00Z",
+    expires_at: null,
+  };
+  assert.equal(parseSessionShareAccessEntry(grant).entryType, "grant");
+  assert.deepEqual(parseSessionShareAccessEntry(invitation), {
+    entryType: "invitation",
+    entryId: invitation.entry_id,
+    userId: null,
+    userEmail: "ada@example.com",
+    capability: "commenter",
+    status: "pending",
+    createdAt: invitation.created_at,
+    expiresAt: invitation.expires_at,
+  });
+  assert.deepEqual(parseSessionShareAccessEntry(request), {
+    entryType: "request",
+    entryId: request.entry_id,
+    userId: request.user_id,
+    userEmail: request.user_email,
+    capability: "viewer",
+    status: "pending",
+    createdAt: request.created_at,
+    expiresAt: null,
+  });
+
+  assert.throws(() =>
+    parseSessionShareAccessEntry({
+      ...invitation,
+      status: "active",
+    }),
+  );
+  assert.throws(() =>
+    parseSessionShareAccessEntry({
+      ...invitation,
+      user_email: "Ada@Example.com",
+    }),
+  );
+  assert.throws(() =>
+    parseSessionShareAccessEntry({
+      ...invitation,
+      expires_at: null,
+    }),
+  );
+  assert.throws(() =>
+    parseSessionShareAccessEntry({
+      ...invitation,
+      secret: "private",
+    }),
+  );
+  assert.throws(() =>
+    parseSessionShareAccessEntry({
+      ...request,
+      user_email: null,
+    }),
+  );
+});
+
+test("bounds manager access pages and derives the descending cursor", () => {
+  const rows = Array.from({ length: 101 }, (_, index) => ({
+    entry_type: "request",
+    entry_id: `00000000-0000-4000-8000-${String(index).padStart(12, "0")}`,
+    user_id: `00000000-0000-4001-8000-${String(index).padStart(12, "0")}`,
+    user_email: `requester-${index}@example.com`,
+    capability: "commenter",
+    status: "pending",
+    created_at: new Date(
+      Date.UTC(2026, 6, 17, 12, 0, 101 - index),
+    ).toISOString(),
+    expires_at: null,
+  }));
+
+  const page = parseSessionShareAccessPage(rows);
+  assert.equal(page.entries.length, 100);
+  assert.deepEqual(page.nextCursor, {
+    beforeCreatedAt: rows[99]?.created_at,
+    beforeEntryId: rows[99]?.entry_id,
+  });
+  assert.equal(
+    page.entries.some((entry) => entry.entryId === rows[100]?.entry_id),
+    false,
+  );
+  assert.equal(
+    parseSessionShareAccessPage(rows.slice(0, 100)).nextCursor,
+    null,
+  );
+  assert.throws(() => parseSessionShareAccessPage([...rows, rows[0]]));
 });
 
 test("accepts a bounded opaque attachment manifest and rejects duplicates", () => {

--- a/apps/web/src/lib/shared-notes.ts
+++ b/apps/web/src/lib/shared-notes.ts
@@ -92,6 +92,82 @@ export type SharedNoteAttachmentDownload = SharedNoteAttachment & {
 export type AuthenticatedSharedNote = {
   snapshot: SharedNoteSnapshot;
   capability: SharedNoteCapability;
+  manageAccess: boolean;
+  accessVersion: number;
+};
+
+export type SharedNoteComment = {
+  commentId: string;
+  isAuthor: boolean;
+  body: string;
+  snapshotRevision: number;
+  createdAt: string;
+};
+
+export type SharedNoteCommentCursor = {
+  beforeCreatedAt: string;
+  beforeCommentId: string;
+};
+
+export type SharedNoteCommentPage = {
+  comments: SharedNoteComment[];
+  nextCursor: SharedNoteCommentCursor | null;
+};
+
+export type SessionAccessRequestState = {
+  requestId: string;
+  requestedCapability: SharedNoteCapability;
+  status: "pending" | "approved" | "denied" | "cancelled";
+  createdAt: string;
+  reviewedAt: string | null;
+};
+
+export type SessionInvitationState = {
+  status: "pending" | "accepted" | "revoked" | "expired";
+  capability: SharedNoteCapability;
+  shareId: string | null;
+};
+
+export type SessionShareAccessEntry =
+  | {
+      entryType: "grant";
+      entryId: string;
+      userId: string;
+      userEmail: string | null;
+      capability: SharedNoteCapability;
+      status: "active";
+      createdAt: string;
+      expiresAt: null;
+    }
+  | {
+      entryType: "invitation";
+      entryId: string;
+      userId: string | null;
+      userEmail: string;
+      capability: SharedNoteCapability;
+      status: "pending";
+      createdAt: string;
+      expiresAt: string;
+    }
+  | {
+      entryType: "request";
+      entryId: string;
+      userId: string;
+      userEmail: string;
+      capability: SharedNoteCapability;
+      status: "pending";
+      createdAt: string;
+      expiresAt: null;
+    };
+
+export type SessionShareAccessCursor = {
+  beforeCreatedAt: string;
+  beforeEntryId: string;
+};
+
+export type SessionShareAccessPage = {
+  entries: SessionShareAccessEntry[];
+  nextCursor: SessionShareAccessCursor | null;
 };
 
 export type ShareHandoff = {
@@ -146,9 +222,91 @@ const authenticatedSnapshotRowSchema = z
     body_json: z.unknown(),
     attachments_json: z.array(z.unknown()).max(64),
     capability: z.enum(["viewer", "commenter", "editor"]),
+    manage_access: z.boolean(),
+    access_version: z.number().int().positive().safe(),
     published_at: z.string(),
   })
   .passthrough();
+
+const sharedNoteCapabilitySchema = z.enum(["viewer", "commenter", "editor"]);
+const rpcTimestampSchema = z.iso.datetime({ offset: true }).max(64);
+const normalizedEmailSchema = z
+  .string()
+  .regex(/^[^\s@]+@[^\s@]+$/)
+  .max(320)
+  .refine((value) => value === value.trim().toLowerCase());
+
+const sharedNoteCommentRowSchema = z
+  .object({
+    comment_id: shareIdSchema,
+    is_author: z.boolean(),
+    body: z.string().min(1).max(16384),
+    snapshot_content_revision: z.number().int().positive().safe(),
+    created_at: rpcTimestampSchema,
+  })
+  .strict();
+
+const sessionAccessRequestStateRowSchema = z
+  .object({
+    request_id: shareIdSchema,
+    requested_capability: sharedNoteCapabilitySchema,
+    status: z.enum(["pending", "approved", "denied", "cancelled"]),
+    created_at: rpcTimestampSchema,
+    reviewed_at: rpcTimestampSchema.nullable(),
+  })
+  .strict()
+  .refine(({ reviewed_at, status }) =>
+    status === "approved" || status === "denied"
+      ? reviewed_at !== null
+      : reviewed_at === null,
+  );
+
+const sessionInvitationStateRowSchema = z
+  .object({
+    status: z.enum(["pending", "accepted", "revoked", "expired"]),
+    capability: sharedNoteCapabilitySchema,
+    share_id: shareIdSchema.nullable(),
+  })
+  .strict();
+
+const sessionShareAccessEntryRowSchema = z.discriminatedUnion("entry_type", [
+  z
+    .object({
+      entry_type: z.literal("grant"),
+      entry_id: shareIdSchema,
+      user_id: shareIdSchema,
+      user_email: normalizedEmailSchema.nullable(),
+      capability: sharedNoteCapabilitySchema,
+      status: z.literal("active"),
+      created_at: rpcTimestampSchema,
+      expires_at: z.null(),
+    })
+    .strict(),
+  z
+    .object({
+      entry_type: z.literal("invitation"),
+      entry_id: shareIdSchema,
+      user_id: shareIdSchema.nullable(),
+      user_email: normalizedEmailSchema,
+      capability: sharedNoteCapabilitySchema,
+      status: z.literal("pending"),
+      created_at: rpcTimestampSchema,
+      expires_at: rpcTimestampSchema,
+    })
+    .strict(),
+  z
+    .object({
+      entry_type: z.literal("request"),
+      entry_id: shareIdSchema,
+      user_id: shareIdSchema,
+      user_email: normalizedEmailSchema,
+      capability: sharedNoteCapabilitySchema,
+      status: z.literal("pending"),
+      created_at: rpcTimestampSchema,
+      expires_at: z.null(),
+    })
+    .strict(),
+]);
 
 const handoffSchema = z
   .object({
@@ -195,6 +353,8 @@ export function parseAuthenticatedSharedNote(
   const parsed = authenticatedSnapshotRowSchema.parse(value);
   return {
     capability: parsed.capability,
+    manageAccess: parsed.manage_access,
+    accessVersion: parsed.access_version,
     snapshot: {
       shareId: parsed.share_id,
       schemaVersion: parsed.schema_version,
@@ -204,6 +364,125 @@ export function parseAuthenticatedSharedNote(
       attachments: parseSharedNoteAttachments(parsed.attachments_json),
       publishedAt: parseTimestamp(parsed.published_at),
     },
+  };
+}
+
+export function parseSharedNoteComment(value: unknown): SharedNoteComment {
+  const parsed = sharedNoteCommentRowSchema.parse(value);
+  return {
+    commentId: parsed.comment_id,
+    isAuthor: parsed.is_author,
+    body: parsed.body,
+    snapshotRevision: parsed.snapshot_content_revision,
+    createdAt: parsed.created_at,
+  };
+}
+
+export function parseSharedNoteCommentPage(
+  value: unknown,
+): SharedNoteCommentPage {
+  if (!Array.isArray(value) || value.length > 101) {
+    throw new Error("invalid shared-note comment page");
+  }
+
+  const parsed = value.map(parseSharedNoteComment);
+  const descendingComments = parsed.slice(0, 100);
+  const oldestComment = descendingComments.at(-1);
+  return {
+    comments: descendingComments.reverse(),
+    nextCursor:
+      parsed.length > descendingComments.length && oldestComment
+        ? {
+            beforeCreatedAt: oldestComment.createdAt,
+            beforeCommentId: oldestComment.commentId,
+          }
+        : null,
+  };
+}
+
+export function parseSessionAccessRequestState(
+  value: unknown,
+): SessionAccessRequestState {
+  const parsed = sessionAccessRequestStateRowSchema.parse(value);
+  return {
+    requestId: parsed.request_id,
+    requestedCapability: parsed.requested_capability,
+    status: parsed.status,
+    createdAt: parsed.created_at,
+    reviewedAt: parsed.reviewed_at,
+  };
+}
+
+export function parseSessionInvitationState(
+  value: unknown,
+): SessionInvitationState {
+  const parsed = sessionInvitationStateRowSchema.parse(value);
+  return {
+    status: parsed.status,
+    capability: parsed.capability,
+    shareId: parsed.share_id,
+  };
+}
+
+export function parseSessionShareAccessEntry(
+  value: unknown,
+): SessionShareAccessEntry {
+  const parsed = sessionShareAccessEntryRowSchema.parse(value);
+  if (parsed.entry_type === "grant") {
+    return {
+      entryType: parsed.entry_type,
+      entryId: parsed.entry_id,
+      userId: parsed.user_id,
+      userEmail: parsed.user_email,
+      capability: parsed.capability,
+      status: parsed.status,
+      createdAt: parsed.created_at,
+      expiresAt: parsed.expires_at,
+    };
+  }
+  if (parsed.entry_type === "invitation") {
+    return {
+      entryType: parsed.entry_type,
+      entryId: parsed.entry_id,
+      userId: parsed.user_id,
+      userEmail: parsed.user_email,
+      capability: parsed.capability,
+      status: parsed.status,
+      createdAt: parsed.created_at,
+      expiresAt: parsed.expires_at,
+    };
+  }
+  return {
+    entryType: parsed.entry_type,
+    entryId: parsed.entry_id,
+    userId: parsed.user_id,
+    userEmail: parsed.user_email,
+    capability: parsed.capability,
+    status: parsed.status,
+    createdAt: parsed.created_at,
+    expiresAt: parsed.expires_at,
+  };
+}
+
+export function parseSessionShareAccessPage(
+  value: unknown,
+): SessionShareAccessPage {
+  if (!Array.isArray(value) || value.length > 101) {
+    throw new Error("invalid shared-note access page");
+  }
+
+  const parsed = value.map(parseSessionShareAccessEntry);
+  const entries = parsed.slice(0, 100);
+  const lastEntry = entries.at(-1);
+  return {
+    entries,
+    nextCursor:
+      parsed.length > entries.length && lastEntry
+        ? {
+            beforeCreatedAt: lastEntry.createdAt,
+            beforeEntryId: lastEntry.entryId,
+          }
+        : null,
   };
 }
 

--- a/apps/web/src/routes/share/$shareId.tsx
+++ b/apps/web/src/routes/share/$shareId.tsx
@@ -2,6 +2,7 @@ import { createFileRoute, redirect } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import { AccountSharedNoteActions } from "@/components/shared-note-actions";
+import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import {
   SharedNoteLoading,
@@ -15,6 +16,7 @@ import {
   readAuthenticatedSharedNote,
 } from "@/functions/shared-notes";
 import { prepareShareRoutePrivacy } from "@/lib/share-route-privacy";
+import { formatAuthenticatedSharedNoteAccessLabel } from "@/lib/shared-note-collaboration";
 import {
   getPrivateShareHead,
   privateShareHeaders,
@@ -60,6 +62,7 @@ export const Route = createFileRoute("/share/$shareId")({
 
 function Component() {
   const { result } = Route.useLoaderData();
+  const { user } = Route.useRouteContext();
   const { scheme } = Route.useSearch();
   const note = result.status === "ready" ? result.note : null;
   const resolveAttachment = useCallback<SharedAttachmentResolver>(
@@ -83,7 +86,19 @@ function Component() {
     <SharedNoteViewer
       snapshot={note.snapshot}
       resolveAttachment={resolveAttachment}
-      accessLabel="Shared with you · View only"
+      accessLabel={formatAuthenticatedSharedNoteAccessLabel(note)}
+      collaboration={
+        <SharedNoteCollaboration
+          capability={note.capability}
+          currentUserId={user.id}
+          manageAccess={note.manageAccess}
+          returnPath={buildSharedNoteWebPath(
+            `/share/${encodeURIComponent(note.snapshot.shareId)}/`,
+            scheme,
+          )}
+          shareId={note.snapshot.shareId}
+        />
+      }
       actions={
         <AccountSharedNoteActions
           scheme={scheme}

--- a/apps/web/src/routes/share/invite/$invitationId.tsx
+++ b/apps/web/src/routes/share/invite/$invitationId.tsx
@@ -1,31 +1,42 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
-import { LogInIcon, MailCheckIcon } from "lucide-react";
+import {
+  CircleCheckIcon,
+  Clock3Icon,
+  LogInIcon,
+  MailCheckIcon,
+  MailXIcon,
+} from "lucide-react";
 
+import { useShareRouteContinuation } from "@/components/share-route-continuation";
 import {
   sharedPrimaryButtonClassName,
   sharedSecondaryButtonClassName,
   SharedNoteLoading,
   SharedNotePrompt,
+  SharedNoteTransientError,
   SharedNoteUnavailable,
 } from "@/components/shared-note-viewer";
 import { fetchUser } from "@/functions/auth";
-import { getSupabaseBrowserClient } from "@/functions/supabase";
+import { clearShareRouteContinuation } from "@/functions/share-route-continuation";
+import {
+  acceptSharedNoteInvitation,
+  inspectMySharedNoteInvitation,
+} from "@/functions/shared-notes";
 import {
   clearShareRouteToken,
-  getShareRouteToken,
   prepareShareRoutePrivacy,
 } from "@/lib/share-route-privacy";
 import {
   getPrivateShareHead,
   privateShareHeaders,
 } from "@/lib/shared-note-meta";
+import { getInvitationRouteFailure } from "@/lib/shared-note-route-state";
 import {
   type SharedNoteDesktopScheme,
   buildSharedNoteWebPath,
   sharedNoteDesktopSchemeSchema,
   invitationIdSchema,
-  shareIdSchema,
 } from "@/lib/shared-notes";
 
 export const Route = createFileRoute("/share/invite/$invitationId")({
@@ -65,35 +76,48 @@ function InvitationClient({
   scheme: SharedNoteDesktopScheme;
 }) {
   const pathname = window.location.pathname;
-  const hasToken = Boolean(getShareRouteToken(pathname));
+  const continuation = useShareRouteContinuation(pathname);
   const validInvitationId = invitationIdSchema.safeParse(invitationId);
+  const parsedInvitationId = validInvitationId.success
+    ? validInvitationId.data
+    : null;
+  const invitationQuery = useQuery({
+    queryKey: ["shared-note-invitation", parsedInvitationId],
+    queryFn: async () => {
+      if (!parsedInvitationId || !continuation.token) {
+        throw new Error("shared note unavailable");
+      }
+      return inspectMySharedNoteInvitation({
+        data: {
+          invitationId: parsedInvitationId,
+          token: continuation.token,
+        },
+      });
+    },
+    enabled: Boolean(signedIn && parsedInvitationId && continuation.token),
+    gcTime: 0,
+    retry: false,
+    staleTime: Infinity,
+  });
   const acceptMutation = useMutation({
     mutationFn: async () => {
-      const token = getShareRouteToken(pathname);
-      if (!token || !validInvitationId.success) {
+      if (!continuation.token || !parsedInvitationId) {
         throw new Error("shared note unavailable");
       }
 
-      const supabase = getSupabaseBrowserClient();
-      const { data, error } = await supabase.rpc(
-        "accept_session_access_invitation",
-        {
-          p_invitation_id: validInvitationId.data,
-          p_invite_token: token,
+      const result = await acceptSharedNoteInvitation({
+        data: {
+          invitationId: parsedInvitationId,
+          token: continuation.token,
         },
-      );
-      if (error || !Array.isArray(data) || data.length !== 1) {
+      });
+      if (result.status !== "ready") {
         throw new Error("shared note unavailable");
       }
-
-      const shareId = shareIdSchema.safeParse(data[0]?.share_id);
-      if (!shareId.success) {
-        throw new Error("shared note unavailable");
-      }
-      return shareId.data;
+      return result.shareId;
     },
-    onSuccess: (shareId) => {
-      clearShareRouteToken(pathname);
+    onSuccess: async (shareId) => {
+      await clearInvitationContinuation(pathname);
       window.location.assign(
         buildSharedNoteWebPath(
           `/share/${encodeURIComponent(shareId)}/`,
@@ -103,7 +127,21 @@ function InvitationClient({
     },
   });
 
-  if (!hasToken || !validInvitationId.success) {
+  if (continuation.isPending) {
+    return <SharedNoteLoading />;
+  }
+
+  if (continuation.isError) {
+    return (
+      <SharedNoteTransientError
+        retry={() => {
+          void continuation.retry();
+        }}
+      />
+    );
+  }
+
+  if (!continuation.token || !parsedInvitationId) {
     return <SharedNoteUnavailable />;
   }
 
@@ -129,6 +167,77 @@ function InvitationClient({
     );
   }
 
+  if (invitationQuery.isPending) {
+    return <SharedNoteLoading />;
+  }
+
+  const invitationFailure = getInvitationRouteFailure({
+    acceptanceFailed: acceptMutation.isError,
+    inspectionFailed: invitationQuery.isError,
+    inspectionReady: invitationQuery.data?.status === "ready",
+  });
+  if (
+    invitationFailure === "unavailable" ||
+    invitationQuery.data?.status !== "ready"
+  ) {
+    return <SharedNoteUnavailable />;
+  }
+
+  const invitation = invitationQuery.data.invitation;
+
+  if (invitation.status === "accepted") {
+    const acceptedShareId = invitation.shareId;
+    if (!acceptedShareId) {
+      return <SharedNoteUnavailable />;
+    }
+
+    return (
+      <SharedNotePrompt
+        icon={<CircleCheckIcon className="size-6" aria-hidden="true" />}
+        title="Invitation accepted"
+        description="This note is already available in your shared notes."
+        actions={
+          <button
+            type="button"
+            className={sharedPrimaryButtonClassName}
+            onClick={() => {
+              void clearInvitationContinuation(pathname).then(() => {
+                window.location.assign(
+                  buildSharedNoteWebPath(
+                    `/share/${encodeURIComponent(acceptedShareId)}/`,
+                    scheme,
+                  ),
+                );
+              });
+            }}
+          >
+            Open note
+          </button>
+        }
+      />
+    );
+  }
+
+  if (invitation.status === "revoked") {
+    return (
+      <SharedNotePrompt
+        icon={<MailXIcon className="size-6" aria-hidden="true" />}
+        title="This invitation was revoked"
+        description="The person who shared the note has withdrawn this invitation."
+      />
+    );
+  }
+
+  if (invitation.status === "expired") {
+    return (
+      <SharedNotePrompt
+        icon={<Clock3Icon className="size-6" aria-hidden="true" />}
+        title="This invitation has expired"
+        description="Ask the person who shared the note to send a new invitation."
+      />
+    );
+  }
+
   return (
     <SharedNotePrompt
       icon={<MailCheckIcon className="size-6" aria-hidden="true" />}
@@ -148,19 +257,25 @@ function InvitationClient({
             type="button"
             className={sharedSecondaryButtonClassName}
             onClick={() => {
-              clearShareRouteToken(pathname);
-              window.location.assign("/");
+              void clearInvitationContinuation(pathname).then(() => {
+                window.location.assign("/");
+              });
             }}
           >
             Not now
           </button>
-          {acceptMutation.isError && (
-            <p className="text-color-muted basis-full text-sm" role="status">
-              This invitation isn’t available for the signed-in account.
+          {invitationFailure === "accept-retry" && (
+            <p className="basis-full text-sm text-red-700" role="status">
+              We couldn’t accept this invitation. Please try again.
             </p>
           )}
         </>
       }
     />
   );
+}
+
+async function clearInvitationContinuation(pathname: string) {
+  clearShareRouteToken(pathname);
+  await clearShareRouteContinuation({ data: pathname }).catch(() => undefined);
 }

--- a/apps/web/src/routes/share/link/$shareId.tsx
+++ b/apps/web/src/routes/share/link/$shareId.tsx
@@ -2,7 +2,9 @@ import { useQuery } from "@tanstack/react-query";
 import { ClientOnly, createFileRoute } from "@tanstack/react-router";
 import { useCallback } from "react";
 
+import { useShareRouteContinuation } from "@/components/share-route-continuation";
 import { LinkSharedNoteActions } from "@/components/shared-note-actions";
+import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
 import {
   SharedNoteLoading,
@@ -10,19 +12,27 @@ import {
   SharedNoteUnavailable,
   SharedNoteViewer,
 } from "@/components/shared-note-viewer";
+import { fetchUser } from "@/functions/auth";
 import {
-  getShareRouteToken,
-  prepareShareRoutePrivacy,
-} from "@/lib/share-route-privacy";
+  createAuthenticatedSharedAttachmentDownload,
+  readAuthenticatedSharedNote,
+} from "@/functions/shared-notes";
+import { prepareShareRoutePrivacy } from "@/lib/share-route-privacy";
 import {
   fetchLinkSharedAttachmentDownload,
   fetchLinkSharedNoteResult,
 } from "@/lib/shared-note-api";
 import {
+  formatAuthenticatedSharedNoteAccessLabel,
+  shouldUseAuthenticatedSharedNoteAccessLabel,
+} from "@/lib/shared-note-collaboration";
+import {
   getPrivateShareHead,
   privateShareHeaders,
 } from "@/lib/shared-note-meta";
+import { getLinkSharedNoteRouteGate } from "@/lib/shared-note-route-state";
 import {
+  buildSharedNoteWebPath,
   sharedNoteDesktopSchemeSchema,
   shareIdSchema,
 } from "@/lib/shared-notes";
@@ -31,7 +41,10 @@ export const Route = createFileRoute("/share/link/$shareId")({
   validateSearch: (search) => ({
     scheme: sharedNoteDesktopSchemeSchema.parse(search.scheme),
   }),
-  beforeLoad: () => prepareShareRoutePrivacy(),
+  beforeLoad: async () => {
+    prepareShareRoutePrivacy();
+    return { user: await fetchUser() };
+  },
   head: getPrivateShareHead,
   headers: () => privateShareHeaders,
   component: Component,
@@ -39,24 +52,38 @@ export const Route = createFileRoute("/share/link/$shareId")({
 
 function Component() {
   const { shareId } = Route.useParams();
+  const { user } = Route.useRouteContext();
   return (
     <ClientOnly fallback={<SharedNoteLoading />}>
-      <LinkSharedNoteClient shareId={shareId} />
+      <LinkSharedNoteClient
+        currentUserId={user?.id ?? null}
+        shareId={shareId}
+      />
     </ClientOnly>
   );
 }
 
-function LinkSharedNoteClient({ shareId }: { shareId: string }) {
+function LinkSharedNoteClient({
+  currentUserId,
+  shareId,
+}: {
+  currentUserId: string | null;
+  shareId: string;
+}) {
   const { scheme } = Route.useSearch();
   const pathname = window.location.pathname;
-  const hasToken = Boolean(getShareRouteToken(pathname));
+  const continuation = useShareRouteContinuation(pathname);
+  const hasToken = continuation.token !== null;
   const validShareId = shareIdSchema.safeParse(shareId);
   const snapshotQuery = useQuery({
     queryKey: ["shared-note-link", shareId],
     queryFn: ({ signal }) => {
-      const token = getShareRouteToken(pathname);
-      return token && validShareId.success
-        ? fetchLinkSharedNoteResult(validShareId.data, token, signal)
+      return continuation.token && validShareId.success
+        ? fetchLinkSharedNoteResult(
+            validShareId.data,
+            continuation.token,
+            signal,
+          )
         : Promise.resolve({ status: "unavailable" } as const);
     },
     enabled: hasToken && validShareId.success,
@@ -64,41 +91,104 @@ function LinkSharedNoteClient({ shareId }: { shareId: string }) {
     retry: false,
     staleTime: 0,
   });
+  const authenticatedQuery = useQuery({
+    queryKey: ["shared-note-authenticated", shareId, currentUserId],
+    queryFn: () => readAuthenticatedSharedNote({ data: shareId }),
+    enabled: currentUserId !== null && validShareId.success,
+    retry: false,
+    staleTime: 0,
+  });
+  const authenticatedNote =
+    authenticatedQuery.data?.status === "ready"
+      ? authenticatedQuery.data.note
+      : null;
   const resolveAttachment = useCallback<SharedAttachmentResolver>(
     (attachment, signal) => {
-      const token = getShareRouteToken(pathname);
-      return token
+      if (authenticatedNote) {
+        return createAuthenticatedSharedAttachmentDownload({
+          data: {
+            shareId: authenticatedNote.snapshot.shareId,
+            attachmentId: attachment.id,
+          },
+        });
+      }
+      return continuation.token
         ? fetchLinkSharedAttachmentDownload(
             shareId,
-            token,
+            continuation.token,
             attachment.id,
             signal,
           )
         : Promise.resolve(null);
     },
-    [pathname, shareId],
+    [authenticatedNote, continuation.token, shareId],
   );
 
-  if (!hasToken || !validShareId.success) {
+  if (!validShareId.success) {
     return <SharedNoteUnavailable />;
   }
-  if (snapshotQuery.isPending) {
+  const routeGate = getLinkSharedNoteRouteGate({
+    authenticatedNotePending:
+      currentUserId !== null && authenticatedQuery.isPending,
+    continuationFailed: continuation.isError,
+    continuationPending: continuation.isPending,
+    hasAuthenticatedNote: authenticatedNote !== null,
+    linkSnapshotPending: hasToken && snapshotQuery.isPending,
+  });
+  if (routeGate === "loading") {
     return <SharedNoteLoading />;
   }
-  if (snapshotQuery.isError || snapshotQuery.data?.status === "error") {
+  if (routeGate === "continuation-error") {
     return (
-      <SharedNoteTransientError retry={() => void snapshotQuery.refetch()} />
+      <SharedNoteTransientError
+        retry={() => {
+          void continuation.retry();
+          if (currentUserId !== null) void authenticatedQuery.refetch();
+        }}
+      />
     );
   }
-  if (!snapshotQuery.data || snapshotQuery.data.status === "unavailable") {
+  if (
+    !authenticatedNote &&
+    (snapshotQuery.isError ||
+      snapshotQuery.data?.status === "error" ||
+      (authenticatedQuery.isError && !hasToken))
+  ) {
+    return (
+      <SharedNoteTransientError
+        retry={() => {
+          void authenticatedQuery.refetch();
+          if (hasToken) void snapshotQuery.refetch();
+        }}
+      />
+    );
+  }
+  const linkSnapshot =
+    snapshotQuery.data?.status === "ready" ? snapshotQuery.data.snapshot : null;
+  const snapshot = authenticatedNote?.snapshot ?? linkSnapshot;
+  if (!snapshot) {
     return <SharedNoteUnavailable />;
   }
 
   return (
     <SharedNoteViewer
-      snapshot={snapshotQuery.data.snapshot}
+      snapshot={snapshot}
       resolveAttachment={resolveAttachment}
-      accessLabel="Anyone with the link · View only"
+      accessLabel={
+        authenticatedNote &&
+        shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)
+          ? formatAuthenticatedSharedNoteAccessLabel(authenticatedNote)
+          : "Anyone with the link · View only"
+      }
+      collaboration={
+        <SharedNoteCollaboration
+          capability={authenticatedNote?.capability ?? "viewer"}
+          currentUserId={currentUserId}
+          manageAccess={authenticatedNote?.manageAccess ?? false}
+          returnPath={buildSharedNoteWebPath(pathname, scheme)}
+          shareId={validShareId.data}
+        />
+      }
       actions={
         <LinkSharedNoteActions
           pathname={pathname}

--- a/apps/web/src/routes/share/public/$publicSlug.tsx
+++ b/apps/web/src/routes/share/public/$publicSlug.tsx
@@ -2,16 +2,24 @@ import { createFileRoute } from "@tanstack/react-router";
 import { useCallback } from "react";
 
 import type { SharedAttachmentResolver } from "@/components/shared-note-document";
-import {
-  PublicSharedNoteActions,
-} from "@/components/shared-note-actions";
+import { PublicSharedNoteActions } from "@/components/shared-note-actions";
+import { SharedNoteCollaboration } from "@/components/shared-note-collaboration";
 import {
   SharedNoteLoading,
   SharedNoteTransientError,
   SharedNoteUnavailable,
   SharedNoteViewer,
 } from "@/components/shared-note-viewer";
-import { readPublicSharedNote } from "@/functions/shared-notes";
+import { fetchUser } from "@/functions/auth";
+import {
+  createAuthenticatedSharedAttachmentDownload,
+  readAuthenticatedSharedNote,
+  readPublicSharedNote,
+} from "@/functions/shared-notes";
+import {
+  formatAuthenticatedSharedNoteAccessLabel,
+  shouldUseAuthenticatedSharedNoteAccessLabel,
+} from "@/lib/shared-note-collaboration";
 import {
   getPublicShareHead,
   publicShareHeaders,
@@ -19,6 +27,7 @@ import {
 import { prepareShareRoutePrivacy } from "@/lib/share-route-privacy";
 import { fetchPublicSharedAttachmentDownload } from "@/lib/shared-note-api";
 import {
+  buildSharedNoteWebPath,
   publicShareSlugSchema,
   sharedNoteDesktopSchemeSchema,
 } from "@/lib/shared-notes";
@@ -31,10 +40,24 @@ export const Route = createFileRoute("/share/public/$publicSlug")({
   loader: async ({ params }) => {
     const publicSlug = publicShareSlugSchema.safeParse(params.publicSlug);
     if (!publicSlug.success) {
-      return { result: { status: "unavailable" } as const };
+      return {
+        authenticatedResult: null,
+        result: { status: "unavailable" } as const,
+        user: null,
+      };
     }
+    const [result, user] = await Promise.all([
+      readPublicSharedNote({ data: publicSlug.data }),
+      fetchUser(),
+    ]);
+    const authenticatedResult =
+      user && result.status === "ready"
+        ? await readAuthenticatedSharedNote({ data: result.snapshot.shareId })
+        : null;
     return {
-      result: await readPublicSharedNote({ data: publicSlug.data }),
+      authenticatedResult,
+      result,
+      user,
     };
   },
   head: ({ loaderData, params }) =>
@@ -50,17 +73,28 @@ export const Route = createFileRoute("/share/public/$publicSlug")({
 });
 
 function Component() {
-  const { result } = Route.useLoaderData();
+  const { authenticatedResult, result, user } = Route.useLoaderData();
   const { publicSlug } = Route.useParams();
   const { scheme } = Route.useSearch();
+  const authenticatedNote =
+    authenticatedResult?.status === "ready"
+      ? authenticatedResult.note
+      : null;
   const resolveAttachment = useCallback<SharedAttachmentResolver>(
     (attachment, signal) =>
-      fetchPublicSharedAttachmentDownload(
-        publicSlug,
-        attachment.id,
-        signal,
-      ),
-    [publicSlug],
+      authenticatedNote
+        ? createAuthenticatedSharedAttachmentDownload({
+            data: {
+              shareId: authenticatedNote.snapshot.shareId,
+              attachmentId: attachment.id,
+            },
+          })
+        : fetchPublicSharedAttachmentDownload(
+            publicSlug,
+            attachment.id,
+            signal,
+          ),
+    [authenticatedNote, publicSlug],
   );
   if (result.status === "error") {
     return <SharedNoteTransientError />;
@@ -69,11 +103,30 @@ function Component() {
     return <SharedNoteUnavailable />;
   }
 
+  const snapshot = authenticatedNote?.snapshot ?? result.snapshot;
+  const accessLabel =
+    authenticatedNote &&
+    shouldUseAuthenticatedSharedNoteAccessLabel(authenticatedNote)
+      ? formatAuthenticatedSharedNoteAccessLabel(authenticatedNote)
+      : "Public note · View only";
+
   return (
     <SharedNoteViewer
-      snapshot={result.snapshot}
+      snapshot={snapshot}
       resolveAttachment={resolveAttachment}
-      accessLabel="Public note · View only"
+      accessLabel={accessLabel}
+      collaboration={
+        <SharedNoteCollaboration
+          capability={authenticatedNote?.capability ?? "viewer"}
+          currentUserId={user?.id ?? null}
+          manageAccess={authenticatedNote?.manageAccess ?? false}
+          returnPath={buildSharedNoteWebPath(
+            `/share/public/${encodeURIComponent(publicSlug)}/`,
+            scheme,
+          )}
+          shareId={snapshot.shareId}
+        />
+      }
       actions={
         <PublicSharedNoteActions publicSlug={publicSlug} scheme={scheme} />
       }

--- a/supabase/migrations/20260717180000_session_share_collaboration.sql
+++ b/supabase/migrations/20260717180000_session_share_collaboration.sql
@@ -1,0 +1,872 @@
+CREATE TABLE public.session_share_comments (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  share_id uuid NOT NULL REFERENCES public.session_shares(id) ON DELETE CASCADE,
+  author_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  snapshot_content_revision bigint NOT NULL,
+  body text NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  deleted_at timestamptz,
+  deleted_by_user_id uuid REFERENCES auth.users(id) ON DELETE SET NULL,
+  CONSTRAINT session_share_comments_revision_check CHECK (
+    snapshot_content_revision > 0
+  ),
+  CONSTRAINT session_share_comments_body_check CHECK (
+    (
+      deleted_at IS NULL
+      AND deleted_by_user_id IS NULL
+      AND body = btrim(body, E' \t\n\r\v\f')
+      AND body <> ''
+      AND octet_length(body) <= 16384
+    )
+    OR (
+      deleted_at IS NOT NULL
+      AND body = ''
+    )
+  )
+);
+
+CREATE INDEX session_share_comments_active_feed_idx
+  ON public.session_share_comments(share_id, created_at, id)
+  WHERE deleted_at IS NULL;
+
+CREATE INDEX session_access_requests_history_idx
+  ON public.session_access_requests(
+    share_id,
+    requester_user_id,
+    updated_at DESC
+  );
+
+CREATE INDEX session_access_events_subject_created_idx
+  ON public.session_access_events(subject_user_id, created_at DESC, id DESC)
+  WHERE event_type IN (
+    'request_approved',
+    'request_denied',
+    'grant_changed',
+    'grant_revoked'
+  );
+
+ALTER TABLE public.session_share_comments ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.session_share_comments
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.session_share_comments TO service_role;
+
+CREATE POLICY session_share_comments_service_all
+  ON public.session_share_comments
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+ALTER TABLE public.session_access_events
+  DROP CONSTRAINT session_access_events_type_check,
+  ADD CONSTRAINT session_access_events_type_check CHECK (
+    event_type IN (
+      'share_created',
+      'share_reactivated',
+      'share_deleted',
+      'scope_changed',
+      'link_enabled',
+      'link_rotated',
+      'invitation_created',
+      'invitation_resent',
+      'invitation_revoked',
+      'invitation_accepted',
+      'grant_changed',
+      'grant_revoked',
+      'request_created',
+      'request_cancelled',
+      'request_approved',
+      'request_denied',
+      'snapshot_published',
+      'comment_created',
+      'comment_deleted'
+    )
+  );
+
+CREATE OR REPLACE FUNCTION private.create_session_share_comment(
+  p_share_id uuid,
+  p_body text
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_body text := btrim(p_body, E' \t\n\r\v\f');
+  v_capability text;
+  v_manage_access boolean;
+  v_revision bigint;
+  v_comment public.session_share_comments%ROWTYPE;
+BEGIN
+  PERFORM 1
+  FROM public.session_shares AS share
+  JOIN public.workspaces AS workspace
+    ON workspace.id = share.workspace_id
+  WHERE share.id = p_share_id
+    AND share.deleted_at IS NULL
+    AND workspace.deleted_at IS NULL
+  FOR UPDATE OF share;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  SELECT access.capability, access.manage_access
+  INTO v_capability, v_manage_access
+  FROM private.resolve_my_session_access(p_share_id) AS access;
+
+  IF COALESCE(private.session_capability_rank(v_capability), 0) < 2
+    AND NOT COALESCE(v_manage_access, false)
+  THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_body IS NULL
+    OR v_body = ''
+    OR octet_length(v_body) > 16384
+  THEN
+    RAISE EXCEPTION 'invalid session comment'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT snapshot.content_revision
+  INTO v_revision
+  FROM public.session_share_snapshots AS snapshot
+  WHERE snapshot.share_id = p_share_id;
+
+  IF v_revision IS NULL THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  INSERT INTO public.session_share_comments (
+    share_id,
+    author_user_id,
+    snapshot_content_revision,
+    body
+  ) VALUES (
+    p_share_id,
+    v_actor_id,
+    v_revision,
+    v_body
+  )
+  RETURNING * INTO v_comment;
+
+  PERFORM private.write_session_access_event(
+    p_share_id,
+    'comment_created',
+    v_actor_id,
+    v_actor_id,
+    v_comment.id,
+    NULL,
+    v_revision::text
+  );
+
+  RETURN QUERY
+  SELECT
+    v_comment.id,
+    true,
+    v_comment.snapshot_content_revision,
+    v_comment.body,
+    v_comment.created_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_session_share_comments(
+  p_share_id uuid,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_comment_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  created_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_limit integer := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 101);
+BEGIN
+  IF (p_before_created_at IS NULL) <> (p_before_comment_id IS NULL) THEN
+    RAISE EXCEPTION 'invalid session comment cursor'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT private.is_session_share_manager(p_share_id, v_actor_id)
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.session_access_grants AS access_grant
+      JOIN public.session_shares AS share
+        ON share.id = access_grant.share_id
+      JOIN public.workspaces AS workspace
+        ON workspace.id = share.workspace_id
+      WHERE access_grant.share_id = p_share_id
+        AND access_grant.grantee_user_id = v_actor_id
+        AND access_grant.capability IN ('viewer', 'commenter', 'editor')
+        AND access_grant.revoked_at IS NULL
+        AND share.deleted_at IS NULL
+        AND workspace.deleted_at IS NULL
+    )
+  THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    comment.id,
+    comment.author_user_id = v_actor_id,
+    comment.snapshot_content_revision,
+    comment.body,
+    comment.created_at
+  FROM public.session_share_comments AS comment
+  WHERE comment.share_id = p_share_id
+    AND comment.deleted_at IS NULL
+    AND (
+      p_before_created_at IS NULL
+      OR (comment.created_at, comment.id)
+        < (p_before_created_at, p_before_comment_id)
+    )
+  ORDER BY comment.created_at DESC, comment.id DESC
+  LIMIT v_limit;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.delete_session_share_comment(
+  p_comment_id uuid
+)
+RETURNS TABLE (
+  comment_id uuid,
+  deleted_at timestamptz
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_share_id uuid;
+  v_comment public.session_share_comments%ROWTYPE;
+  v_deleted_at timestamptz;
+BEGIN
+  SELECT comment.share_id
+  INTO v_share_id
+  FROM public.session_share_comments AS comment
+  WHERE comment.id = p_comment_id;
+
+  IF v_share_id IS NULL THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  PERFORM 1
+  FROM public.session_shares AS share
+  WHERE share.id = v_share_id
+  FOR UPDATE;
+
+  SELECT comment.*
+  INTO v_comment
+  FROM public.session_share_comments AS comment
+  WHERE comment.id = p_comment_id
+    AND comment.share_id = v_share_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR (
+      v_comment.author_user_id <> v_actor_id
+      AND NOT private.is_session_share_manager(v_share_id, v_actor_id)
+    )
+  THEN
+    RAISE EXCEPTION 'session comment operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  IF v_comment.deleted_at IS NULL THEN
+    v_deleted_at := now();
+
+    UPDATE public.session_share_comments
+    SET
+      body = '',
+      deleted_at = v_deleted_at,
+      deleted_by_user_id = v_actor_id
+    WHERE id = v_comment.id;
+
+    PERFORM private.write_session_access_event(
+      v_share_id,
+      'comment_deleted',
+      v_actor_id,
+      v_comment.author_user_id,
+      v_comment.id,
+      v_comment.snapshot_content_revision::text,
+      NULL
+    );
+  ELSE
+    v_deleted_at := v_comment.deleted_at;
+  END IF;
+
+  RETURN QUERY SELECT v_comment.id, v_deleted_at;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.get_my_session_access_request(
+  p_share_id uuid
+)
+RETURNS TABLE (
+  request_id uuid,
+  requested_capability text,
+  status text,
+  created_at timestamptz,
+  reviewed_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+BEGIN
+  RETURN QUERY
+  SELECT
+    request.id,
+    request.requested_capability,
+    request.status,
+    request.created_at,
+    request.reviewed_at
+  FROM (
+    SELECT latest.*
+    FROM public.session_access_requests AS latest
+    WHERE latest.share_id = p_share_id
+      AND latest.requester_user_id = v_actor_id
+    ORDER BY latest.created_at DESC, latest.id DESC
+    LIMIT 1
+  ) AS request
+  WHERE request.status <> 'approved'
+    OR EXISTS (
+      SELECT 1
+      FROM public.session_access_grants AS access_grant
+      WHERE access_grant.share_id = request.share_id
+        AND access_grant.grantee_user_id = v_actor_id
+        AND access_grant.revoked_at IS NULL
+        AND private.session_capability_rank(access_grant.capability)
+          >= private.session_capability_rank(request.requested_capability)
+    );
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.request_session_access(
+  p_share_id uuid,
+  p_requested_capability text
+)
+RETURNS TABLE (
+  request_id uuid,
+  requested_capability text,
+  was_created boolean
+)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_request public.session_access_requests%ROWTYPE;
+  v_existing_capability text;
+  v_manage_access boolean;
+BEGIN
+  IF private.session_capability_rank(p_requested_capability) = 0 OR NOT EXISTS (
+    SELECT 1
+    FROM public.session_shares AS share
+    JOIN public.workspaces AS workspace
+      ON workspace.id = share.workspace_id
+    WHERE share.id = p_share_id
+      AND share.deleted_at IS NULL
+      AND workspace.deleted_at IS NULL
+  ) THEN
+    RAISE EXCEPTION 'session access request is unavailable'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM 1
+  FROM public.session_shares AS share
+  WHERE share.id = p_share_id
+    AND share.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'session access request is unavailable'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT access.capability, access.manage_access
+  INTO v_existing_capability, v_manage_access
+  FROM private.resolve_my_session_access(p_share_id) AS access;
+
+  IF COALESCE(v_manage_access, false)
+    OR private.session_capability_rank(v_existing_capability)
+      >= private.session_capability_rank(p_requested_capability)
+  THEN
+    RAISE EXCEPTION 'session access request not needed'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT access_request.*
+  INTO v_request
+  FROM public.session_access_requests AS access_request
+  WHERE access_request.share_id = p_share_id
+    AND access_request.requester_user_id = v_actor_id
+    AND access_request.status = 'pending';
+
+  IF FOUND THEN
+    RETURN QUERY
+    SELECT v_request.id, v_request.requested_capability, false;
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.session_access_requests AS recent_request
+    WHERE recent_request.share_id = p_share_id
+      AND recent_request.requester_user_id = v_actor_id
+      AND recent_request.status = 'cancelled'
+      AND recent_request.updated_at > now() - interval '15 minutes'
+  ) THEN
+    RAISE EXCEPTION 'session access request is rate limited'
+      USING ERRCODE = '22023';
+  END IF;
+
+  INSERT INTO public.session_access_requests (
+    share_id,
+    requester_user_id,
+    requested_capability
+  ) VALUES (
+    p_share_id,
+    v_actor_id,
+    p_requested_capability
+  )
+  RETURNING * INTO v_request;
+
+  PERFORM private.write_session_access_event(
+    p_share_id,
+    'request_created',
+    v_actor_id,
+    v_actor_id,
+    v_request.id,
+    NULL,
+    p_requested_capability
+  );
+
+  RETURN QUERY
+  SELECT v_request.id, v_request.requested_capability, true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.list_session_share_access_page(
+  p_share_id uuid,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_entry_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100
+)
+RETURNS TABLE (
+  entry_type text,
+  entry_id uuid,
+  user_id uuid,
+  user_email text,
+  capability text,
+  status text,
+  created_at timestamptz,
+  expires_at timestamptz
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_limit integer := LEAST(GREATEST(COALESCE(p_limit, 100), 1), 1000);
+BEGIN
+  IF (p_before_created_at IS NULL) <> (p_before_entry_id IS NULL) THEN
+    RAISE EXCEPTION 'invalid session access cursor'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF NOT private.is_session_share_manager(p_share_id, v_actor_id) THEN
+    RAISE EXCEPTION 'session access operation not permitted'
+      USING ERRCODE = '42501';
+  END IF;
+
+  RETURN QUERY
+  WITH access_entries AS (
+    SELECT
+      'grant'::text AS entry_type,
+      access_grant.id AS entry_id,
+      access_grant.grantee_user_id AS user_id,
+      lower(btrim(grantee.email)) AS user_email,
+      access_grant.capability,
+      'active'::text AS status,
+      access_grant.created_at,
+      NULL::timestamptz AS expires_at
+    FROM public.session_access_grants AS access_grant
+    JOIN auth.users AS grantee
+      ON grantee.id = access_grant.grantee_user_id
+    WHERE access_grant.share_id = p_share_id
+      AND access_grant.revoked_at IS NULL
+
+    UNION ALL
+
+    SELECT
+      'invitation'::text,
+      invitation.id,
+      invitation.invitee_user_id,
+      invitation.invitee_email,
+      invitation.capability,
+      'pending'::text,
+      invitation.created_at,
+      invitation.expires_at
+    FROM public.session_access_invitations AS invitation
+    WHERE invitation.share_id = p_share_id
+      AND invitation.accepted_at IS NULL
+      AND invitation.revoked_at IS NULL
+      AND invitation.expires_at > now()
+
+    UNION ALL
+
+    SELECT
+      'request'::text,
+      access_request.id,
+      access_request.requester_user_id,
+      lower(btrim(requester.email)),
+      access_request.requested_capability,
+      access_request.status,
+      access_request.created_at,
+      NULL::timestamptz
+    FROM public.session_access_requests AS access_request
+    JOIN auth.users AS requester
+      ON requester.id = access_request.requester_user_id
+    WHERE access_request.share_id = p_share_id
+      AND access_request.status = 'pending'
+      AND requester.email IS NOT NULL
+  )
+  SELECT access_entry.*
+  FROM access_entries AS access_entry
+  WHERE p_before_created_at IS NULL
+    OR (access_entry.created_at, access_entry.entry_id)
+      < (p_before_created_at, p_before_entry_id)
+  ORDER BY access_entry.created_at DESC, access_entry.entry_id DESC
+  LIMIT v_limit;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION private.inspect_my_session_access_invitation(
+  p_invitation_id uuid,
+  p_invite_token text
+)
+RETURNS TABLE (
+  status text,
+  capability text,
+  share_id uuid
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+DECLARE
+  v_actor_id uuid := private.require_permanent_user();
+  v_actor_email text;
+  v_invitation public.session_access_invitations%ROWTYPE;
+  v_status text;
+  v_share_id uuid;
+BEGIN
+  IF p_invite_token IS NULL
+    OR p_invite_token !~ '^[A-Za-z0-9_-]{43}$'
+  THEN
+    RETURN;
+  END IF;
+
+  SELECT lower(btrim(auth_user.email))
+  INTO v_actor_email
+  FROM auth.users AS auth_user
+  WHERE auth_user.id = v_actor_id;
+
+  SELECT invitation.*
+  INTO v_invitation
+  FROM public.session_access_invitations AS invitation
+  JOIN public.session_shares AS share
+    ON share.id = invitation.share_id
+  JOIN public.workspaces AS workspace
+    ON workspace.id = share.workspace_id
+  WHERE invitation.id = p_invitation_id
+    AND invitation.token_hash = extensions.digest(p_invite_token, 'sha256')
+    AND invitation.invitee_email = v_actor_email
+    AND share.deleted_at IS NULL
+    AND workspace.deleted_at IS NULL
+    AND (
+      invitation.invitee_user_id IS NULL
+      OR invitation.invitee_user_id = v_actor_id
+    );
+
+  IF NOT FOUND THEN
+    RETURN;
+  END IF;
+
+  v_status := CASE
+    WHEN v_invitation.revoked_at IS NOT NULL THEN 'revoked'
+    WHEN v_invitation.accepted_at IS NOT NULL
+      AND v_invitation.accepted_by_user_id = v_actor_id
+      AND EXISTS (
+        SELECT 1
+        FROM public.session_access_grants AS access_grant
+        WHERE access_grant.share_id = v_invitation.share_id
+          AND access_grant.grantee_user_id = v_actor_id
+          AND access_grant.revoked_at IS NULL
+      )
+      THEN 'accepted'
+    WHEN v_invitation.accepted_at IS NOT NULL THEN 'revoked'
+    WHEN v_invitation.expires_at <= now() THEN 'expired'
+    ELSE 'pending'
+  END;
+
+  IF v_status = 'accepted' THEN
+    v_share_id := v_invitation.share_id;
+  END IF;
+
+  RETURN QUERY
+  SELECT v_status, v_invitation.capability, v_share_id;
+END;
+$$;
+
+
+REVOKE ALL ON FUNCTION private.create_session_share_comment(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_session_share_comments(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.delete_session_share_comment(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.get_my_session_access_request(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.list_session_share_access_page(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION private.inspect_my_session_access_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION private.create_session_share_comment(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_session_share_comments(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION private.delete_session_share_comment(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.get_my_session_access_request(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION private.list_session_share_access_page(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION private.inspect_my_session_access_invitation(uuid, text)
+  TO authenticated;
+
+CREATE OR REPLACE FUNCTION public.create_session_share_comment(
+  p_share_id uuid,
+  p_body text
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  created_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.create_session_share_comment(p_share_id, p_body);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_session_share_comments(
+  p_share_id uuid,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_comment_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100
+)
+RETURNS TABLE (
+  comment_id uuid,
+  is_author boolean,
+  snapshot_content_revision bigint,
+  body text,
+  created_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.list_session_share_comments(
+    p_share_id,
+    p_before_created_at,
+    p_before_comment_id,
+    p_limit
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.delete_session_share_comment(
+  p_comment_id uuid
+)
+RETURNS TABLE (
+  comment_id uuid,
+  deleted_at timestamptz
+)
+LANGUAGE sql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.delete_session_share_comment(p_comment_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.get_my_session_access_request(
+  p_share_id uuid
+)
+RETURNS TABLE (
+  request_id uuid,
+  requested_capability text,
+  status text,
+  created_at timestamptz,
+  reviewed_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.get_my_session_access_request(p_share_id);
+$$;
+
+CREATE OR REPLACE FUNCTION public.list_session_share_access_page(
+  p_share_id uuid,
+  p_before_created_at timestamptz DEFAULT NULL,
+  p_before_entry_id uuid DEFAULT NULL,
+  p_limit integer DEFAULT 100
+)
+RETURNS TABLE (
+  entry_type text,
+  entry_id uuid,
+  user_id uuid,
+  user_email text,
+  capability text,
+  status text,
+  created_at timestamptz,
+  expires_at timestamptz
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.list_session_share_access_page(
+    p_share_id,
+    p_before_created_at,
+    p_before_entry_id,
+    p_limit
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.inspect_my_session_access_invitation(
+  p_invitation_id uuid,
+  p_invite_token text
+)
+RETURNS TABLE (
+  status text,
+  capability text,
+  share_id uuid
+)
+LANGUAGE sql
+STABLE
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+  SELECT *
+  FROM private.inspect_my_session_access_invitation(
+    p_invitation_id,
+    p_invite_token
+  );
+$$;
+
+
+REVOKE ALL ON FUNCTION public.create_session_share_comment(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_session_share_comments(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.delete_session_share_comment(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.get_my_session_access_request(uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.list_session_share_access_page(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.inspect_my_session_access_invitation(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.create_session_share_comment(uuid, text)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_session_share_comments(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.delete_session_share_comment(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.get_my_session_access_request(uuid)
+  TO authenticated;
+GRANT EXECUTE ON FUNCTION public.list_session_share_access_page(
+  uuid,
+  timestamptz,
+  uuid,
+  integer
+) TO authenticated;
+GRANT EXECUTE ON FUNCTION public.inspect_my_session_access_invitation(uuid, text)
+  TO authenticated;

--- a/supabase/tests/023-session-share-collaboration.sql
+++ b/supabase/tests/023-session-share-collaboration.sql
@@ -1,0 +1,1316 @@
+begin;
+select plan(48);
+
+select tests.create_supabase_user('collab_owner', 'collab-owner@example.com');
+select tests.create_supabase_user('collab_manager', 'collab-manager@example.com');
+select tests.create_supabase_user('collab_commenter', 'collab-commenter@example.com');
+select tests.create_supabase_user('collab_editor', 'collab-editor@example.com');
+select tests.create_supabase_user('collab_viewer', 'collab-viewer@example.com');
+select tests.create_supabase_user('collab_other', 'collab-other@example.com');
+select tests.create_supabase_user('collab_revoked', 'collab-revoked@example.com');
+select tests.create_supabase_user('collab_requester', 'collab-requester@example.com');
+select tests.create_supabase_user('collab_invitee', 'collab-invitee@example.com');
+select tests.create_supabase_user('collab_wrong', 'collab-wrong@example.com');
+
+create temporary table session_share_collaboration_test_state (
+  name text primary key,
+  workspace_id uuid,
+  share_id uuid,
+  entity_id uuid,
+  secret text,
+  body text,
+  revision bigint
+);
+
+grant all on session_share_collaboration_test_state
+  to anon, authenticated, service_role;
+
+insert into session_share_collaboration_test_state (
+  name,
+  workspace_id,
+  share_id
+) values (
+  'share',
+  gen_random_uuid(),
+  gen_random_uuid()
+);
+
+insert into session_share_collaboration_test_state (
+  name,
+  workspace_id
+) values (
+  'anonymous_user',
+  gen_random_uuid()
+);
+
+insert into session_share_collaboration_test_state (
+  name,
+  entity_id,
+  secret
+) values (
+  'invitation',
+  gen_random_uuid(),
+  repeat('i', 43)
+);
+
+insert into auth.users (
+  id,
+  raw_user_meta_data,
+  raw_app_meta_data,
+  is_anonymous,
+  created_at,
+  updated_at
+)
+select
+  workspace_id,
+  jsonb_build_object('test_identifier', 'collab_anonymous'),
+  '{}'::jsonb,
+  true,
+  now(),
+  now()
+from session_share_collaboration_test_state
+where name = 'anonymous_user';
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('collab_owner'),
+  tests.get_supabase_uid('collab_manager'),
+  tests.get_supabase_uid('collab_commenter'),
+  tests.get_supabase_uid('collab_editor'),
+  tests.get_supabase_uid('collab_viewer'),
+  tests.get_supabase_uid('collab_other'),
+  tests.get_supabase_uid('collab_revoked'),
+  tests.get_supabase_uid('collab_requester'),
+  tests.get_supabase_uid('collab_invitee'),
+  tests.get_supabase_uid('collab_wrong')
+);
+
+select tests.authenticate_as_service_role();
+
+insert into public.workspaces (id, owner_user_id, kind, name)
+select
+  workspace_id,
+  tests.get_supabase_uid('collab_owner'),
+  'shared',
+  'Session collaboration workspace'
+from session_share_collaboration_test_state
+where name = 'share';
+
+insert into public.workspace_memberships (workspace_id, user_id, role)
+select
+  workspace_id,
+  tests.get_supabase_uid('collab_owner'),
+  'owner'
+from session_share_collaboration_test_state
+where name = 'share'
+union all
+select
+  workspace_id,
+  tests.get_supabase_uid('collab_manager'),
+  'admin'
+from session_share_collaboration_test_state
+where name = 'share'
+union all
+select
+  workspace_id,
+  tests.get_supabase_uid('collab_other'),
+  'member'
+from session_share_collaboration_test_state
+where name = 'share';
+
+insert into public.session_shares (
+  id,
+  workspace_id,
+  session_id,
+  created_by_user_id
+)
+select
+  share_id,
+  workspace_id,
+  'collaboration-session',
+  tests.get_supabase_uid('collab_owner')
+from session_share_collaboration_test_state
+where name = 'share';
+
+insert into public.session_share_snapshots (
+  share_id,
+  content_revision,
+  title,
+  body_json,
+  published_by_user_id
+)
+select
+  share_id,
+  7,
+  'Collaboration fixture',
+  '{"type":"doc","content":[{"type":"paragraph"}]}'::jsonb,
+  tests.get_supabase_uid('collab_owner')
+from session_share_collaboration_test_state
+where name = 'share';
+
+insert into public.session_access_grants (
+  share_id,
+  grantee_user_id,
+  capability,
+  granted_by_user_id,
+  revoked_by_user_id,
+  revoked_at
+)
+select
+  share_id,
+  tests.get_supabase_uid('collab_commenter'),
+  'commenter',
+  tests.get_supabase_uid('collab_owner'),
+  null::uuid,
+  null::timestamptz
+from session_share_collaboration_test_state
+where name = 'share'
+union all
+select
+  share_id,
+  tests.get_supabase_uid('collab_editor'),
+  'editor',
+  tests.get_supabase_uid('collab_owner'),
+  null::uuid,
+  null::timestamptz
+from session_share_collaboration_test_state
+where name = 'share'
+union all
+select
+  share_id,
+  tests.get_supabase_uid('collab_viewer'),
+  'viewer',
+  tests.get_supabase_uid('collab_owner'),
+  null::uuid,
+  null::timestamptz
+from session_share_collaboration_test_state
+where name = 'share'
+union all
+select
+  share_id,
+  tests.get_supabase_uid('collab_revoked'),
+  'commenter',
+  tests.get_supabase_uid('collab_owner'),
+  tests.get_supabase_uid('collab_owner'),
+  now()
+from session_share_collaboration_test_state
+where name = 'share';
+
+insert into public.session_access_invitations (
+  id,
+  share_id,
+  invitee_email,
+  invitee_user_id,
+  capability,
+  token_hash,
+  invited_by_user_id,
+  expires_at
+)
+select
+  invitation.entity_id,
+  share.share_id,
+  'collab-invitee@example.com',
+  tests.get_supabase_uid('collab_invitee'),
+  'commenter',
+  extensions.digest(invitation.secret, 'sha256'),
+  tests.get_supabase_uid('collab_owner'),
+  now() + interval '30 days'
+from session_share_collaboration_test_state as invitation
+cross join session_share_collaboration_test_state as share
+where invitation.name = 'invitation'
+  and share.name = 'share';
+
+select tests.clear_authentication();
+reset role;
+
+select ok(
+  (
+    select class.relrowsecurity
+    from pg_class as class
+    join pg_namespace as namespace
+      on namespace.oid = class.relnamespace
+    where namespace.nspname = 'public'
+      and class.relname = 'session_share_comments'
+  ),
+  'The shared comment table has row-level security enabled'
+);
+
+select ok(
+  not exists (
+    select 1
+    from information_schema.table_privileges as privilege
+    where privilege.table_schema = 'public'
+      and privilege.table_name = 'session_share_comments'
+      and privilege.grantee in ('PUBLIC', 'anon', 'authenticated')
+  )
+    and has_table_privilege(
+      'service_role',
+      'public.session_share_comments',
+      'SELECT, INSERT, UPDATE, DELETE'
+    ),
+  'Shared comments are hidden from clients and writable by trusted service code'
+);
+
+select ok(
+  exists (
+    select 1
+    from pg_constraint
+    where conrelid = 'public.session_share_comments'::regclass
+      and conname = 'session_share_comments_revision_check'
+  )
+    and exists (
+      select 1
+      from pg_constraint
+      where conrelid = 'public.session_share_comments'::regclass
+        and conname = 'session_share_comments_body_check'
+    )
+    and exists (
+      select 1
+      from pg_indexes
+      where schemaname = 'public'
+        and tablename = 'session_share_comments'
+        and indexname = 'session_share_comments_active_feed_idx'
+        and indexdef ilike '%where (deleted_at is null)%'
+    ),
+  'Shared comments constrain revisions and bodies and have an active feed index'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from pg_indexes
+    where schemaname = 'public'
+      and indexname in (
+        'session_access_requests_history_idx',
+        'session_access_events_subject_created_idx'
+      )
+  $$,
+  array[2::bigint],
+  'Collaboration request and subject event lookups have targeted indexes'
+);
+
+select ok(
+  (
+    select count(*) = 6
+      and bool_and(not proc.prosecdef)
+      and bool_and(
+        'search_path=""' = any(coalesce(proc.proconfig, array[]::text[]))
+      )
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments',
+        'delete_session_share_comment',
+        'get_my_session_access_request',
+        'list_session_share_access_page',
+        'inspect_my_session_access_invitation'
+      )
+  ),
+  'Public collaboration wrappers are hardened security invokers'
+);
+
+select ok(
+  (
+    select count(*) = 6
+      and bool_and(proc.prosecdef)
+      and bool_and(
+        'search_path=""' = any(coalesce(proc.proconfig, array[]::text[]))
+      )
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'private'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments',
+        'delete_session_share_comment',
+        'get_my_session_access_request',
+        'list_session_share_access_page',
+        'inspect_my_session_access_invitation'
+      )
+  ),
+  'Private collaboration implementations use hardened security definers'
+);
+
+select ok(
+  (
+    select count(*) = 6
+      and bool_and(has_function_privilege('authenticated', proc.oid, 'EXECUTE'))
+      and bool_and(not has_function_privilege('anon', proc.oid, 'EXECUTE'))
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments',
+        'delete_session_share_comment',
+        'get_my_session_access_request',
+        'list_session_share_access_page',
+        'inspect_my_session_access_invitation'
+      )
+  ),
+  'Only authenticated database clients can execute collaboration wrappers'
+);
+
+select ok(
+  (
+    select count(*) = 2
+      and bool_and('is_author' = any(proc.proargnames))
+      and bool_and(not ('author_user_id' = any(proc.proargnames)))
+    from pg_proc as proc
+    join pg_namespace as namespace
+      on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'create_session_share_comment',
+        'list_session_share_comments'
+      )
+  ),
+  'Public comment results expose author ownership without stable user identifiers'
+);
+
+select tests.authenticate_as('collab_owner');
+
+select throws_ok(
+  $$select count(*) from public.session_share_comments$$,
+  '42501',
+  'permission denied for table session_share_comments',
+  'Authenticated clients cannot read comment rows directly'
+);
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id,
+      body,
+      revision
+    )
+    select
+      'owner_comment',
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      comment_id,
+      body,
+      snapshot_content_revision
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      '  Owner comment  '
+    )
+  $$,
+  'A source workspace owner can create a comment'
+);
+
+select results_eq(
+  $$
+    select body, revision
+    from session_share_collaboration_test_state
+    where name = 'owner_comment'
+  $$,
+  $$values ('Owner comment'::text, 7::bigint)$$,
+  'Comment creation trims the body and records the current snapshot revision'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_commenter');
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id,
+      body,
+      revision
+    )
+    select
+      'commenter_comment',
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      comment_id,
+      body,
+      snapshot_content_revision
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'Commenter comment'
+    )
+  $$,
+  'A named Commenter can create a comment without a Pro entitlement'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_editor');
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id,
+      body,
+      revision
+    )
+    select
+      'editor_comment',
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      comment_id,
+      body,
+      snapshot_content_revision
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'Editor comment'
+    )
+  $$,
+  'A named Editor can create a comment without a Pro entitlement'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_viewer');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'Viewer write'
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'A named Viewer cannot create a comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_anonymous');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'Anonymous write'
+    )
+  $$,
+  '42501',
+  'session access operation not permitted',
+  'An anonymous Auth identity cannot create a comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_other');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'Ungranted write'
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'An ungranted permanent user cannot create a comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_revoked');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'Revoked write'
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'A revoked Commenter cannot create a comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_owner');
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      E' \t\n\r\v\f '
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'Whitespace-only comment bodies are rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.create_session_share_comment(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      repeat('x', 16385)
+    )
+  $$,
+  '22023',
+  'invalid session comment',
+  'Comment bodies larger than sixteen KiB are rejected'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_viewer');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  array[3::bigint],
+  'An invited Viewer with an active individual grant can list comments'
+);
+
+select results_eq(
+  $$
+    select count(*), min(snapshot_content_revision), max(snapshot_content_revision)
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  $$values (3::bigint, 7::bigint, 7::bigint)$$,
+  'Every created comment is tied to the published snapshot revision'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_service_role();
+
+update public.session_shares
+set
+  general_scope = 'public',
+  general_workspace_id = null
+where id = (
+  select share_id
+  from session_share_collaboration_test_state
+  where name = 'share'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_other');
+
+select throws_ok(
+  $$
+    select *
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'Public viewers without an individual grant receive an explicit comment-access denial'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_service_role();
+
+update public.session_shares
+set
+  general_scope = 'workspace',
+  general_workspace_id = (
+    select workspace_id
+    from session_share_collaboration_test_state
+    where name = 'share'
+  )
+where id = (
+  select share_id
+  from session_share_collaboration_test_state
+  where name = 'share'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_other');
+
+select throws_ok(
+  $$
+    select *
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'Workspace viewers without an individual grant receive an explicit comment-access denial'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_service_role();
+
+update public.session_shares
+set
+  general_scope = 'restricted',
+  general_workspace_id = null
+where id = (
+  select share_id
+  from session_share_collaboration_test_state
+  where name = 'share'
+);
+
+insert into public.session_share_comments (
+  share_id,
+  author_user_id,
+  snapshot_content_revision,
+  body,
+  created_at
+)
+select
+  state.share_id,
+  tests.get_supabase_uid('collab_owner'),
+  7,
+  format('pagination-comment-%s', lpad(series.value::text, 3, '0')),
+  now() + interval '1 day' + series.value * interval '1 second'
+from session_share_collaboration_test_state as state
+cross join generate_series(1, 101) as series(value)
+where state.name = 'share';
+
+insert into session_share_collaboration_test_state (
+  name,
+  entity_id,
+  secret
+)
+select
+  'comment_cursor',
+  comment.id,
+  comment.created_at::text
+from public.session_share_comments as comment
+where comment.body = 'pagination-comment-002';
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_viewer');
+
+select results_eq(
+  $$
+    select
+      count(*),
+      bool_or(body = 'pagination-comment-001'),
+      bool_or(body = 'pagination-comment-101')
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  $$values (100::bigint, false, true)$$,
+  'The initial comment page returns the newest one hundred active comments'
+);
+
+select results_eq(
+  $$
+    select
+      count(*),
+      bool_or(body = 'pagination-comment-001'),
+      bool_or(body = 'pagination-comment-002'),
+      bool_or(body = 'pagination-comment-101')
+    from public.list_session_share_comments(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      (
+        select secret::timestamptz
+        from session_share_collaboration_test_state
+        where name = 'comment_cursor'
+      ),
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'comment_cursor'
+      ),
+      100
+    )
+  $$,
+  $$values (4::bigint, true, false, false)$$,
+  'A comment cursor loads only the earlier active history'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_requester');
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id
+    )
+    select
+      'access_request',
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      request_id
+    from public.request_session_access(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'commenter'
+    )
+  $$,
+  'An ungranted permanent user can request Commenter access'
+);
+
+select results_eq(
+  $$
+    select requested_capability, status, reviewed_at is null
+    from public.get_my_session_access_request(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  $$values ('commenter'::text, 'pending'::text, true)$$,
+  'A requester can read their own latest request state'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_owner');
+
+select results_eq(
+  $$
+    select user_email, capability, status
+    from public.list_session_share_access_page(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      null,
+      null,
+      100
+    )
+    where entry_id = (
+      select entity_id
+      from session_share_collaboration_test_state
+      where name = 'access_request'
+    )
+  $$,
+  $$values ('collab-requester@example.com'::text, 'commenter'::text, 'pending'::text)$$,
+  'A manager can identify the account behind a pending request'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_requester');
+
+select lives_ok(
+  $$
+    select *
+    from public.cancel_session_access_request(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'access_request'
+      )
+    )
+  $$,
+  'A requester can cancel their pending access request'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.request_session_access(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'commenter'
+    )
+  $$,
+  '22023',
+  'session access request is rate limited',
+  'A requester cannot recreate a cancelled request during the cooldown'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_other');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.get_my_session_access_request(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  array[0::bigint],
+  'Another user cannot inspect the requester state'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_invitee');
+
+select results_eq(
+  $$
+    select status, capability, share_id is null
+    from public.inspect_my_session_access_invitation(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      ),
+      (
+        select secret
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      )
+    )
+  $$,
+  $$values ('pending'::text, 'commenter'::text, true)$$,
+  'The intended recipient can inspect a pending invitation without note metadata'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_wrong');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.inspect_my_session_access_invitation(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      ),
+      (
+        select secret
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      )
+    )
+  $$,
+  array[0::bigint],
+  'A valid invitation token reveals no state to the wrong account'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_invitee');
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id
+    )
+    select
+      'accepted_grant',
+      share_id,
+      grant_id
+    from public.accept_session_access_invitation(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      ),
+      (
+        select secret
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      )
+    )
+  $$,
+  'The intended recipient can accept the inspected invitation'
+);
+
+select results_eq(
+  $$
+    select
+      status,
+      capability,
+      share_id = (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    from public.inspect_my_session_access_invitation(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      ),
+      (
+        select secret
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      )
+    )
+  $$,
+  $$values ('accepted'::text, 'commenter'::text, true)$$,
+  'Accepted invitation inspection returns only the granted share identity'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_other');
+
+select throws_ok(
+  $$
+    select *
+    from public.delete_session_share_comment(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'commenter_comment'
+      )
+    )
+  $$,
+  '42501',
+  'session comment operation not permitted',
+  'An unrelated user cannot delete another collaborator comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('collab_commenter');
+
+select lives_ok(
+  $$
+    select *
+    from public.delete_session_share_comment(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'commenter_comment'
+      )
+    )
+  $$,
+  'A comment author can delete their own comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select
+      body,
+      deleted_at is not null,
+      deleted_by_user_id = tests.get_supabase_uid('collab_commenter')
+    from public.session_share_comments
+    where id = (
+      select entity_id
+      from session_share_collaboration_test_state
+      where name = 'commenter_comment'
+    )
+  $$,
+  $$values (''::text, true, true)$$,
+  'Author deletion redacts the persisted comment body'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_manager');
+
+select lives_ok(
+  $$
+    select *
+    from public.delete_session_share_comment(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'editor_comment'
+      )
+    )
+  $$,
+  'A source workspace manager can moderate a collaborator comment'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select results_eq(
+  $$
+    select
+      body,
+      deleted_at is not null,
+      deleted_by_user_id = tests.get_supabase_uid('collab_manager')
+    from public.session_share_comments
+    where id = (
+      select entity_id
+      from session_share_collaboration_test_state
+      where name = 'editor_comment'
+    )
+  $$,
+  $$values (''::text, true, true)$$,
+  'Manager moderation redacts the persisted comment body'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select ok(
+  not exists (
+    select 1
+    from public.session_access_events as event
+    join session_share_collaboration_test_state as state
+      on state.entity_id = event.related_entity_id
+    where state.name in (
+        'owner_comment',
+        'commenter_comment',
+        'editor_comment'
+      )
+      and (
+        event.previous_value = state.body
+        or event.new_value = state.body
+      )
+  ),
+  'Collaboration events never persist comment bodies'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_revoked');
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id
+    )
+    select
+      'revoked_access_request',
+      share.share_id,
+      request.request_id
+    from session_share_collaboration_test_state as share
+    cross join lateral public.request_session_access(
+      share.share_id,
+      'commenter'
+    ) as request
+    where share.name = 'share'
+  $$,
+  'A user with a revoked grant can request Commenter access again'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_hyprnote_pro('collab_owner');
+
+select lives_ok(
+  $$
+    insert into session_share_collaboration_test_state (
+      name,
+      share_id,
+      entity_id,
+      body
+    )
+    select
+      'revoked_access_grant',
+      request.share_id,
+      review.grant_id,
+      review.capability
+    from session_share_collaboration_test_state as request
+    cross join lateral public.review_session_access_request(
+      request.entity_id,
+      'approved',
+      'commenter'
+    ) as review
+    where request.name = 'revoked_access_request'
+  $$,
+  'A Pro manager can approve the renewed Commenter request'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_revoked');
+
+select results_eq(
+  $$
+    select requested_capability, status
+    from public.get_my_session_access_request(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  $$values ('commenter'::text, 'approved'::text)$$,
+  'An approved request remains visible while its matching grant is active'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_hyprnote_pro('collab_owner');
+
+select lives_ok(
+  $$
+    select *
+    from public.revoke_session_access_grant(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'revoked_access_grant'
+      )
+    )
+  $$,
+  'A manager can revoke the approved Commenter grant'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_revoked');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.get_my_session_access_request(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      )
+    )
+  $$,
+  array[0::bigint],
+  'A revoked approval no longer traps the requester in approved state'
+);
+
+select results_eq(
+  $$
+    select requested_capability, was_created
+    from public.request_session_access(
+      (
+        select share_id
+        from session_share_collaboration_test_state
+        where name = 'share'
+      ),
+      'commenter'
+    )
+  $$,
+  $$values ('commenter'::text, true)$$,
+  'A user can create a fresh request after the approved grant is revoked'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as_service_role();
+
+update public.workspaces
+set deleted_at = now()
+where id = (
+  select workspace_id
+  from session_share_collaboration_test_state
+  where name = 'share'
+);
+
+select tests.clear_authentication();
+reset role;
+select tests.authenticate_as('collab_invitee');
+
+select results_eq(
+  $$
+    select count(*)
+    from public.inspect_my_session_access_invitation(
+      (
+        select entity_id
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      ),
+      (
+        select secret
+        from session_share_collaboration_test_state
+        where name = 'invitation'
+      )
+    )
+  $$,
+  array[0::bigint],
+  'Invitation inspection hides shares whose source workspace is unavailable'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- Add authenticated comments, invitations, access requests, and per-person viewer/commenter/editor grants.
- Continue invitation flows safely through sign-in without exposing or prematurely discarding share credentials.
- Preserve the requested capability during manager approval instead of silently downgrading edit/view requests to comment access.
- Keep comment threads private to source-workspace managers and active individual grantees; public, workspace-general, and link-only viewers receive an explicit grant-required state.
- Add owner management surfaces for pending requests and existing collaborators.
- Keep the API surface narrow by retaining internal collaboration audit writes without exposing an unused activity-feed RPC.

## Validation

- `supabase db reset --local --yes`
- `supabase test db`: 23 files / 804 tests
- Collaboration pgTAP: 48/48 assertions (49 target tests including setup)
- Pro-entitlement pgTAP: 63/63 assertions including setup
- Web: 71/71 tests and TypeScript typecheck
- Desktop: 244 files / 1,770 tests and TypeScript typecheck
- dprint formatting and SQL diff checks
- Supabase security advisors: only the two pre-existing test-extension warnings

## Dependency

- #6127 is merged; this PR is now based directly on `main`.


<!-- GitButler Footer Boundary Top -->
---
This is **part 1 of 4 in a stack** made with GitButler:
- <kbd>&nbsp;4&nbsp;</kbd> #6130
- <kbd>&nbsp;3&nbsp;</kbd> #6129
- <kbd>&nbsp;2&nbsp;</kbd> #6128
- <kbd>&nbsp;1&nbsp;</kbd> #6102 👈 
<!-- GitButler Footer Boundary Bottom -->
