### PR TITLE
fix(oauth): clarify calendar data consent

### DIFF
--- a/apps/web/content/legal/privacy.mdx
+++ b/apps/web/content/legal/privacy.mdx
@@ -1,5 +1,5 @@
 ---
-date: "2026-07-16"
+date: "2026-07-17"
 title: "Privacy Policy"
 summary: "How we collect, use, and protect your personal information"
 ---
@@ -37,13 +37,13 @@ Analytics and telemetry events are designed to avoid raw meeting audio, transcri
 
 ### 3.3 Google Calendar and Microsoft Outlook Calendar Accounts
 
-If you connect Google Calendar or Microsoft Outlook Calendar through Microsoft Graph, we collect and process the data needed to display your calendars and upcoming events in Anarlog and let you create personal notes and memos associated with those events. This may include:
+If you connect Google Calendar or Microsoft Outlook Calendar, we use the Google Calendar API or Microsoft Graph, respectively, to collect and process the data needed to display your calendars and upcoming events in Anarlog and let you create personal notes and memos associated with those events. This may include:
 
 - **Calendar Information:** Calendar IDs, names, colors, access or ownership metadata, and source or account identifiers
 - **Event Information:** Event IDs, titles, descriptions, locations, meeting links, start and end times, time zones, recurrence metadata, organizer details, and attendee details such as names, email addresses, and RSVP status
 - **Connection Information:** Provider connection IDs, connection status, and the Google or Microsoft account identity associated with the connection
 
-We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
+We use connected calendar data to display calendars and upcoming events and to support the personal notes and memos you create for those events. Calendar API responses pass through Nango's encrypted API proxy before reaching Anarlog. We do not use connected calendar data for advertising, marketing personalization, sale to data brokers, or training generalized AI models. The use of information received from Google Workspace APIs adheres to the [Google Workspace API User Data and Developer Policy](https://developers.google.com/workspace/workspace-api-user-data-developer-policy), including the Limited Use requirements.
 
 ## 4. How We Use Your Information
 
@@ -60,9 +60,9 @@ We use your information to:
 
 ## 5. Data Storage and Security
 
-We implement appropriate technical and organizational security measures to protect your information against unauthorized access, alteration, disclosure, or destruction. Your data is encrypted in transit and at rest.
+We implement appropriate technical and organizational security measures to protect your information against unauthorized access, alteration, disclosure, or destruction. We use HTTPS/TLS to protect data transmitted over external networks. The operating system controls at-rest protection for data stored locally on your device, including any device-level encryption you enable.
 
-For connected calendars, synced calendar and event data is primarily stored locally on your device. We may store limited connection metadata on our backend (integration ID, connection ID, connection status, error state, timestamps) needed to operate the integration securely. We protect this data in transit using HTTPS/TLS and at rest using encryption and access controls.
+For connected calendars, calendar and event data is primarily stored in Anarlog's local application database on your device. Nango, our integration provider, stores the OAuth access and refresh tokens needed to maintain the connection. Nango encrypts these credentials at rest using AES-256-GCM and protects data in transit using TLS. We store limited connection metadata on our backend (integration ID, connection ID, connection status, error state, and timestamps) needed to operate the integration securely.
 
 No method of transmission over the Internet or electronic storage is 100% secure. While we strive to use commercially acceptable means to protect your information, we cannot guarantee its absolute security.
 
@@ -77,7 +77,7 @@ We do not sell, trade, or rent your personal information to third parties, inclu
 We may share your information with third-party service providers who perform services on our behalf, such as:
 
 - **Cloud hosting and infrastructure providers** (e.g., Fly.io, Netlify, Cloudflare, Supabase) for hosting our application and storing data securely
-- **Integration providers** (e.g., Nango) for OAuth connection management and calendar sync infrastructure
+- **Integration providers** (e.g., Nango) for encrypted OAuth credential storage, token refresh, and the API proxy used to retrieve calendar data
 - **Payment processors** (e.g., Stripe) for processing payments securely
 - **Analytics services** (e.g., PostHog, Google Analytics) for understanding how users interact with our Service
 - **Speech-to-text providers** (e.g., Deepgram, AssemblyAI, Soniox) for cloud-based transcription when you enable this feature
@@ -90,11 +90,14 @@ We may share your information with third-party service providers who perform ser
 When you connect Google Calendar or Microsoft Outlook Calendar, we may share connected calendar data only:
 
 - With service providers directly involved in authenticating the connection, syncing calendars and events, and delivering the calendar features you enable
+- Through encrypted Cloud Sync or content you choose to share when event context has been associated with a note and you enable that user-facing feature
 - For security purposes, such as investigating abuse, preventing fraud, or fixing integration failures
 - To comply with applicable law, regulation, legal process, or enforceable governmental request
-- As part of a merger, acquisition, or asset sale, subject to applicable legal requirements
+- As part of a merger, acquisition, or asset sale, only after obtaining your explicit prior consent
 
 We do not sell connected calendar data or transfer it to third parties for advertising, marketing, or data broker purposes.
+
+We do not permit employees, contractors, or other people to read connected calendar data unless you give explicit consent for support involving specific data, access is necessary to investigate a security issue or abuse, or access is required by applicable law.
 
 ### 6.4 Legal Requirements
 
@@ -104,7 +107,7 @@ We may disclose your information if required by law or in response to valid requ
 
 ### 7.1 Access and Portability
 
-Your notes are stored as plain markdown files on your device — you have full access at all times.
+Your notes are stored locally on your device. You can access them in Anarlog and use Anarlog's export tools to create portable copies.
 
 ### 7.2 Correction and Deletion
 
@@ -112,7 +115,7 @@ You may request account deletion at any time by contacting us at hello@anarlog.s
 
 ### 7.3 Data Retention
 
-If you connect Google Calendar or Microsoft Outlook Calendar, synced calendar and event data is retained locally on your device until you delete it, disconnect the account, or remove local Anarlog data. On our systems, we retain limited connection metadata while the integration is active and for up to 30 days after disconnection or account deletion, except where a longer period is required by law. If you delete your account, we will delete your cloud-stored data within 30 days, except where required to retain it for legal purposes.
+If you connect Google Calendar or Microsoft Outlook Calendar, calendar and event data is retained locally on your device. Disconnecting stops future access and removes the data from active calendar views after Anarlog refreshes, but underlying local records and event context already associated with notes may remain until you remove local Anarlog app data. When a connection is deleted, our integration provider makes it inaccessible immediately and permanently deletes its credentials and associated metadata after its default 31-day retention period. Before requesting account deletion, disconnect each connected calendar account. If you cannot access the app, contact us so we can delete the connection for you. We delete cloud-stored data controlled by Anarlog within 30 days, except where required to retain it for legal purposes.
 
 ### 7.4 Analytics and Telemetry Controls
 
@@ -121,7 +124,7 @@ If you connect Google Calendar or Microsoft Outlook Calendar, synced calendar an
 
 ### 7.5 Connected Account Controls
 
-You can disconnect Google Calendar or Microsoft Outlook Calendar in your account integrations settings. Disconnecting stops future syncs. Calendar and event data already synced locally to your device remains until you remove it or delete local app data.
+You can choose which calendars Anarlog displays or disconnect an account from the Calendar sidebar. Disconnecting stops future access and syncs; it does not delete personal notes or memos you created. Follow our [connected calendar data instructions](https://docs.anarlog.so/calendar#manage-or-delete-connected-calendar-data) to manage calendars, disconnect an account, revoke provider access, or permanently remove locally retained calendar data. Permanently removing local calendar data currently requires removing all local Anarlog app data from that device.
 
 ## 8. International Data Transfers
 

--- a/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
+++ b/apps/web/src/routes/_view/app/-integrations-connect-flow.tsx
@@ -7,7 +7,6 @@ import { createClient } from "@hypr/api-client/client";
 
 import { env } from "@/env";
 import { getAccessToken } from "@/functions/access-token";
-import { useMountEffect } from "@/hooks/useMountEffect";
 
 import { IntegrationButton, IntegrationPageLayout } from "./-integration-ui";
 import { getIntegrationDisplay, Route } from "./integration";
@@ -16,13 +15,15 @@ export function ConnectFlow() {
   const search = Route.useSearch();
   const navigate = useNavigate();
   const isGoogleCalendar = search.integration_id === "google-calendar";
+  const isOutlookCalendar = search.integration_id === "outlook";
+  const isConnectedCalendar = isGoogleCalendar || isOutlookCalendar;
   const [nango] = useState(() => new Nango());
   const [status, setStatus] = useState<
     "idle" | "loading" | "connecting" | "success" | "error"
-  >(isGoogleCalendar ? "loading" : "idle");
+  >("idle");
   const statusRef = useRef<
     "idle" | "loading" | "connecting" | "success" | "error"
-  >(isGoogleCalendar ? "loading" : "idle");
+  >("idle");
   const inFlightRef = useRef(false);
 
   const display = getIntegrationDisplay(search.integration_id);
@@ -109,13 +110,9 @@ export function ConnectFlow() {
     connect.setSessionToken(sessionToken);
   };
 
-  useMountEffect(() => {
-    if (!isGoogleCalendar) return;
-    void handleConnect();
-  });
-
   const isLoading = status === "loading";
   const isConnecting = status === "connecting";
+  const consentProvider = isGoogleCalendar ? "Google" : "Microsoft";
 
   return (
     <IntegrationPageLayout>
@@ -127,6 +124,42 @@ export function ConnectFlow() {
           {isConnecting ? display.connectingHint : display.description}
         </p>
       </div>
+
+      {isConnectedCalendar && !isConnecting && status !== "success" && (
+        <div className="flex flex-col gap-3 rounded-2xl border border-stone-200 bg-stone-50 p-5 text-left text-sm leading-6 text-stone-700">
+          <p>
+            Anarlog will read your calendar list and event details—including
+            titles, times, participants, locations, and meeting links—to show
+            upcoming events and associate them with your private notes.
+          </p>
+          <p>
+            Access is read-only. Anarlog cannot create, edit, or delete events.
+            Calendar API responses pass through Nango's encrypted proxy before
+            reaching Anarlog, and Nango stores the encrypted OAuth credentials
+            needed to maintain the connection. Calendar data is then stored
+            locally on your device.
+          </p>
+          <p>
+            If you enable encrypted Cloud Sync or share a note, event context
+            associated with that note can be included in the content you choose
+            to sync or share.
+          </p>
+          <p>
+            Read our{" "}
+            <a className="underline" href="/privacy">
+              Privacy Policy
+            </a>{" "}
+            and{" "}
+            <a
+              className="underline"
+              href="https://docs.anarlog.so/calendar#manage-or-delete-connected-calendar-data"
+            >
+              calendar data instructions
+            </a>
+            .
+          </p>
+        </div>
+      )}
 
       {(status === "idle" || isLoading) && (
         <IntegrationButton onClick={handleConnect} disabled={isLoading}>
@@ -152,7 +185,11 @@ export function ConnectFlow() {
               />
             </svg>
           )}
-          {isLoading ? "Connecting…" : `Connect ${display.name}`}
+          {isLoading
+            ? "Connecting…"
+            : isConnectedCalendar
+              ? `Continue to ${consentProvider}`
+              : `Connect ${display.name}`}
         </IntegrationButton>
       )}
 

--- a/apps/web/src/routes/_view/app/integration.tsx
+++ b/apps/web/src/routes/_view/app/integration.tsx
@@ -24,8 +24,16 @@ export const INTEGRATION_DISPLAY: Record<
 > = {
   "google-calendar": {
     name: "Google Calendar",
-    description: "Connect your Google Calendar to sync your meetings",
-    connectingHint: "Follow the prompts to connect your Google account",
+    description:
+      "Review how Anarlog uses Google Calendar data, then continue to Google",
+    connectingHint: "Finish authorization with Google, then return to Anarlog",
+  },
+  outlook: {
+    name: "Outlook Calendar",
+    description:
+      "Review how Anarlog uses Outlook Calendar data, then continue to Microsoft",
+    connectingHint:
+      "Finish authorization with Microsoft, then return to Anarlog",
   },
   linear: {
     name: "Linear",

--- a/docs/calendar.mdx
+++ b/docs/calendar.mdx
@@ -7,6 +7,8 @@ Open **Calendar** in the sidebar, add an account, and enable the calendars you w
 
 Anarlog uses calendar events for titles, times, participants, reminders, and meeting links. It does not add a bot to your calls.
 
+Google and Outlook connections are read-only. Anarlog reads calendar and event details to show upcoming events and associate them with your notes. It does not create, edit, or delete events in Google Calendar or Outlook.
+
 ## Apple Calendar
 
 Apple Calendar is available on macOS.
@@ -28,6 +30,32 @@ If access was denied, open **Settings → Permissions** in Anarlog. Use **Open**
 1. Sign in to Anarlog.
 2. Choose **Outlook Calendar**, then finish authorization in your browser.
 3. Return to Anarlog and enable the calendars you want to sync.
+
+## Manage or delete connected calendar data
+
+To control which calendars appear in Anarlog, open **Calendar**, expand the provider, and turn individual calendars on or off.
+
+To disconnect Google Calendar or Outlook Calendar:
+
+1. Open **Calendar** and expand **Google** or **Outlook**.
+2. Hover over or right-click the connected account heading.
+3. Open **•••** and choose **Disconnect**.
+
+Disconnecting stops future access and syncs. After Anarlog refreshes, the account's cached calendars and events disappear from active calendar views. Your notes and memos remain, including event context already associated with a note. The OAuth connection becomes inaccessible immediately and its stored credentials are scheduled for permanent deletion within 31 days.
+
+You can also revoke Anarlog's access from your [Google Account connections](https://myaccount.google.com/connections), the [Microsoft My Apps portal](https://myapplications.microsoft.com) for a work or school account, or [Microsoft account app access](https://account.live.com/consent/Manage) for a personal account.
+
+To permanently remove calendar-derived data retained on a Mac, you currently need to remove all local Anarlog app data from that Mac:
+
+1. Export anything you want to keep, then quit Anarlog.
+2. In Finder, choose **Go → Go to Folder**.
+3. Move any of these folders that exist to Trash:
+   - `~/Library/Application Support/anarlog`
+   - `~/Library/Application Support/hyprnote`
+   - `~/Library/Application Support/com.hyprnote.stable`
+4. Empty Trash before reopening Anarlog.
+
+This removes Anarlog's local database and settings on that Mac, including cached calendar data and event context stored with local records. It can also remove other Anarlog data stored in those folders. It does not delete files you exported or copies you chose to sync or share. You can request deletion of your Anarlog account and cloud-stored data at [hello@anarlog.so](mailto:hello@anarlog.so). Contact us before deleting anything if you need help identifying the correct folder.
 
 <Note>
   Google and Outlook connections are included with Anarlog Pro. Apple Calendar uses the calendar accounts already connected to your Mac.

--- a/docs/data-and-privacy.mdx
+++ b/docs/data-and-privacy.mdx
@@ -17,7 +17,7 @@ The destination depends on the feature you choose:
 
 - A hosted **Transcription** provider receives the audio needed to create a transcript.
 - A hosted **Intelligence** provider receives the text and instructions needed to create a summary or chat response.
-- Connected calendars exchange the event data required to show and update your meetings.
+- Connected calendars send the calendar and event details needed to show upcoming events and associate them with your notes.
 - Sync and sharing features send the content you choose to make available on another device or through a link.
 
 Anarlog Cloud, your own API-key providers, and local providers are separate choices. Review the provider's own retention and training policies before sending sensitive content.


### PR DESCRIPTION
Make connected-calendar consent explicit before OAuth and align the public privacy documentation with the implemented Google and Microsoft data flow.

## What changed

- Replace automatic Google authorization with a user-initiated consent screen for Google Calendar and Outlook.
- Explain the read-only event fields Anarlog uses, Nango proxy/token storage, local persistence, and how sync or sharing can include associated event context.
- Correct the Privacy Policy and calendar documentation for provider-specific APIs, retention, disconnect behavior, revocation, and local-data removal.
- Add the missing Outlook integration copy.

## Verification

- All 10 exact-head checks pass, including web CI and docs deployment.
- No unresolved review threads or requested changes.

