### PR TITLE
feat(attachments): add encrypted cloud backup authority

### DIFF
--- a/.github/workflows/web_ci.yaml
+++ b/.github/workflows/web_ci.yaml
@@ -21,5 +21,7 @@ jobs:
       - uses: ./.github/actions/pnpm_install
       - uses: denoland/setup-deno@v2
       - run: pnpm -F ui build
+      - run: pnpm -F @hypr/supabase typecheck
+      - run: pnpm -F @hypr/supabase test
       - run: pnpm -F web typecheck
       - run: pnpm -F web test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -873,6 +873,7 @@ dependencies = [
  "sentry",
  "serde",
  "serde_json",
+ "supabase-storage",
  "thiserror 2.0.18",
  "tokio",
  "tower 0.5.3",
@@ -17195,12 +17196,16 @@ dependencies = [
 name = "supabase-storage"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "observability",
  "reqwest 0.13.2",
  "serde",
  "serde_json",
+ "sha2 0.11.0",
  "thiserror 2.0.18",
  "tokio",
+ "urlencoding",
+ "wiremock",
 ]
 
 [[package]]

--- a/apps/api/fly.toml
+++ b/apps/api/fly.toml
@@ -18,6 +18,9 @@ auto_stop_machines = 'stop'
 auto_start_machines = true
 min_machines_running = 1
 
+[http_service.http_options]
+idle_timeout = 660
+
 [http_service.concurrency]
 type = "connections"
 hard_limit = 200

--- a/apps/desktop/src/session/attachments.test.ts
+++ b/apps/desktop/src/session/attachments.test.ts
@@ -4,7 +4,7 @@ const mocks = vi.hoisted(() => ({
   audioDelete: vi.fn(),
   audioMetadata: vi.fn(),
   execute: vi.fn(),
-  executeTransaction: vi.fn().mockResolvedValue([0, 1]),
+  executeTransaction: vi.fn().mockResolvedValue([0, 1, 1]),
   enqueueDatabaseWrite: vi.fn(
     async (_key: string, write: () => Promise<number[]>) => write(),
   ),
@@ -38,7 +38,7 @@ import {
 describe("attachment catalog", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mocks.executeTransaction.mockResolvedValue([0, 1]);
+    mocks.executeTransaction.mockResolvedValue([0, 1, 1]);
     mocks.execute.mockResolvedValue([{ is_deleted: 1 }]);
     mocks.audioDelete.mockResolvedValue({ status: "ok", data: true });
     mocks.audioMetadata.mockResolvedValue({
@@ -67,10 +67,13 @@ describe("attachment catalog", () => {
       expect.any(Function),
     );
     const statements = mocks.executeTransaction.mock.calls[0]![0];
-    expect(statements).toHaveLength(2);
+    expect(statements).toHaveLength(3);
     expect(statements[1].sql).toContain("session.workspace_id");
     expect(statements[1].sql).toContain("session.deleted_at IS NULL");
     expect(statements[1].sql).not.toContain("/vault/");
+    expect(statements[0].sql).toMatch(
+      /WHEN session_attachments\.sha256 = \? THEN storage_kind/,
+    );
     expect(statements[1].params).toEqual([
       expect.stringMatching(
         /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
@@ -84,10 +87,18 @@ describe("attachment catalog", () => {
       "session-1",
       "attachments/diagram 1.png",
     ]);
+    expect(statements[2].sql).toContain("attachment_local_state");
+    expect(statements[2].sql).toContain("'present'");
+    expect(statements[2].sql).toContain("ON CONFLICT(attachment_id)");
+    expect(statements[2].params).toEqual([
+      "session-1",
+      "attachments/diagram 1.png",
+    ]);
+    expect(statements[2].expectedRowsAffected).toBe(1);
   });
 
   it("updates an existing physical attachment without creating a duplicate", async () => {
-    mocks.executeTransaction.mockResolvedValue([1, 0]);
+    mocks.executeTransaction.mockResolvedValue([1, 0, 1]);
 
     await expect(
       catalogLocalNoteAttachment({
@@ -99,10 +110,37 @@ describe("attachment catalog", () => {
         sha256: "b".repeat(64),
       }),
     ).resolves.toBeUndefined();
+
+    expect(mocks.executeTransaction.mock.calls[0]![0][0].params).toEqual([
+      "diagram.png",
+      "image/png",
+      42,
+      "b".repeat(64),
+      "b".repeat(64),
+      "b".repeat(64),
+      "diagram.png",
+      "session-1",
+      "attachments/diagram.png",
+    ]);
+  });
+
+  it("fails cataloging when local presence cannot be recorded", async () => {
+    mocks.executeTransaction.mockResolvedValue([0, 1, 0]);
+
+    await expect(
+      catalogLocalNoteAttachment({
+        sessionId: "session-1",
+        attachmentId: "diagram.png",
+        filename: "diagram.png",
+        contentType: "image/png",
+        sizeBytes: 42,
+        sha256: "b".repeat(64),
+      }),
+    ).rejects.toThrow("attachment session is unavailable");
   });
 
   it("rejects missing or deleted sessions and unsafe attachment IDs", async () => {
-    mocks.executeTransaction.mockResolvedValue([0, 0]);
+    mocks.executeTransaction.mockResolvedValue([0, 0, 0]);
     await expect(
       catalogLocalNoteAttachment({
         sessionId: "missing-session",
@@ -166,10 +204,11 @@ describe("attachment catalog", () => {
     ]);
     expect(statements[2].sql).toContain("attachment_local_state");
     expect(statements[2].sql).toContain("'present'");
+    expect(statements[2].expectedRowsAffected).toBe(1);
   });
 
   it("updates the same audio row when the finalized format changes", async () => {
-    mocks.executeTransaction.mockResolvedValue([1, 0]);
+    mocks.executeTransaction.mockResolvedValue([1, 0, 1]);
     mocks.audioMetadata.mockResolvedValue({
       status: "ok",
       data: {
@@ -188,6 +227,7 @@ describe("attachment catalog", () => {
       "audio.wav",
       "audio/wav",
       128,
+      "e".repeat(64),
       "e".repeat(64),
       "e".repeat(64),
       "session-audio:session-1",

--- a/apps/desktop/src/session/attachments.ts
+++ b/apps/desktop/src/session/attachments.ts
@@ -47,8 +47,11 @@ export async function catalogLocalNoteAttachment(input: {
               WHEN session_attachments.sha256 = ? THEN cloud_object_key
               ELSE ''
             END,
+            storage_kind = CASE
+              WHEN session_attachments.sha256 = ? THEN storage_kind
+              ELSE 'local_file'
+            END,
             sha256 = ?,
-            storage_kind = 'local_file',
             source_type = 'note_upload',
             source_id = ?,
             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
@@ -71,6 +74,7 @@ export async function catalogLocalNoteAttachment(input: {
           filename,
           contentType,
           input.sizeBytes,
+          input.sha256,
           input.sha256,
           input.sha256,
           attachmentId,
@@ -132,10 +136,40 @@ export async function catalogLocalNoteAttachment(input: {
           relativePath,
         ],
       },
+      {
+        sql: `
+          INSERT INTO attachment_local_state (
+            attachment_id,
+            session_id,
+            relative_path,
+            availability,
+            updated_at
+          )
+          SELECT
+            attachment.id,
+            attachment.session_id,
+            attachment.relative_path,
+            'present',
+            strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+          FROM session_attachments AS attachment
+          WHERE attachment.session_id = ?
+            AND attachment.relative_path = ?
+            AND attachment.deleted_at IS NULL
+          ORDER BY attachment.updated_at DESC, attachment.id
+          LIMIT 1
+          ON CONFLICT(attachment_id) DO UPDATE SET
+            session_id = excluded.session_id,
+            relative_path = excluded.relative_path,
+            availability = excluded.availability,
+            updated_at = excluded.updated_at
+        `,
+        params: [sessionId, relativePath],
+        expectedRowsAffected: 1,
+      },
     ]),
   );
 
-  if ((results[0] ?? 0) + (results[1] ?? 0) !== 1) {
+  if ((results[0] ?? 0) + (results[1] ?? 0) !== 1 || (results[2] ?? 0) !== 1) {
     throw new Error("attachment session is unavailable");
   }
 }
@@ -183,8 +217,11 @@ export async function catalogLocalSessionAudio(
               WHEN session_attachments.sha256 = ? THEN cloud_object_key
               ELSE ''
             END,
+            storage_kind = CASE
+              WHEN session_attachments.sha256 = ? THEN storage_kind
+              ELSE 'local_file'
+            END,
             sha256 = ?,
-            storage_kind = 'local_file',
             source_type = 'session_audio',
             source_id = 'primary',
             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
@@ -203,6 +240,7 @@ export async function catalogLocalSessionAudio(
           filename,
           contentType,
           result.data.sizeBytes,
+          result.data.sha256,
           result.data.sha256,
           result.data.sha256,
           attachmentId,
@@ -287,10 +325,14 @@ export async function catalogLocalSessionAudio(
             updated_at = excluded.updated_at
         `,
         params: [attachmentId, sessionId],
+        expectedRowsAffected: 1,
       },
     ]);
 
-    if ((results[0] ?? 0) + (results[1] ?? 0) !== 1) {
+    if (
+      (results[0] ?? 0) + (results[1] ?? 0) !== 1 ||
+      (results[2] ?? 0) !== 1
+    ) {
       throw new Error("audio session is unavailable");
     }
   });

--- a/crates/api-sync/Cargo.toml
+++ b/crates/api-sync/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2024"
 [dependencies]
 hypr-api-auth = { workspace = true }
 hypr-api-error = { workspace = true }
+hypr-supabase-storage = { workspace = true }
 
 utoipa = { workspace = true }
 
@@ -13,7 +14,7 @@ axum = { workspace = true }
 chrono = { workspace = true }
 reqwest = { workspace = true, features = ["json", "query", "stream"] }
 sentry = { workspace = true }
-tokio = { workspace = true }
+tokio = { workspace = true, features = ["sync"] }
 tracing = { workspace = true }
 
 serde = { workspace = true, features = ["derive"] }

--- a/crates/api-sync/src/error.rs
+++ b/crates/api-sync/src/error.rs
@@ -29,6 +29,24 @@ pub enum SyncError {
     #[error("CloudSync credential service is unavailable")]
     Upstream,
 
+    #[error("Attachment backup access is not permitted")]
+    AttachmentBackupForbidden,
+
+    #[error("Attachment backup is unavailable")]
+    AttachmentBackupNotFound,
+
+    #[error("Attachment backup changed")]
+    AttachmentBackupConflict,
+
+    #[error("Attachment backup quota is exhausted")]
+    AttachmentBackupQuotaExceeded,
+
+    #[error("Attachment backup service is unavailable")]
+    AttachmentBackupServiceUnavailable,
+
+    #[error("Attachment backup verification is busy")]
+    AttachmentBackupVerificationBusy,
+
     #[error("Internal error: {0}")]
     Internal(String),
 }
@@ -66,6 +84,36 @@ impl IntoResponse for SyncError {
                 StatusCode::BAD_GATEWAY,
                 "cloudsync_credential_service_unavailable",
                 "CloudSync credential service is unavailable".to_string(),
+            ),
+            Self::AttachmentBackupForbidden => (
+                StatusCode::FORBIDDEN,
+                "attachment_backup_forbidden",
+                "Attachment backup access is not permitted".to_string(),
+            ),
+            Self::AttachmentBackupNotFound => (
+                StatusCode::NOT_FOUND,
+                "attachment_backup_not_found",
+                "Attachment backup is unavailable".to_string(),
+            ),
+            Self::AttachmentBackupConflict => (
+                StatusCode::CONFLICT,
+                "attachment_backup_conflict",
+                "Attachment backup changed".to_string(),
+            ),
+            Self::AttachmentBackupQuotaExceeded => (
+                StatusCode::INSUFFICIENT_STORAGE,
+                "attachment_backup_quota_exceeded",
+                "Attachment backup quota is exhausted".to_string(),
+            ),
+            Self::AttachmentBackupServiceUnavailable => (
+                StatusCode::BAD_GATEWAY,
+                "attachment_backup_service_unavailable",
+                "Attachment backup service is unavailable".to_string(),
+            ),
+            Self::AttachmentBackupVerificationBusy => (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "attachment_backup_verification_busy",
+                "Attachment backup verification is busy".to_string(),
             ),
             Self::Internal(message) => (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/api-sync/src/routes/attachment_backups.rs
+++ b/crates/api-sync/src/routes/attachment_backups.rs
@@ -1,0 +1,2327 @@
+use std::time::Duration;
+
+use axum::{
+    Extension, Json, Router,
+    extract::{DefaultBodyLimit, Path, Request, State},
+    http::{HeaderValue, header},
+    middleware::{self, Next},
+    response::Response,
+    routing::{get, post, put},
+};
+use chrono::{SecondsFormat, TimeDelta, Utc};
+use hypr_api_auth::AuthContext;
+use reqwest::StatusCode;
+use serde::{Deserialize, Serialize, de::DeserializeOwned};
+use utoipa::OpenApi;
+use uuid::{Uuid, Version};
+
+use crate::{
+    error::{Result, SyncError},
+    state::AppState,
+};
+
+const ATTACHMENT_BACKUP_BUCKET: &str = "attachment-backups";
+const BACKUP_RPC_TIMEOUT: Duration = Duration::from_secs(5);
+const MAX_BACKUP_REQUEST_BYTES: usize = 4 * 1024;
+const MAX_BACKUP_RPC_RESPONSE_BYTES: usize = 16 * 1024;
+const MAX_CIPHERTEXT_SIZE_BYTES: u64 = 545_259_520;
+const FORMAT_VERSION: i16 = 1;
+const UPLOAD_TOKEN_TTL_SECONDS: i64 = 2 * 60 * 60;
+const UPLOAD_CLEANUP_GRACE_SECONDS: i64 = 24 * 60 * 60 + 5 * 60;
+const DOWNLOAD_URL_TTL_SECONDS: i64 = 15 * 60;
+const DOWNLOAD_CLEANUP_GRACE_SECONDS: i64 = 5 * 60;
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct ReserveAttachmentBackupRequest {
+    attachment_ref: String,
+    version_ref: String,
+    ciphertext_size_bytes: u64,
+    format_version: i16,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct ReservedAttachmentBackup {
+    object_id: String,
+    object_key: String,
+    object_state: String,
+    ciphertext_size_bytes: u64,
+    format_version: i16,
+    reservation_expires_at: String,
+    ciphertext_sha256: Option<String>,
+    was_created: bool,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct AttachmentBackupObjectRequest {
+    object_key: String,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct GrantAttachmentBackupUploadRequest {
+    object_key: String,
+    ciphertext_sha256: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AttachmentBackupUploadGrant {
+    object_id: String,
+    object_key: String,
+    object_state: String,
+    ciphertext_size_bytes: u64,
+    ciphertext_sha256: String,
+    format_version: i16,
+    upload_expires_at: Option<String>,
+    upload_token: Option<String>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct FinalizedAttachmentBackup {
+    object_key: String,
+    object_state: String,
+    was_finalized: bool,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub(super) struct PromoteAttachmentBackupRequest {
+    object_key: String,
+    expected_current_object_key: Option<String>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct PromotedAttachmentBackup {
+    current_object_key: String,
+    current_version_ref: String,
+    current_ciphertext_sha256: String,
+    displaced_object_key: Option<String>,
+    was_promoted: bool,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct CurrentAttachmentBackup {
+    version_ref: String,
+    object_key: String,
+    ciphertext_sha256: String,
+    ciphertext_size_bytes: u64,
+    format_version: i16,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct AttachmentBackupDownload {
+    object_id: String,
+    object_key: String,
+    ciphertext_size_bytes: u64,
+    ciphertext_sha256: String,
+    format_version: i16,
+    signed_url: String,
+    expires_at: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct DeletedAttachmentBackup {
+    object_key: String,
+    was_marked: bool,
+}
+
+#[derive(Serialize)]
+struct ReserveRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_attachment_ref: &'a str,
+    p_version_ref: &'a str,
+    p_ciphertext_size_bytes: i64,
+    p_format_version: i16,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ReservedRow {
+    object_id: String,
+    object_key: String,
+    object_state: String,
+    ciphertext_size_bytes: i64,
+    format_version: i16,
+    reservation_expires_at: String,
+    cleanup_not_before: String,
+    ciphertext_sha256: Option<String>,
+    was_created: bool,
+}
+
+#[derive(Serialize)]
+struct MarkSignedRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_object_id: &'a str,
+    p_upload_expires_at: &'a str,
+    p_ciphertext_sha256: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct MarkedSignedRow {
+    object_id: String,
+    object_key: String,
+    last_signed_at: String,
+    upload_expires_at: String,
+    cleanup_not_before: String,
+    ciphertext_sha256: String,
+}
+
+#[derive(Serialize)]
+struct ObjectKeyRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_object_key: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct BackupObjectRow {
+    object_id: String,
+    attachment_ref: String,
+    version_ref: String,
+    object_key: String,
+    object_state: String,
+    ciphertext_size_bytes: i64,
+    format_version: i16,
+    reservation_expires_at: String,
+    upload_expires_at: Option<String>,
+    cleanup_not_before: String,
+    ciphertext_sha256: Option<String>,
+}
+
+#[derive(Serialize)]
+struct FinalizeRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_object_id: &'a str,
+    p_object_key: &'a str,
+    p_observed_ciphertext_size_bytes: i64,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct FinalizedRow {
+    object_id: String,
+    object_key: String,
+    object_state: String,
+    was_finalized: bool,
+}
+
+#[derive(Serialize)]
+struct PromoteRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_candidate_object_id: &'a str,
+    p_candidate_object_key: &'a str,
+    p_expected_current_object_key: Option<&'a str>,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PromotedRow {
+    current_object_id: String,
+    current_object_key: String,
+    current_version_ref: String,
+    current_ciphertext_sha256: String,
+    displaced_object_id: Option<String>,
+    displaced_object_key: Option<String>,
+    was_promoted: bool,
+}
+
+#[derive(Serialize)]
+struct CurrentRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_attachment_ref: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CurrentRow {
+    object_id: String,
+    version_ref: String,
+    object_key: String,
+    ciphertext_sha256: String,
+    ciphertext_size_bytes: i64,
+    format_version: i16,
+}
+
+#[derive(Serialize)]
+struct PrepareDownloadRpcRequest<'a> {
+    p_owner_user_id: &'a str,
+    p_object_key: &'a str,
+    p_download_expires_at: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PreparedDownloadRow {
+    object_id: String,
+    object_key: String,
+    ciphertext_sha256: String,
+    ciphertext_size_bytes: i64,
+    format_version: i16,
+    cleanup_not_before: String,
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct DeletingRow {
+    object_id: String,
+    object_key: String,
+    ciphertext_size_bytes: i64,
+    cleanup_not_before: String,
+    was_marked: bool,
+}
+
+#[derive(Deserialize)]
+struct PostgrestError {
+    code: String,
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(
+        reserve_attachment_backup,
+        grant_attachment_backup_upload,
+        finalize_attachment_backup,
+        promote_attachment_backup,
+        read_current_attachment_backup,
+        download_attachment_backup,
+        delete_attachment_backup
+    ),
+    components(schemas(
+        ReserveAttachmentBackupRequest,
+        ReservedAttachmentBackup,
+        AttachmentBackupObjectRequest,
+        GrantAttachmentBackupUploadRequest,
+        AttachmentBackupUploadGrant,
+        FinalizedAttachmentBackup,
+        PromoteAttachmentBackupRequest,
+        PromotedAttachmentBackup,
+        CurrentAttachmentBackup,
+        AttachmentBackupDownload,
+        DeletedAttachmentBackup
+    ))
+)]
+struct AttachmentBackupsApiDoc;
+
+pub(super) fn openapi() -> utoipa::openapi::OpenApi {
+    AttachmentBackupsApiDoc::openapi()
+}
+
+pub(super) fn router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/attachment-backups/reserve",
+            post(reserve_attachment_backup),
+        )
+        .route(
+            "/attachment-backups/upload-grant",
+            post(grant_attachment_backup_upload),
+        )
+        .route(
+            "/attachment-backups/finalize",
+            post(finalize_attachment_backup),
+        )
+        .route("/attachment-backups/head", put(promote_attachment_backup))
+        .route(
+            "/attachment-backups/head/{attachment_ref}",
+            get(read_current_attachment_backup),
+        )
+        .route(
+            "/attachment-backups/download",
+            post(download_attachment_backup),
+        )
+        .route("/attachment-backups/delete", post(delete_attachment_backup))
+        .layer(DefaultBodyLimit::max(MAX_BACKUP_REQUEST_BYTES))
+        .layer(middleware::from_fn(add_no_store))
+}
+
+async fn add_no_store(request: Request, next: Next) -> Response {
+    let mut response = next.run(request).await;
+    response
+        .headers_mut()
+        .insert(header::CACHE_CONTROL, HeaderValue::from_static("no-store"));
+    response
+}
+
+#[utoipa::path(
+    post,
+    path = "/attachment-backups/reserve",
+    tag = "sync",
+    request_body = ReserveAttachmentBackupRequest,
+    responses(
+        (status = 200, description = "Reserved immutable backup identity", body = ReservedAttachmentBackup),
+        (status = 400, description = "Invalid backup metadata"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 409, description = "Backup reservation conflict"),
+        (status = 507, description = "Backup quota exhausted"),
+        (status = 502, description = "Backup service unavailable")
+    )
+)]
+async fn reserve_attachment_backup(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<ReserveAttachmentBackupRequest>,
+) -> Result<Json<ReservedAttachmentBackup>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    validate_ref(&request.attachment_ref, "attachment")?;
+    validate_ref(&request.version_ref, "version")?;
+    if request.attachment_ref == request.version_ref
+        || request.ciphertext_size_bytes == 0
+        || request.ciphertext_size_bytes > MAX_CIPHERTEXT_SIZE_BYTES
+        || request.format_version != FORMAT_VERSION
+    {
+        return Err(invalid_request());
+    }
+
+    let row: ReservedRow = rpc_single(
+        &state,
+        "reserve_attachment_backup",
+        &ReserveRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_attachment_ref: &request.attachment_ref,
+            p_version_ref: &request.version_ref,
+            p_ciphertext_size_bytes: request.ciphertext_size_bytes as i64,
+            p_format_version: request.format_version,
+        },
+    )
+    .await
+    .map_err(map_reservation_error)?;
+    validate_reserved_row(&row, &owner_user_id, &request)?;
+
+    Ok(Json(ReservedAttachmentBackup {
+        object_id: row.object_id,
+        object_key: row.object_key,
+        object_state: row.object_state,
+        ciphertext_size_bytes: request.ciphertext_size_bytes,
+        format_version: row.format_version,
+        reservation_expires_at: row.reservation_expires_at,
+        ciphertext_sha256: row.ciphertext_sha256,
+        was_created: row.was_created,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/attachment-backups/upload-grant",
+    tag = "sync",
+    request_body = GrantAttachmentBackupUploadRequest,
+    responses(
+        (status = 200, description = "Time-limited grant for an immutable backup upload", body = AttachmentBackupUploadGrant),
+        (status = 400, description = "Invalid object key or ciphertext hash"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 404, description = "Backup reservation unavailable"),
+        (status = 409, description = "Backup state or ciphertext hash conflict"),
+        (status = 502, description = "Backup service unavailable")
+    )
+)]
+async fn grant_attachment_backup_upload(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<GrantAttachmentBackupUploadRequest>,
+) -> Result<Json<AttachmentBackupUploadGrant>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    let object_key = validate_object_key(&request.object_key, &owner_user_id)?;
+    validate_sha256(&request.ciphertext_sha256)?;
+    let object = read_backup_object(&state, &owner_user_id, &object_key).await?;
+    if object
+        .ciphertext_sha256
+        .as_deref()
+        .is_some_and(|hash| hash != request.ciphertext_sha256)
+    {
+        return Err(SyncError::AttachmentBackupConflict);
+    }
+    if object.object_state != "reserved" {
+        if !matches!(object.object_state.as_str(), "ready" | "current")
+            || object.ciphertext_sha256.as_deref() != Some(&request.ciphertext_sha256)
+        {
+            return Err(SyncError::AttachmentBackupConflict);
+        }
+        return Ok(Json(AttachmentBackupUploadGrant {
+            object_id: object.object_id,
+            object_key,
+            object_state: object.object_state,
+            ciphertext_size_bytes: valid_size(object.ciphertext_size_bytes)?,
+            ciphertext_sha256: request.ciphertext_sha256,
+            format_version: object.format_version,
+            upload_expires_at: None,
+            upload_token: None,
+        }));
+    }
+
+    let upload_expires_at = future_timestamp(UPLOAD_TOKEN_TTL_SECONDS)?;
+    let marked: MarkedSignedRow = rpc_single(
+        &state,
+        "mark_attachment_backup_signed",
+        &MarkSignedRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_object_id: &object.object_id,
+            p_upload_expires_at: &upload_expires_at,
+            p_ciphertext_sha256: &request.ciphertext_sha256,
+        },
+    )
+    .await
+    .map_err(map_backup_error)?;
+    validate_marked_signed_row(
+        &marked,
+        &object,
+        &request.ciphertext_sha256,
+        &upload_expires_at,
+    )?;
+
+    let signed_upload = state
+        .storage
+        .create_signed_upload(ATTACHMENT_BACKUP_BUCKET, &object_key)
+        .await
+        .map_err(|_| {
+            tracing::warn!("Supabase Storage upload signing failed");
+            SyncError::AttachmentBackupServiceUnavailable
+        })?;
+
+    Ok(Json(AttachmentBackupUploadGrant {
+        object_id: object.object_id,
+        object_key,
+        object_state: object.object_state,
+        ciphertext_size_bytes: valid_size(object.ciphertext_size_bytes)?,
+        ciphertext_sha256: marked.ciphertext_sha256,
+        format_version: object.format_version,
+        upload_expires_at: Some(marked.upload_expires_at),
+        upload_token: Some(signed_upload.token),
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/attachment-backups/finalize",
+    tag = "sync",
+    request_body = AttachmentBackupObjectRequest,
+    responses(
+        (status = 200, description = "Uploaded backup verified and finalized", body = FinalizedAttachmentBackup),
+        (status = 400, description = "Invalid object key"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 404, description = "Backup unavailable"),
+        (status = 409, description = "Uploaded object does not match its reservation"),
+        (status = 502, description = "Backup service unavailable"),
+        (status = 503, description = "Backup verification capacity is busy")
+    )
+)]
+async fn finalize_attachment_backup(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<AttachmentBackupObjectRequest>,
+) -> Result<Json<FinalizedAttachmentBackup>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    let object_key = validate_object_key(&request.object_key, &owner_user_id)?;
+    let object = read_backup_object(&state, &owner_user_id, &object_key).await?;
+    if matches!(object.object_state.as_str(), "ready" | "current") {
+        return Ok(Json(FinalizedAttachmentBackup {
+            object_key,
+            object_state: object.object_state,
+            was_finalized: false,
+        }));
+    }
+    if object.object_state != "reserved" {
+        return Err(SyncError::AttachmentBackupConflict);
+    }
+    let cleanup_not_before = parse_timestamp(&object.cleanup_not_before)
+        .ok_or_else(|| invalid_upstream_response("object lookup"))?;
+    if cleanup_not_before <= Utc::now() {
+        return Err(SyncError::AttachmentBackupConflict);
+    }
+    let expected_ciphertext_sha256 = object
+        .ciphertext_sha256
+        .as_deref()
+        .ok_or(SyncError::AttachmentBackupConflict)?;
+
+    let object_info = state
+        .storage
+        .object_info(ATTACHMENT_BACKUP_BUCKET, &object_key)
+        .await
+        .map_err(|_| {
+            tracing::warn!("Supabase Storage object verification failed");
+            SyncError::AttachmentBackupServiceUnavailable
+        })?;
+    let expected_size = valid_size(object.ciphertext_size_bytes)?;
+    if object_info.size_bytes != expected_size
+        || object_info.content_type != "application/octet-stream"
+        || object_info.ciphertext_sha256 != expected_ciphertext_sha256
+        || i16::from(object_info.format_version) != object.format_version
+    {
+        tracing::warn!(
+            expected_size,
+            observed_size = object_info.size_bytes,
+            "Attachment backup object metadata did not match the reservation"
+        );
+        return Err(SyncError::AttachmentBackupConflict);
+    }
+    let _verification_slot = state
+        .attachment_verification_slots
+        .clone()
+        .try_acquire_owned()
+        .map_err(|_| SyncError::AttachmentBackupVerificationBusy)?;
+    let observed_ciphertext_sha256 = state
+        .storage
+        .object_sha256(ATTACHMENT_BACKUP_BUCKET, &object_key, expected_size)
+        .await
+        .map_err(|_| {
+            tracing::warn!("Supabase Storage object checksum verification failed");
+            SyncError::AttachmentBackupServiceUnavailable
+        })?;
+    if observed_ciphertext_sha256 != expected_ciphertext_sha256 {
+        tracing::warn!("Attachment backup object checksum did not match the reservation");
+        return Err(SyncError::AttachmentBackupConflict);
+    }
+
+    let row: FinalizedRow = rpc_single(
+        &state,
+        "finalize_attachment_backup",
+        &FinalizeRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_object_id: &object.object_id,
+            p_object_key: &object_key,
+            p_observed_ciphertext_size_bytes: object.ciphertext_size_bytes,
+        },
+    )
+    .await
+    .map_err(map_backup_error)?;
+    if canonical_object_id(&row.object_id).as_deref() != Some(object.object_id.as_str())
+        || row.object_key != object_key
+        || !matches!(row.object_state.as_str(), "ready" | "current")
+    {
+        return Err(invalid_upstream_response("finalization"));
+    }
+
+    Ok(Json(FinalizedAttachmentBackup {
+        object_key: row.object_key,
+        object_state: row.object_state,
+        was_finalized: row.was_finalized,
+    }))
+}
+
+#[utoipa::path(
+    put,
+    path = "/attachment-backups/head",
+    tag = "sync",
+    request_body = PromoteAttachmentBackupRequest,
+    responses(
+        (status = 200, description = "Backup promoted with compare-and-swap semantics", body = PromotedAttachmentBackup),
+        (status = 400, description = "Invalid object key"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 404, description = "Backup unavailable"),
+        (status = 409, description = "Current backup changed"),
+        (status = 502, description = "Backup service unavailable")
+    )
+)]
+async fn promote_attachment_backup(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<PromoteAttachmentBackupRequest>,
+) -> Result<Json<PromotedAttachmentBackup>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    let object_key = validate_object_key(&request.object_key, &owner_user_id)?;
+    let expected_current_object_key = request
+        .expected_current_object_key
+        .as_deref()
+        .map(|key| validate_object_key(key, &owner_user_id))
+        .transpose()?;
+    let candidate = read_backup_object(&state, &owner_user_id, &object_key).await?;
+    if !matches!(candidate.object_state.as_str(), "ready" | "current") {
+        return Err(SyncError::AttachmentBackupConflict);
+    }
+
+    let row: PromotedRow = rpc_single(
+        &state,
+        "promote_attachment_backup",
+        &PromoteRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_candidate_object_id: &candidate.object_id,
+            p_candidate_object_key: &object_key,
+            p_expected_current_object_key: expected_current_object_key.as_deref(),
+        },
+    )
+    .await
+    .map_err(map_backup_error)?;
+    validate_promoted_row(
+        &row,
+        &owner_user_id,
+        &candidate,
+        expected_current_object_key.as_deref(),
+    )?;
+
+    Ok(Json(PromotedAttachmentBackup {
+        current_object_key: row.current_object_key,
+        current_version_ref: row.current_version_ref,
+        current_ciphertext_sha256: row.current_ciphertext_sha256,
+        displaced_object_key: row.displaced_object_key,
+        was_promoted: row.was_promoted,
+    }))
+}
+
+#[utoipa::path(
+    get,
+    path = "/attachment-backups/head/{attachment_ref}",
+    tag = "sync",
+    params(("attachment_ref" = String, Path, description = "Blind attachment reference")),
+    responses(
+        (status = 200, description = "Current backup head", body = CurrentAttachmentBackup),
+        (status = 400, description = "Invalid attachment reference"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 404, description = "Current backup unavailable"),
+        (status = 502, description = "Backup service unavailable")
+    )
+)]
+async fn read_current_attachment_backup(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(attachment_ref): Path<String>,
+) -> Result<Json<CurrentAttachmentBackup>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    validate_ref(&attachment_ref, "attachment")?;
+    let row: CurrentRow = rpc_single(
+        &state,
+        "read_current_attachment_backup",
+        &CurrentRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_attachment_ref: &attachment_ref,
+        },
+    )
+    .await
+    .map_err(map_backup_error)?;
+    let object_key = validate_object_key(&row.object_key, &owner_user_id)
+        .map_err(|_| invalid_upstream_response("current backup"))?;
+    canonical_object_id(&row.object_id)
+        .ok_or_else(|| invalid_upstream_response("current backup"))?;
+    let ciphertext_size_bytes = valid_size(row.ciphertext_size_bytes)?;
+    if validate_ref(&row.version_ref, "version").is_err()
+        || validate_sha256(&row.ciphertext_sha256).is_err()
+        || row.format_version != FORMAT_VERSION
+    {
+        return Err(invalid_upstream_response("current backup"));
+    }
+
+    Ok(Json(CurrentAttachmentBackup {
+        version_ref: row.version_ref,
+        object_key,
+        ciphertext_sha256: row.ciphertext_sha256,
+        ciphertext_size_bytes,
+        format_version: row.format_version,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/attachment-backups/download",
+    tag = "sync",
+    request_body = AttachmentBackupObjectRequest,
+    responses(
+        (status = 200, description = "Short-lived download for the server-current backup", body = AttachmentBackupDownload),
+        (status = 400, description = "Invalid object key"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 404, description = "Current backup unavailable"),
+        (status = 409, description = "Backup is no longer current"),
+        (status = 502, description = "Backup service unavailable")
+    )
+)]
+async fn download_attachment_backup(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<AttachmentBackupObjectRequest>,
+) -> Result<Json<AttachmentBackupDownload>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    let object_key = validate_object_key(&request.object_key, &owner_user_id)?;
+    let expires_at = future_timestamp(DOWNLOAD_URL_TTL_SECONDS)?;
+    let row: PreparedDownloadRow = rpc_single(
+        &state,
+        "prepare_attachment_backup_download",
+        &PrepareDownloadRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_object_key: &object_key,
+            p_download_expires_at: &expires_at,
+        },
+    )
+    .await
+    .map_err(map_backup_error)?;
+    validate_prepared_download(&row, &owner_user_id, &object_key, &expires_at)?;
+
+    let signed_url = state
+        .storage
+        .create_signed_url(
+            ATTACHMENT_BACKUP_BUCKET,
+            &object_key,
+            DOWNLOAD_URL_TTL_SECONDS as u64,
+        )
+        .await
+        .map_err(|_| {
+            tracing::warn!("Supabase Storage download signing failed");
+            SyncError::AttachmentBackupServiceUnavailable
+        })?;
+
+    Ok(Json(AttachmentBackupDownload {
+        object_id: row.object_id,
+        object_key,
+        ciphertext_size_bytes: valid_size(row.ciphertext_size_bytes)?,
+        ciphertext_sha256: row.ciphertext_sha256,
+        format_version: row.format_version,
+        signed_url,
+        expires_at,
+    }))
+}
+
+#[utoipa::path(
+    post,
+    path = "/attachment-backups/delete",
+    tag = "sync",
+    request_body = AttachmentBackupObjectRequest,
+    responses(
+        (status = 200, description = "Backup marked for asynchronous physical deletion", body = DeletedAttachmentBackup),
+        (status = 400, description = "Invalid object key"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Anarlog Pro subscription or backup access required"),
+        (status = 404, description = "Backup unavailable"),
+        (status = 502, description = "Backup service unavailable")
+    )
+)]
+async fn delete_attachment_backup(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Json(request): Json<AttachmentBackupObjectRequest>,
+) -> Result<Json<DeletedAttachmentBackup>> {
+    require_pro(&auth)?;
+    let owner_user_id = canonical_owner(&auth)?;
+    let object_key = validate_object_key(&request.object_key, &owner_user_id)?;
+    let row: DeletingRow = rpc_single(
+        &state,
+        "mark_attachment_backup_deleting_by_key",
+        &ObjectKeyRpcRequest {
+            p_owner_user_id: &owner_user_id,
+            p_object_key: &object_key,
+        },
+    )
+    .await
+    .map_err(map_deletion_error)?;
+    if canonical_object_id(&row.object_id).is_none()
+        || row.object_key != object_key
+        || valid_size(row.ciphertext_size_bytes).is_err()
+        || parse_timestamp(&row.cleanup_not_before).is_none()
+    {
+        return Err(invalid_upstream_response("deletion"));
+    }
+
+    Ok(Json(DeletedAttachmentBackup {
+        object_key,
+        was_marked: row.was_marked,
+    }))
+}
+
+#[derive(Debug)]
+enum RpcFailure {
+    Empty,
+    Rejected {
+        status: StatusCode,
+        code: Option<String>,
+    },
+    Unavailable,
+}
+
+async fn rpc_single<RequestBody, Row>(
+    state: &AppState,
+    function: &str,
+    request: &RequestBody,
+) -> std::result::Result<Row, RpcFailure>
+where
+    RequestBody: Serialize + ?Sized,
+    Row: DeserializeOwned,
+{
+    let mut response = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/{function}",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(BACKUP_RPC_TIMEOUT)
+        .json(request)
+        .send()
+        .await
+        .map_err(|_| {
+            tracing::warn!(function, "Attachment backup ledger request failed");
+            RpcFailure::Unavailable
+        })?;
+    let status = response.status();
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_BACKUP_RPC_RESPONSE_BYTES as u64)
+    {
+        tracing::warn!(function, %status, "Attachment backup ledger response was too large");
+        return Err(RpcFailure::Unavailable);
+    }
+
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|_| {
+        tracing::warn!(
+            function,
+            "Attachment backup ledger response could not be read"
+        );
+        RpcFailure::Unavailable
+    })? {
+        if bytes.len().saturating_add(chunk.len()) > MAX_BACKUP_RPC_RESPONSE_BYTES {
+            tracing::warn!(function, %status, "Attachment backup ledger response was too large");
+            return Err(RpcFailure::Unavailable);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+
+    if !status.is_success() {
+        let code = serde_json::from_slice::<PostgrestError>(&bytes)
+            .ok()
+            .map(|error| error.code);
+        tracing::warn!(function, %status, ?code, "Attachment backup ledger request was rejected");
+        return Err(RpcFailure::Rejected { status, code });
+    }
+
+    let mut rows = serde_json::from_slice::<Vec<Row>>(&bytes).map_err(|_| {
+        tracing::warn!(function, "Attachment backup ledger response was invalid");
+        RpcFailure::Unavailable
+    })?;
+    match rows.len() {
+        0 => Err(RpcFailure::Empty),
+        1 => Ok(rows.pop().expect("row count was checked")),
+        row_count => {
+            tracing::warn!(
+                function,
+                row_count,
+                "Attachment backup ledger returned multiple rows"
+            );
+            Err(RpcFailure::Unavailable)
+        }
+    }
+}
+
+async fn read_backup_object(
+    state: &AppState,
+    owner_user_id: &str,
+    object_key: &str,
+) -> Result<BackupObjectRow> {
+    let row: BackupObjectRow = rpc_single(
+        state,
+        "read_attachment_backup_by_key",
+        &ObjectKeyRpcRequest {
+            p_owner_user_id: owner_user_id,
+            p_object_key: object_key,
+        },
+    )
+    .await
+    .map_err(map_backup_error)?;
+    validate_backup_object_row(&row, owner_user_id, object_key)?;
+    Ok(row)
+}
+
+fn map_reservation_error(error: RpcFailure) -> SyncError {
+    match &error {
+        RpcFailure::Rejected { code, .. } if code.as_deref() == Some("54000") => {
+            SyncError::AttachmentBackupQuotaExceeded
+        }
+        _ => map_backup_error(error),
+    }
+}
+
+fn map_deletion_error(error: RpcFailure) -> SyncError {
+    match &error {
+        RpcFailure::Rejected { code, .. } if code.as_deref() == Some("55000") => {
+            SyncError::AttachmentBackupNotFound
+        }
+        _ => map_backup_error(error),
+    }
+}
+
+fn map_backup_error(error: RpcFailure) -> SyncError {
+    match error {
+        RpcFailure::Empty => SyncError::AttachmentBackupNotFound,
+        RpcFailure::Rejected { status, code }
+            if status == StatusCode::UNAUTHORIZED
+                || status == StatusCode::FORBIDDEN
+                || code.as_deref() == Some("42501") =>
+        {
+            SyncError::AttachmentBackupForbidden
+        }
+        RpcFailure::Rejected { code, .. } if code.as_deref() == Some("22023") => invalid_request(),
+        RpcFailure::Rejected { code, .. } if matches!(code.as_deref(), Some("40001" | "55000")) => {
+            SyncError::AttachmentBackupConflict
+        }
+        RpcFailure::Rejected { .. } | RpcFailure::Unavailable => {
+            SyncError::AttachmentBackupServiceUnavailable
+        }
+    }
+}
+
+fn require_pro(auth: &AuthContext) -> Result<()> {
+    if !auth.claims.is_pro() {
+        return Err(SyncError::ProPlanRequired);
+    }
+    Ok(())
+}
+
+fn canonical_owner(auth: &AuthContext) -> Result<String> {
+    canonical_uuid(&auth.claims.sub).ok_or_else(|| {
+        tracing::warn!("Authenticated attachment backup subject was not a canonical UUID");
+        SyncError::AttachmentBackupForbidden
+    })
+}
+
+fn canonical_uuid(value: &str) -> Option<String> {
+    let uuid = Uuid::parse_str(value).ok()?;
+    let canonical = uuid.to_string();
+    (canonical == value).then_some(canonical)
+}
+
+fn canonical_object_id(value: &str) -> Option<String> {
+    let uuid = Uuid::parse_str(value).ok()?;
+    let canonical = uuid.to_string();
+    (canonical == value && uuid.get_version() == Some(Version::Random)).then_some(canonical)
+}
+
+fn validate_ref(value: &str, kind: &str) -> Result<()> {
+    if value.len() != 43
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+    {
+        return Err(SyncError::BadRequest(format!(
+            "Attachment backup {kind} reference is invalid"
+        )));
+    }
+    Ok(())
+}
+
+fn validate_sha256(value: &str) -> Result<()> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(invalid_request());
+    }
+    Ok(())
+}
+
+fn validate_object_key(value: &str, owner_user_id: &str) -> Result<String> {
+    let (owner, filename) = value.split_once('/').ok_or_else(invalid_request)?;
+    let object_id = filename.strip_suffix(".anb1").ok_or_else(invalid_request)?;
+    let object_uuid = Uuid::parse_str(object_id).map_err(|_| invalid_request())?;
+    if owner != owner_user_id
+        || filename.contains('/')
+        || object_uuid.to_string() != object_id
+        || !matches!(
+            object_uuid.get_version(),
+            Some(Version::Random | Version::SortRand)
+        )
+    {
+        return Err(invalid_request());
+    }
+    Ok(value.to_string())
+}
+
+fn validate_reserved_row(
+    row: &ReservedRow,
+    owner_user_id: &str,
+    request: &ReserveAttachmentBackupRequest,
+) -> Result<()> {
+    canonical_object_id(&row.object_id).ok_or_else(|| invalid_upstream_response("reservation"))?;
+    validate_object_key(&row.object_key, owner_user_id)
+        .map_err(|_| invalid_upstream_response("reservation"))?;
+    let size = valid_size(row.ciphertext_size_bytes)?;
+    let reservation_expires_at = parse_timestamp(&row.reservation_expires_at)
+        .ok_or_else(|| invalid_upstream_response("reservation"))?;
+    let cleanup_not_before = parse_timestamp(&row.cleanup_not_before)
+        .ok_or_else(|| invalid_upstream_response("reservation"))?;
+    if row
+        .ciphertext_sha256
+        .as_deref()
+        .is_some_and(|hash| validate_sha256(hash).is_err())
+    {
+        return Err(invalid_upstream_response("reservation"));
+    }
+    if size != request.ciphertext_size_bytes
+        || row.format_version != request.format_version
+        || !matches!(row.object_state.as_str(), "reserved" | "ready" | "current")
+        || (row.object_state != "reserved" && row.ciphertext_sha256.is_none())
+        || cleanup_not_before < reservation_expires_at
+    {
+        return Err(invalid_upstream_response("reservation"));
+    }
+    Ok(())
+}
+
+fn validate_marked_signed_row(
+    marked: &MarkedSignedRow,
+    reserved: &BackupObjectRow,
+    expected_ciphertext_sha256: &str,
+    requested_upload_expiry: &str,
+) -> Result<()> {
+    let requested_upload_expiry = parse_timestamp(requested_upload_expiry)
+        .ok_or_else(|| invalid_upstream_response("upload signing"))?;
+    let last_signed_at = parse_timestamp(&marked.last_signed_at)
+        .ok_or_else(|| invalid_upstream_response("upload signing"))?;
+    let upload_expires_at = parse_timestamp(&marked.upload_expires_at)
+        .ok_or_else(|| invalid_upstream_response("upload signing"))?;
+    let cleanup_not_before = parse_timestamp(&marked.cleanup_not_before)
+        .ok_or_else(|| invalid_upstream_response("upload signing"))?;
+    let minimum_cleanup = upload_expires_at
+        .checked_add_signed(TimeDelta::seconds(UPLOAD_CLEANUP_GRACE_SECONDS))
+        .ok_or_else(|| invalid_upstream_response("upload signing"))?;
+    if marked.object_id != reserved.object_id
+        || marked.object_key != reserved.object_key
+        || marked.ciphertext_sha256 != expected_ciphertext_sha256
+        || last_signed_at >= upload_expires_at
+        || upload_expires_at < requested_upload_expiry
+        || cleanup_not_before < minimum_cleanup
+    {
+        return Err(invalid_upstream_response("upload signing"));
+    }
+    Ok(())
+}
+
+fn validate_backup_object_row(
+    row: &BackupObjectRow,
+    owner_user_id: &str,
+    expected_object_key: &str,
+) -> Result<()> {
+    canonical_object_id(&row.object_id)
+        .ok_or_else(|| invalid_upstream_response("object lookup"))?;
+    let object_key = validate_object_key(&row.object_key, owner_user_id)
+        .map_err(|_| invalid_upstream_response("object lookup"))?;
+    validate_ref(&row.attachment_ref, "attachment")
+        .map_err(|_| invalid_upstream_response("object lookup"))?;
+    validate_ref(&row.version_ref, "version")
+        .map_err(|_| invalid_upstream_response("object lookup"))?;
+    valid_size(row.ciphertext_size_bytes)?;
+    let reservation_expires_at = parse_timestamp(&row.reservation_expires_at)
+        .ok_or_else(|| invalid_upstream_response("object lookup"))?;
+    let cleanup_not_before = parse_timestamp(&row.cleanup_not_before)
+        .ok_or_else(|| invalid_upstream_response("object lookup"))?;
+    let upload_expires_at = match row.upload_expires_at.as_deref() {
+        Some(value) => {
+            Some(parse_timestamp(value).ok_or_else(|| invalid_upstream_response("object lookup"))?)
+        }
+        None => None,
+    };
+    if row
+        .ciphertext_sha256
+        .as_deref()
+        .is_some_and(|hash| validate_sha256(hash).is_err())
+    {
+        return Err(invalid_upstream_response("object lookup"));
+    }
+    if object_key != expected_object_key
+        || row.format_version != FORMAT_VERSION
+        || row.attachment_ref == row.version_ref
+        || !matches!(
+            row.object_state.as_str(),
+            "reserved" | "ready" | "current" | "deleting"
+        )
+        || (matches!(row.object_state.as_str(), "ready" | "current")
+            && row.ciphertext_sha256.is_none())
+        || cleanup_not_before < reservation_expires_at
+        || upload_expires_at.is_some_and(|expiry| cleanup_not_before < expiry)
+    {
+        return Err(invalid_upstream_response("object lookup"));
+    }
+    Ok(())
+}
+
+fn validate_promoted_row(
+    row: &PromotedRow,
+    owner_user_id: &str,
+    candidate: &BackupObjectRow,
+    expected_current_object_key: Option<&str>,
+) -> Result<()> {
+    let current_id = canonical_object_id(&row.current_object_id)
+        .ok_or_else(|| invalid_upstream_response("promotion"))?;
+    let current_key = validate_object_key(&row.current_object_key, owner_user_id)
+        .map_err(|_| invalid_upstream_response("promotion"))?;
+    let displaced = match (&row.displaced_object_id, &row.displaced_object_key) {
+        (None, None) => None,
+        (Some(id), Some(key)) => {
+            canonical_object_id(id).ok_or_else(|| invalid_upstream_response("promotion"))?;
+            Some(
+                validate_object_key(key, owner_user_id)
+                    .map_err(|_| invalid_upstream_response("promotion"))?,
+            )
+        }
+        _ => return Err(invalid_upstream_response("promotion")),
+    };
+    if current_id != candidate.object_id
+        || current_key != candidate.object_key
+        || row.current_version_ref != candidate.version_ref
+        || candidate.ciphertext_sha256.as_deref() != Some(&row.current_ciphertext_sha256)
+        || validate_sha256(&row.current_ciphertext_sha256).is_err()
+        || (row.was_promoted && displaced.as_deref() != expected_current_object_key)
+        || (!row.was_promoted && displaced.is_some())
+    {
+        return Err(invalid_upstream_response("promotion"));
+    }
+    Ok(())
+}
+
+fn validate_prepared_download(
+    row: &PreparedDownloadRow,
+    owner_user_id: &str,
+    expected_object_key: &str,
+    requested_expiry: &str,
+) -> Result<()> {
+    canonical_object_id(&row.object_id)
+        .ok_or_else(|| invalid_upstream_response("download preparation"))?;
+    let object_key = validate_object_key(&row.object_key, owner_user_id)
+        .map_err(|_| invalid_upstream_response("download preparation"))?;
+    valid_size(row.ciphertext_size_bytes)?;
+    validate_sha256(&row.ciphertext_sha256)
+        .map_err(|_| invalid_upstream_response("download preparation"))?;
+    let cleanup_not_before = parse_timestamp(&row.cleanup_not_before)
+        .ok_or_else(|| invalid_upstream_response("download preparation"))?;
+    let requested_expiry = parse_timestamp(requested_expiry)
+        .ok_or_else(|| invalid_upstream_response("download preparation"))?;
+    let minimum_cleanup = requested_expiry
+        .checked_add_signed(TimeDelta::seconds(DOWNLOAD_CLEANUP_GRACE_SECONDS))
+        .ok_or_else(|| invalid_upstream_response("download preparation"))?;
+    if object_key != expected_object_key
+        || row.format_version != FORMAT_VERSION
+        || cleanup_not_before < minimum_cleanup
+    {
+        return Err(invalid_upstream_response("download preparation"));
+    }
+    Ok(())
+}
+
+fn valid_size(value: i64) -> Result<u64> {
+    let value = u64::try_from(value)
+        .ok()
+        .filter(|value| (1..=MAX_CIPHERTEXT_SIZE_BYTES).contains(value))
+        .ok_or_else(|| invalid_upstream_response("ciphertext size"))?;
+    Ok(value)
+}
+
+fn parse_timestamp(value: &str) -> Option<chrono::DateTime<chrono::FixedOffset>> {
+    chrono::DateTime::parse_from_rfc3339(value).ok()
+}
+
+fn future_timestamp(seconds: i64) -> Result<String> {
+    let delta = TimeDelta::try_seconds(seconds)
+        .ok_or_else(|| SyncError::Internal("Attachment backup expiry is invalid".to_string()))?;
+    Utc::now()
+        .checked_add_signed(delta)
+        .ok_or_else(|| SyncError::Internal("Attachment backup expiry is invalid".to_string()))
+        .map(|expiry| expiry.to_rfc3339_opts(SecondsFormat::Secs, true))
+}
+
+fn invalid_request() -> SyncError {
+    SyncError::BadRequest("Attachment backup request is invalid".to_string())
+}
+
+fn invalid_upstream_response(operation: &str) -> SyncError {
+    tracing::warn!(
+        operation,
+        "Attachment backup ledger response failed validation"
+    );
+    SyncError::AttachmentBackupServiceUnavailable
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Method, Request, StatusCode, header},
+    };
+    use hypr_api_auth::{AuthContext, Claims};
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_partial_json, header as request_header, method, path},
+    };
+
+    use super::*;
+    use crate::SyncConfig;
+
+    const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+    const OBJECT_ID: &str = "22222222-2222-4222-8222-222222222222";
+    const OBJECT_UUID: &str = "33333333-3333-4333-8333-333333333333";
+    const DISPLACED_UUID: &str = "55555555-5555-4555-8555-555555555555";
+    const ATTACHMENT_REF: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const VERSION_REF: &str = "BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB";
+    const CIPHERTEXT_SHA256: &str =
+        "ad47fd9e87159d651a53b3dfba3ef200684a9ed88c2528b62e18f3881fe203b0";
+
+    fn object_key() -> String {
+        format!("{OWNER}/{OBJECT_UUID}.anb1")
+    }
+
+    fn displaced_key() -> String {
+        format!("{OWNER}/{DISPLACED_UUID}.anb1")
+    }
+
+    fn timestamp_after(seconds: i64) -> String {
+        (Utc::now() + TimeDelta::seconds(seconds)).to_rfc3339_opts(SecondsFormat::Secs, true)
+    }
+
+    fn test_state(server: &MockServer) -> AppState {
+        AppState::new(SyncConfig {
+            project_url: server.uri(),
+            token_issuer_api_key: "issuer-key".to_string(),
+            database_id: "database-id".to_string(),
+            token_ttl_seconds: 60,
+            supabase_url: server.uri(),
+            supabase_anon_key: "anon-key".to_string(),
+            supabase_service_role_key: "service-role-key".to_string(),
+        })
+    }
+
+    fn test_router_with_state(state: AppState, is_pro: bool) -> axum::Router {
+        router().with_state(state).layer(Extension(AuthContext {
+            token: "user-token".to_string(),
+            claims: Claims {
+                sub: OWNER.to_string(),
+                email: None,
+                entitlements: is_pro
+                    .then(|| "hyprnote_pro".to_string())
+                    .into_iter()
+                    .collect(),
+                subscription_status: None,
+                trial_end: None,
+                has_payment_method: None,
+            },
+        }))
+    }
+
+    fn test_router(server: &MockServer, is_pro: bool) -> axum::Router {
+        test_router_with_state(test_state(server), is_pro)
+    }
+
+    fn json_request(method: Method, path: &str, body: Value) -> Request<Body> {
+        Request::builder()
+            .method(method)
+            .uri(path)
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(serde_json::to_vec(&body).unwrap()))
+            .unwrap()
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 64 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    fn reserved_row(state: &str, hash: Option<&str>) -> Value {
+        json!({
+            "object_id": OBJECT_ID,
+            "object_key": object_key(),
+            "object_state": state,
+            "ciphertext_sha256": hash,
+            "ciphertext_size_bytes": 1234,
+            "format_version": 1,
+            "reservation_expires_at": timestamp_after(15 * 60),
+            "cleanup_not_before": timestamp_after(30 * 60),
+            "was_created": true
+        })
+    }
+
+    fn object_row(state: &str, hash: Option<&str>) -> Value {
+        json!({
+            "object_id": OBJECT_ID,
+            "attachment_ref": ATTACHMENT_REF,
+            "version_ref": VERSION_REF,
+            "object_key": object_key(),
+            "object_state": state,
+            "ciphertext_sha256": hash,
+            "ciphertext_size_bytes": 1234,
+            "format_version": 1,
+            "reservation_expires_at": timestamp_after(15 * 60),
+            "upload_expires_at": hash.map(|_| timestamp_after(2 * 60 * 60)),
+            "cleanup_not_before": timestamp_after(26 * 60 * 60)
+        })
+    }
+
+    async fn mount_rpc(server: &MockServer, function: &str, response: ResponseTemplate) {
+        Mock::given(method("POST"))
+            .and(path(format!("/rest/v1/rpc/{function}")))
+            .and(request_header("apikey", "service-role-key"))
+            .and(request_header("authorization", "Bearer service-role-key"))
+            .respond_with(response)
+            .mount(server)
+            .await;
+    }
+
+    #[tokio::test]
+    async fn reserves_identity_without_issuing_a_storage_capability() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "reserve_attachment_backup",
+            ResponseTemplate::new(200).set_body_json(json!([reserved_row("reserved", None)])),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/reserve",
+                json!({
+                    "attachmentRef": ATTACHMENT_REF,
+                    "versionRef": VERSION_REF,
+                    "ciphertextSizeBytes": 1234,
+                    "formatVersion": 1
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let body = response_json(response).await;
+        assert_eq!(body["objectId"], OBJECT_ID);
+        assert_eq!(body["ciphertextSha256"], Value::Null);
+        assert!(body.get("uploadToken").is_none());
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert_eq!(
+            requests[0].url.path(),
+            "/rest/v1/rpc/reserve_attachment_backup"
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_reservation_races_as_conflicts() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "reserve_attachment_backup",
+            ResponseTemplate::new(409).set_body_json(json!({
+                "code": "40001",
+                "message": "reservation-secret-must-not-leak"
+            })),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/reserve",
+                json!({
+                    "attachmentRef": ATTACHMENT_REF,
+                    "versionRef": VERSION_REF,
+                    "ciphertextSizeBytes": 1234,
+                    "formatVersion": 1
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "attachment_backup_conflict");
+        assert!(!body.to_string().contains("reservation-secret"));
+    }
+
+    #[tokio::test]
+    async fn reports_reservation_limit_as_conflict() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "reserve_attachment_backup",
+            ResponseTemplate::new(409).set_body_json(json!({
+                "code": "55000",
+                "message": "reservation-limit-secret-must-not-leak"
+            })),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/reserve",
+                json!({
+                    "attachmentRef": ATTACHMENT_REF,
+                    "versionRef": VERSION_REF,
+                    "ciphertextSizeBytes": 1234,
+                    "formatVersion": 1
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "attachment_backup_conflict");
+        assert!(!body.to_string().contains("reservation-limit-secret"));
+    }
+
+    #[tokio::test]
+    async fn reads_then_marks_integrity_before_signing_upload() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200).set_body_json(json!([object_row("reserved", None)])),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/mark_attachment_backup_signed"))
+            .and(body_partial_json(json!({
+                "p_owner_user_id": OWNER,
+                "p_object_id": OBJECT_ID,
+                "p_ciphertext_sha256": CIPHERTEXT_SHA256
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "object_key": object_key(),
+                "ciphertext_sha256": CIPHERTEXT_SHA256,
+                "last_signed_at": timestamp_after(-1),
+                "upload_expires_at": timestamp_after(2 * 60 * 60 + 30),
+                "cleanup_not_before": timestamp_after(27 * 60 * 60)
+            }])))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/storage/v1/object/upload/sign/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "url": format!(
+                    "/object/upload/sign/{ATTACHMENT_BACKUP_BUCKET}/{}?token=upload-secret",
+                    object_key()
+                )
+            })))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/upload-grant",
+                json!({
+                    "objectKey": object_key(),
+                    "ciphertextSha256": CIPHERTEXT_SHA256
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["uploadToken"], "upload-secret");
+        assert_eq!(body["ciphertextSha256"], CIPHERTEXT_SHA256);
+
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 3);
+        assert_eq!(
+            requests[0].url.path(),
+            "/rest/v1/rpc/read_attachment_backup_by_key"
+        );
+        assert_eq!(
+            requests[1].url.path(),
+            "/rest/v1/rpc/mark_attachment_backup_signed"
+        );
+        assert!(
+            requests[2]
+                .url
+                .path()
+                .contains("/storage/v1/object/upload/sign/")
+        );
+    }
+
+    #[tokio::test]
+    async fn never_issues_upload_token_for_an_unsafe_cleanup_window() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200).set_body_json(json!([object_row("reserved", None)])),
+        )
+        .await;
+        mount_rpc(
+            &server,
+            "mark_attachment_backup_signed",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "object_key": object_key(),
+                "ciphertext_sha256": CIPHERTEXT_SHA256,
+                "last_signed_at": timestamp_after(-1),
+                "upload_expires_at": timestamp_after(2 * 60 * 60 + 4 * 60),
+                "cleanup_not_before": timestamp_after(26 * 60 * 60 + 6 * 60)
+            }])),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/upload-grant",
+                json!({
+                    "objectKey": object_key(),
+                    "ciphertextSha256": CIPHERTEXT_SHA256
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.url.path().contains("/storage/v1/"))
+        );
+    }
+
+    #[tokio::test]
+    async fn never_issues_upload_token_when_integrity_mark_fails() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200).set_body_json(json!([object_row("reserved", None)])),
+        )
+        .await;
+        mount_rpc(
+            &server,
+            "mark_attachment_backup_signed",
+            ResponseTemplate::new(500).set_body_json(json!({
+                "code": "XX000",
+                "message": "database-secret-must-not-leak"
+            })),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/upload-grant",
+                json!({
+                    "objectKey": object_key(),
+                    "ciphertextSha256": CIPHERTEXT_SHA256
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
+        let body = response_json(response).await.to_string();
+        assert!(!body.contains("database-secret"));
+        assert!(!body.contains("upload-secret"));
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.url.path().contains("/storage/v1/"))
+        );
+    }
+
+    #[tokio::test]
+    async fn reports_integrity_mark_races_as_conflicts_without_signing() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200).set_body_json(json!([object_row("reserved", None)])),
+        )
+        .await;
+        mount_rpc(
+            &server,
+            "mark_attachment_backup_signed",
+            ResponseTemplate::new(409).set_body_json(json!({
+                "code": "40001",
+                "message": "hash-secret-must-not-leak"
+            })),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/upload-grant",
+                json!({
+                    "objectKey": object_key(),
+                    "ciphertextSha256": CIPHERTEXT_SHA256
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "attachment_backup_conflict");
+        assert!(!body.to_string().contains("hash-secret"));
+        assert!(
+            !server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .any(|request| request.url.path().contains("/storage/v1/"))
+        );
+    }
+
+    #[tokio::test]
+    async fn verifies_storage_metadata_before_finalizing() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("reserved", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/info/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "size": 1234,
+                "content_type": "application/octet-stream",
+                "metadata": {
+                    "ciphertextSha256": CIPHERTEXT_SHA256,
+                    "formatVersion": 1
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/authenticated/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![0_u8; 1_234]))
+            .mount(&server)
+            .await;
+        mount_rpc(
+            &server,
+            "finalize_attachment_backup",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "object_key": object_key(),
+                "object_state": "ready",
+                "was_finalized": true
+            }])),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["objectState"], "ready");
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 4);
+        assert_eq!(
+            requests[0].url.path(),
+            "/rest/v1/rpc/read_attachment_backup_by_key"
+        );
+        assert!(requests[1].url.path().contains("/storage/v1/object/info/"));
+        assert!(
+            requests[2]
+                .url
+                .path()
+                .contains("/storage/v1/object/authenticated/")
+        );
+        assert_eq!(
+            requests[3].url.path(),
+            "/rest/v1/rpc/finalize_attachment_backup"
+        );
+    }
+
+    #[tokio::test]
+    async fn rejects_expired_finalize_before_storage_verification() {
+        let server = MockServer::start().await;
+        let mut row = object_row("reserved", Some(CIPHERTEXT_SHA256));
+        row["reservation_expires_at"] = json!(timestamp_after(-3 * 60 * 60));
+        row["upload_expires_at"] = json!(timestamp_after(-2 * 60 * 60));
+        row["cleanup_not_before"] = json!(timestamp_after(-60 * 60));
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200).set_body_json(json!([row])),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(
+            response_json(response).await["error"]["code"],
+            "attachment_backup_conflict"
+        );
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn accepts_finalize_retry_after_the_candidate_is_current() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("current", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["objectState"], "current");
+        assert_eq!(body["wasFinalized"], false);
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_storage_integrity_mismatch_without_finalizing() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("reserved", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/info/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "size": 1234,
+                "content_type": "application/octet-stream",
+                "metadata": {
+                    "ciphertextSha256": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                    "formatVersion": 1
+                }
+            })))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn rejects_storage_content_mismatch_without_finalizing() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("reserved", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/info/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "size": 1234,
+                "content_type": "application/octet-stream",
+                "metadata": {
+                    "ciphertextSha256": CIPHERTEXT_SHA256,
+                    "formatVersion": 1
+                }
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/authenticated/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![1_u8; 1_234]))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(server.received_requests().await.unwrap().len(), 3);
+    }
+
+    #[tokio::test]
+    async fn throttles_parallel_storage_content_verification() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("reserved", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/info/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "size": 1234,
+                "content_type": "application/octet-stream",
+                "metadata": {
+                    "ciphertextSha256": CIPHERTEXT_SHA256,
+                    "formatVersion": 1
+                }
+            })))
+            .mount(&server)
+            .await;
+        let state = test_state(&server);
+        let _verification_slot = state
+            .attachment_verification_slots
+            .clone()
+            .try_acquire_owned()
+            .unwrap();
+
+        let response = test_router_with_state(state, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn reports_storage_verification_failures_as_unavailable() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("reserved", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/storage/v1/object/info/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(json!({ "message": "storage-secret-must-not-leak" })),
+            )
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/finalize",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            !response_json(response)
+                .await
+                .to_string()
+                .contains("storage-secret")
+        );
+        assert_eq!(server.received_requests().await.unwrap().len(), 2);
+    }
+
+    #[tokio::test]
+    async fn reports_head_cas_conflict_without_leaking_upstream_details() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("ready", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        mount_rpc(
+            &server,
+            "promote_attachment_backup",
+            ResponseTemplate::new(409).set_body_json(json!({
+                "code": "40001",
+                "message": "current-key-secret"
+            })),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::PUT,
+                "/attachment-backups/head",
+                json!({
+                    "objectKey": object_key(),
+                    "expectedCurrentObjectKey": displaced_key()
+                }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["error"]["code"], "attachment_backup_conflict");
+        assert!(!body.to_string().contains("current-key-secret"));
+    }
+
+    #[tokio::test]
+    async fn returns_version_and_integrity_for_current_and_promoted_heads() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_current_attachment_backup",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "version_ref": VERSION_REF,
+                "object_key": object_key(),
+                "ciphertext_sha256": CIPHERTEXT_SHA256,
+                "ciphertext_size_bytes": 1234,
+                "format_version": 1
+            }])),
+        )
+        .await;
+        let current = test_router(&server, true)
+            .oneshot(
+                Request::get(format!("/attachment-backups/head/{ATTACHMENT_REF}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(current.status(), StatusCode::OK);
+        let body = response_json(current).await;
+        assert_eq!(body["versionRef"], VERSION_REF);
+        assert_eq!(body["ciphertextSha256"], CIPHERTEXT_SHA256);
+
+        let promote_server = MockServer::start().await;
+        mount_rpc(
+            &promote_server,
+            "read_attachment_backup_by_key",
+            ResponseTemplate::new(200)
+                .set_body_json(json!([object_row("ready", Some(CIPHERTEXT_SHA256))])),
+        )
+        .await;
+        mount_rpc(
+            &promote_server,
+            "promote_attachment_backup",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "current_object_id": OBJECT_ID,
+                "current_object_key": object_key(),
+                "current_version_ref": VERSION_REF,
+                "current_ciphertext_sha256": CIPHERTEXT_SHA256,
+                "displaced_object_id": null,
+                "displaced_object_key": null,
+                "was_promoted": true
+            }])),
+        )
+        .await;
+        let promoted = test_router(&promote_server, true)
+            .oneshot(json_request(
+                Method::PUT,
+                "/attachment-backups/head",
+                json!({ "objectKey": object_key(), "expectedCurrentObjectKey": null }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(promoted.status(), StatusCode::OK);
+        let body = response_json(promoted).await;
+        assert_eq!(body["currentVersionRef"], VERSION_REF);
+        assert_eq!(body["currentCiphertextSha256"], CIPHERTEXT_SHA256);
+    }
+
+    #[tokio::test]
+    async fn prepares_current_download_before_signing() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "prepare_attachment_backup_download",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "object_key": object_key(),
+                "ciphertext_sha256": CIPHERTEXT_SHA256,
+                "ciphertext_size_bytes": 1234,
+                "format_version": 1,
+                "cleanup_not_before": timestamp_after(60 * 60)
+            }])),
+        )
+        .await;
+        Mock::given(method("POST"))
+            .and(path(format!(
+                "/storage/v1/object/sign/{ATTACHMENT_BACKUP_BUCKET}/{}",
+                object_key()
+            )))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "signedURL": format!(
+                    "/object/sign/{ATTACHMENT_BACKUP_BUCKET}/{}?token=download-secret",
+                    object_key()
+                )
+            })))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/download",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["objectId"], OBJECT_ID);
+        assert_eq!(body["ciphertextSha256"], CIPHERTEXT_SHA256);
+        assert!(
+            body["signedUrl"]
+                .as_str()
+                .unwrap()
+                .contains("download-secret")
+        );
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 2);
+        assert_eq!(
+            requests[0].url.path(),
+            "/rest/v1/rpc/prepare_attachment_backup_download"
+        );
+        assert!(requests[1].url.path().contains("/storage/v1/object/sign/"));
+    }
+
+    #[tokio::test]
+    async fn never_signs_a_download_for_an_unsafe_cleanup_window() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "prepare_attachment_backup_download",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "object_key": object_key(),
+                "ciphertext_sha256": CIPHERTEXT_SHA256,
+                "ciphertext_size_bytes": 1234,
+                "format_version": 1,
+                "cleanup_not_before": timestamp_after(DOWNLOAD_URL_TTL_SECONDS + 60)
+            }])),
+        )
+        .await;
+
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/download",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::BAD_GATEWAY);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(
+            !requests
+                .iter()
+                .any(|request| request.url.path().contains("/storage/v1/"))
+        );
+    }
+
+    #[tokio::test]
+    async fn never_signs_a_noncurrent_download() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "prepare_attachment_backup_download",
+            ResponseTemplate::new(409).set_body_json(json!({
+                "code": "55000",
+                "message": "not current"
+            })),
+        )
+        .await;
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/download",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert_eq!(server.received_requests().await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn marks_delete_without_physically_deleting_storage() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "mark_attachment_backup_deleting_by_key",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "object_key": object_key(),
+                "ciphertext_size_bytes": 1234,
+                "cleanup_not_before": timestamp_after(60 * 60),
+                "was_marked": true
+            }])),
+        )
+        .await;
+        let response = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/delete",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["wasMarked"], true);
+        let requests = server.received_requests().await.unwrap();
+        assert_eq!(requests.len(), 1);
+        assert!(!requests[0].url.path().contains("/storage/v1/object/"));
+    }
+
+    #[tokio::test]
+    async fn requires_pro_and_rejects_bad_inputs_before_upstream_calls() {
+        let server = MockServer::start().await;
+        let non_pro = test_router(&server, false)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/download",
+                json!({ "objectKey": object_key() }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(non_pro.status(), StatusCode::FORBIDDEN);
+        assert_eq!(
+            response_json(non_pro).await["error"]["code"],
+            "subscription_required"
+        );
+
+        let invalid_key = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/download",
+                json!({ "objectKey": "../other-user/object" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(invalid_key.status(), StatusCode::BAD_REQUEST);
+
+        let invalid_hash = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/upload-grant",
+                json!({ "objectKey": object_key(), "ciphertextSha256": "ABC" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(invalid_hash.status(), StatusCode::BAD_REQUEST);
+
+        let unknown_field = test_router(&server, true)
+            .oneshot(json_request(
+                Method::POST,
+                "/attachment-backups/delete",
+                json!({ "objectKey": object_key(), "ownerUserId": "attacker" }),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(unknown_field.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn rejects_oversized_or_origin_injecting_ledger_responses() {
+        let server = MockServer::start().await;
+        mount_rpc(
+            &server,
+            "read_current_attachment_backup",
+            ResponseTemplate::new(200)
+                .set_body_string("x".repeat(MAX_BACKUP_RPC_RESPONSE_BYTES + 1)),
+        )
+        .await;
+        let oversized = test_router(&server, true)
+            .oneshot(
+                Request::get(format!("/attachment-backups/head/{ATTACHMENT_REF}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(oversized.status(), StatusCode::BAD_GATEWAY);
+
+        let second_server = MockServer::start().await;
+        mount_rpc(
+            &second_server,
+            "read_current_attachment_backup",
+            ResponseTemplate::new(200).set_body_json(json!([{
+                "object_id": OBJECT_ID,
+                "version_ref": VERSION_REF,
+                "object_key": "https://attacker.example/secret",
+                "ciphertext_sha256": CIPHERTEXT_SHA256,
+                "ciphertext_size_bytes": 1234,
+                "format_version": 1
+            }])),
+        )
+        .await;
+        let malformed = test_router(&second_server, true)
+            .oneshot(
+                Request::get(format!("/attachment-backups/head/{ATTACHMENT_REF}"))
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(malformed.status(), StatusCode::BAD_GATEWAY);
+        assert!(
+            !response_json(malformed)
+                .await
+                .to_string()
+                .contains("attacker.example")
+        );
+    }
+}

--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -18,6 +18,8 @@ use crate::error::{Result, SyncError};
 use crate::snapshot::{MAX_SNAPSHOT_BODY_BYTES, sanitize_document, sanitize_title};
 use crate::state::AppState;
 
+mod attachment_backups;
+
 const WORKSPACE_PROJECTION_SELECT: &str = "id,user_id,role,created_at,updated_at,workspace:workspaces!inner(id,owner_user_id,kind,name,created_at,updated_at)";
 const WORKSPACE_PROJECTION_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const MAX_TOKEN_WORKSPACES: usize = 128;
@@ -179,7 +181,9 @@ struct PostgrestError {
 pub struct ApiDoc;
 
 pub fn openapi() -> utoipa::openapi::OpenApi {
-    ApiDoc::openapi()
+    let mut openapi = ApiDoc::openapi();
+    openapi.merge(attachment_backups::openapi());
+    openapi
 }
 
 pub fn router(state: AppState) -> Router {
@@ -191,6 +195,7 @@ pub fn router(state: AppState) -> Router {
             put(publish_session_share_snapshot)
                 .layer(DefaultBodyLimit::max(MAX_SNAPSHOT_REQUEST_BYTES)),
         )
+        .merge(attachment_backups::router())
         .with_state(state)
 }
 

--- a/crates/api-sync/src/state.rs
+++ b/crates/api-sync/src/state.rs
@@ -1,21 +1,40 @@
+use std::sync::Arc;
+
+use tokio::sync::Semaphore;
+
 use crate::config::SyncConfig;
 
 const UPSTREAM_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(10);
+const ATTACHMENT_VERIFICATION_CONCURRENCY: usize = 1;
 
 #[derive(Clone)]
 pub struct AppState {
     pub config: SyncConfig,
     pub client: reqwest::Client,
+    pub storage: hypr_supabase_storage::SupabaseStorage,
+    pub attachment_verification_slots: Arc<Semaphore>,
 }
 
 impl AppState {
     pub fn new(config: SyncConfig) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(UPSTREAM_REQUEST_TIMEOUT)
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .expect("CloudSync HTTP client must build");
+        let storage = hypr_supabase_storage::SupabaseStorage::new(
+            client.clone(),
+            &config.supabase_url,
+            &config.supabase_service_role_key,
+        );
+
         Self {
             config,
-            client: reqwest::Client::builder()
-                .timeout(UPSTREAM_REQUEST_TIMEOUT)
-                .build()
-                .expect("CloudSync HTTP client must build"),
+            client,
+            storage,
+            attachment_verification_slots: Arc::new(Semaphore::new(
+                ATTACHMENT_VERIFICATION_CONCURRENCY,
+            )),
         }
     }
 }

--- a/crates/db-app/migrations/20260717150000_attachment_transfer_jobs.sql
+++ b/crates/db-app/migrations/20260717150000_attachment_transfer_jobs.sql
@@ -1,0 +1,100 @@
+CREATE TABLE IF NOT EXISTS attachment_transfer_jobs (
+  id                  TEXT PRIMARY KEY NOT NULL
+                      CHECK (id <> '' AND length(id) <= 512),
+  attachment_id       TEXT NOT NULL
+                      CHECK (attachment_id <> '' AND length(attachment_id) <= 512),
+  session_id          TEXT NOT NULL
+                      CHECK (session_id <> '' AND length(session_id) <= 512),
+  workspace_id        TEXT NOT NULL
+                      CHECK (workspace_id <> '' AND length(workspace_id) <= 512),
+  direction           TEXT NOT NULL
+                      CHECK (direction IN ('upload', 'download', 'delete')),
+  expected_sha256     TEXT NOT NULL
+                      CHECK (
+                        length(expected_sha256) = 64
+                        AND expected_sha256 NOT GLOB '*[^0-9a-f]*'
+                      ),
+  expected_size_bytes INTEGER NOT NULL DEFAULT 0
+                      CHECK (
+                        expected_size_bytes >= 0
+                        AND expected_size_bytes <= 536870912
+                      ),
+  ciphertext_sha256   TEXT NOT NULL DEFAULT ''
+                      CHECK (
+                        ciphertext_sha256 = ''
+                        OR (
+                          length(ciphertext_sha256) = 64
+                          AND ciphertext_sha256 NOT GLOB '*[^0-9a-f]*'
+                        )
+                      ),
+  ciphertext_size_bytes INTEGER NOT NULL DEFAULT 0
+                        CHECK (
+                          ciphertext_size_bytes >= 0
+                          AND ciphertext_size_bytes <= 545259520
+                        ),
+  remote_object_id    TEXT NOT NULL DEFAULT ''
+                      CHECK (length(remote_object_id) <= 1024),
+  object_key          TEXT NOT NULL DEFAULT ''
+                      CHECK (length(object_key) <= 2048),
+  cache_id            TEXT NOT NULL DEFAULT ''
+                      CHECK (length(cache_id) <= 1024),
+  phase               TEXT NOT NULL DEFAULT 'queued'
+                      CHECK (phase IN (
+                        'queued',
+                        'preparing',
+                        'ready',
+                        'transferring',
+                        'finalizing',
+                        'retry_wait',
+                        'failed',
+                        'completed'
+                      )),
+  attempt_count       INTEGER NOT NULL DEFAULT 0
+                      CHECK (attempt_count >= 0),
+  next_attempt_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  last_attempt_at     TEXT,
+  last_error          TEXT NOT NULL DEFAULT ''
+                      CHECK (length(last_error) <= 2048),
+  created_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  updated_at          TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  completed_at        TEXT,
+  CHECK (direction = 'upload' OR object_key <> ''),
+  CHECK (
+    (ciphertext_sha256 = '' AND ciphertext_size_bytes = 0)
+    OR (ciphertext_sha256 <> '' AND ciphertext_size_bytes > 0)
+  )
+) STRICT;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_live_version
+ON attachment_transfer_jobs (
+  attachment_id,
+  expected_sha256,
+  expected_size_bytes
+)
+WHERE direction IN ('upload', 'download')
+  AND phase <> 'completed';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_delete_object
+ON attachment_transfer_jobs(object_key)
+WHERE direction = 'delete';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_upload_object_id
+ON attachment_transfer_jobs(remote_object_id)
+WHERE direction = 'upload' AND remote_object_id <> '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_delete_object_id
+ON attachment_transfer_jobs(remote_object_id)
+WHERE direction = 'delete' AND remote_object_id <> '';
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_cache_id
+ON attachment_transfer_jobs(cache_id)
+WHERE cache_id <> '';
+
+CREATE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_due
+ON attachment_transfer_jobs(phase, next_attempt_at, created_at);
+
+CREATE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_attachment_id
+ON attachment_transfer_jobs(attachment_id);
+
+CREATE INDEX IF NOT EXISTS idx_attachment_transfer_jobs_session_id
+ON attachment_transfer_jobs(session_id);

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -137,6 +137,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260717140000_attachment_local_state.sql"),
     },
+    hypr_db_migrate::MigrationStep {
+        id: "20260717150000_attachment_transfer_jobs",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260717150000_attachment_transfer_jobs.sql"),
+    },
 ];
 
 pub fn schema() -> hypr_db_migrate::DbSchema {
@@ -346,6 +351,7 @@ mod tests {
                 "action_items",
                 "app_settings",
                 "attachment_local_state",
+                "attachment_transfer_jobs",
                 "calendars",
                 "chat_groups",
                 "chat_messages",
@@ -765,6 +771,195 @@ mod tests {
         );
         assert!(!E2EE_DOMAIN_TABLES.contains(&"attachment_local_state"));
         assert!(!cloudsync_alter_guard_required("attachment_local_state"));
+    }
+
+    #[test]
+    fn attachment_transfer_jobs_are_plain_and_excluded_from_cloudsync() {
+        let migration = APP_MIGRATION_STEPS
+            .iter()
+            .find(|step| step.id == "20260717150000_attachment_transfer_jobs")
+            .unwrap();
+
+        assert_eq!(migration.scope, hypr_db_migrate::MigrationScope::Plain);
+        assert!(
+            !cloudsync_table_registry()
+                .iter()
+                .any(|table| table.table_name == "attachment_transfer_jobs")
+        );
+        assert!(!E2EE_DOMAIN_TABLES.contains(&"attachment_transfer_jobs"));
+        assert!(!cloudsync_alter_guard_required("attachment_transfer_jobs"));
+    }
+
+    #[tokio::test]
+    async fn attachment_transfer_jobs_deduplicate_work_without_collapsing_old_objects() {
+        let db = test_db().await;
+        let insert = "INSERT INTO attachment_transfer_jobs (
+            id,
+            attachment_id,
+            session_id,
+            workspace_id,
+            direction,
+            expected_sha256,
+            expected_size_bytes,
+            remote_object_id,
+            object_key
+        ) VALUES (?, 'attachment-1', 'session-1', 'workspace-1', ?, ?, 42, ?, ?)";
+        let sha256 = "a".repeat(64);
+
+        sqlx::query(insert)
+            .bind("upload-1")
+            .bind("upload")
+            .bind(&sha256)
+            .bind("remote-object-1")
+            .bind("")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let duplicate_upload = sqlx::query(insert)
+            .bind("upload-2")
+            .bind("upload")
+            .bind(&sha256)
+            .bind("remote-object-1")
+            .bind("")
+            .execute(db.pool())
+            .await;
+        assert!(duplicate_upload.is_err());
+
+        let competing_download = sqlx::query(insert)
+            .bind("download-1")
+            .bind("download")
+            .bind(&sha256)
+            .bind("remote-object-1")
+            .bind("private/current-object")
+            .execute(db.pool())
+            .await;
+        assert!(competing_download.is_err());
+
+        sqlx::query(
+            "UPDATE attachment_transfer_jobs SET phase = 'completed' WHERE id = 'upload-1'",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(insert)
+            .bind("download-1")
+            .bind("download")
+            .bind(&sha256)
+            .bind("remote-object-1")
+            .bind("private/current-object")
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        for (id, remote_object_id, object_key) in [
+            ("delete-old-1", "remote-object-1", "private/old-object-1"),
+            ("delete-old-2", "remote-object-2", "private/old-object-2"),
+        ] {
+            sqlx::query(insert)
+                .bind(id)
+                .bind("delete")
+                .bind(&sha256)
+                .bind(remote_object_id)
+                .bind(object_key)
+                .execute(db.pool())
+                .await
+                .unwrap();
+        }
+
+        let delete_count: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM attachment_transfer_jobs
+             WHERE attachment_id = 'attachment-1' AND direction = 'delete'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(delete_count, 2);
+
+        let duplicate_delete = sqlx::query(insert)
+            .bind("delete-old-1-again")
+            .bind("delete")
+            .bind(&sha256)
+            .bind("remote-object-3")
+            .bind("private/old-object-1")
+            .execute(db.pool())
+            .await;
+        assert!(duplicate_delete.is_err());
+
+        let duplicate_delete_object = sqlx::query(insert)
+            .bind("delete-old-1-different-key")
+            .bind("delete")
+            .bind(&sha256)
+            .bind("remote-object-1")
+            .bind("private/other-key")
+            .execute(db.pool())
+            .await;
+        assert!(duplicate_delete_object.is_err());
+
+        for (id, object_key) in [
+            ("delete-by-key-1", "private/key-only-1"),
+            ("delete-by-key-2", "private/key-only-2"),
+        ] {
+            sqlx::query(insert)
+                .bind(id)
+                .bind("delete")
+                .bind(&sha256)
+                .bind("")
+                .bind(object_key)
+                .execute(db.pool())
+                .await
+                .unwrap();
+        }
+    }
+
+    #[tokio::test]
+    async fn attachment_transfer_jobs_require_complete_ciphertext_metadata() {
+        let db = test_db().await;
+        let sha256 = "a".repeat(64);
+        sqlx::query(
+            "INSERT INTO attachment_transfer_jobs (
+                id,
+                attachment_id,
+                session_id,
+                workspace_id,
+                direction,
+                expected_sha256,
+                expected_size_bytes
+            ) VALUES ('upload-1', 'attachment-1', 'session-1', 'workspace-1', 'upload', ?, 42)",
+        )
+        .bind(&sha256)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let incomplete = sqlx::query(
+            "UPDATE attachment_transfer_jobs
+             SET ciphertext_sha256 = ?
+             WHERE id = 'upload-1'",
+        )
+        .bind(&sha256)
+        .execute(db.pool())
+        .await;
+        assert!(incomplete.is_err());
+
+        sqlx::query(
+            "UPDATE attachment_transfer_jobs
+             SET ciphertext_sha256 = ?, ciphertext_size_bytes = 84
+             WHERE id = 'upload-1'",
+        )
+        .bind(&sha256)
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let oversized = sqlx::query(
+            "UPDATE attachment_transfer_jobs
+             SET ciphertext_size_bytes = 545259521
+             WHERE id = 'upload-1'",
+        )
+        .execute(db.pool())
+        .await;
+        assert!(oversized.is_err());
     }
 
     #[tokio::test]

--- a/crates/e2ee/src/blob.rs
+++ b/crates/e2ee/src/blob.rs
@@ -1,0 +1,1364 @@
+use std::io::{self, Read, Write};
+
+use base64::Engine;
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use chacha20poly1305::aead::AeadInPlace;
+use chacha20poly1305::{KeyInit, XChaCha20Poly1305, XNonce};
+use hkdf::Hkdf;
+use hmac::{Hmac, Mac};
+use sha2::{Digest, Sha256};
+use zeroize::Zeroizing;
+
+use super::WorkspaceKey;
+
+pub const ATTACHMENT_BLOB_CHUNK_SIZE: usize = 4 * 1024 * 1024;
+pub const ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES: u64 = 512 * 1024 * 1024;
+
+const MAGIC: &[u8; 8] = b"ANABLB01";
+const VERSION: u8 = 1;
+const HEADER_SCHEMA_VERSION: u8 = 1;
+const AEAD_TAG_BYTES: u64 = 16;
+const HEADER_NONCE_BYTES: usize = 24;
+const CHUNK_NONCE_PREFIX_BYTES: usize = 16;
+const FIXED_PREFIX_BYTES: usize = MAGIC.len() + 1 + HEADER_NONCE_BYTES + 4;
+const MAX_WORKSPACE_ID_BYTES: usize = 256;
+const MAX_ATTACHMENT_ID_BYTES: usize = 1024;
+const CANONICAL_UUID_BYTES: usize = 36;
+const BLOB_KEY_SALT: &[u8] = b"anarlog-e2ee-attachment-blob-key-v1";
+const BLOB_KEY_INFO_DOMAIN: &[u8] = b"anarlog-e2ee-attachment-blob-object-v1";
+const HEADER_KEY_INFO: &[u8] = b"anarlog-e2ee-attachment-blob-header-key-v1";
+const CHUNK_KEY_INFO: &[u8] = b"anarlog-e2ee-attachment-blob-chunk-key-v1";
+const HEADER_AAD_DOMAIN: &[u8] = b"anarlog-e2ee-attachment-blob-header-aad-v1";
+const CHUNK_AAD_DOMAIN: &[u8] = b"anarlog-e2ee-attachment-blob-chunk-aad-v1";
+const ATTACHMENT_BACKUP_REF_DOMAIN: &[u8] = b"anarlog-e2ee-attachment-backup-ref-v1";
+const ATTACHMENT_BACKUP_VERSION_REF_DOMAIN: &[u8] =
+    b"anarlog-e2ee-attachment-backup-version-ref-v1";
+
+#[derive(Debug, thiserror::Error)]
+pub enum AttachmentBlobError {
+    #[error("the attachment blob context is invalid")]
+    InvalidContext,
+    #[error("the attachment blob metadata is invalid")]
+    InvalidMetadata,
+    #[error("the attachment blob version is unsupported")]
+    UnsupportedVersion,
+    #[error("the attachment blob exceeds the plaintext size limit")]
+    PlaintextTooLarge,
+    #[error("the attachment blob header is invalid")]
+    InvalidHeader,
+    #[error("the attachment blob is truncated")]
+    Truncated,
+    #[error("the attachment blob contains trailing data")]
+    TrailingData,
+    #[error("the attachment source does not match its metadata")]
+    SourceMismatch,
+    #[error("the attachment ciphertext does not match its metadata")]
+    CiphertextMismatch,
+    #[error("the attachment blob failed authentication")]
+    AuthenticationFailed,
+    #[error("cryptographic randomness is unavailable")]
+    RandomnessUnavailable,
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+pub type AttachmentBlobResult<T> = std::result::Result<T, AttachmentBlobError>;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentBlobContext {
+    workspace_id: String,
+    attachment_id: String,
+    object_id: String,
+}
+
+impl AttachmentBlobContext {
+    pub fn new(
+        workspace_id: impl Into<String>,
+        attachment_id: impl Into<String>,
+        object_id: impl Into<String>,
+    ) -> AttachmentBlobResult<Self> {
+        let workspace_id = workspace_id.into();
+        let attachment_id = attachment_id.into();
+        let object_id = object_id.into();
+        validate_identifier(&workspace_id, MAX_WORKSPACE_ID_BYTES)?;
+        validate_identifier(&attachment_id, MAX_ATTACHMENT_ID_BYTES)?;
+        if !is_canonical_uuid(&object_id) {
+            return Err(AttachmentBlobError::InvalidContext);
+        }
+
+        Ok(Self {
+            workspace_id,
+            attachment_id,
+            object_id,
+        })
+    }
+
+    pub fn workspace_id(&self) -> &str {
+        &self.workspace_id
+    }
+
+    pub fn attachment_id(&self) -> &str {
+        &self.attachment_id
+    }
+
+    pub fn object_id(&self) -> &str {
+        &self.object_id
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentBlobPlaintextMetadata {
+    pub size_bytes: u64,
+    pub sha256: [u8; 32],
+}
+
+impl AttachmentBlobPlaintextMetadata {
+    pub fn new(size_bytes: u64, sha256: [u8; 32]) -> Self {
+        Self { size_bytes, sha256 }
+    }
+
+    pub fn from_hex(size_bytes: u64, sha256: &str) -> AttachmentBlobResult<Self> {
+        Ok(Self::new(size_bytes, decode_sha256_hex(sha256)?))
+    }
+
+    pub fn sha256_hex(&self) -> String {
+        encode_sha256_hex(&self.sha256)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentBlobCiphertextMetadata {
+    pub size_bytes: u64,
+    pub sha256: [u8; 32],
+}
+
+impl AttachmentBlobCiphertextMetadata {
+    pub fn new(size_bytes: u64, sha256: [u8; 32]) -> Self {
+        Self { size_bytes, sha256 }
+    }
+
+    pub fn from_hex(size_bytes: u64, sha256: &str) -> AttachmentBlobResult<Self> {
+        Ok(Self::new(size_bytes, decode_sha256_hex(sha256)?))
+    }
+
+    pub fn sha256_hex(&self) -> String {
+        encode_sha256_hex(&self.sha256)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AttachmentBlobMetadata {
+    pub version: u8,
+    pub plaintext: AttachmentBlobPlaintextMetadata,
+    pub ciphertext: AttachmentBlobCiphertextMetadata,
+}
+
+impl WorkspaceKey {
+    pub fn attachment_blob_ciphertext_size(
+        &self,
+        workspace_id: &str,
+        attachment_id: &str,
+        plaintext_size_bytes: u64,
+    ) -> AttachmentBlobResult<u64> {
+        let sizing_context = AttachmentBlobContext::new(
+            workspace_id,
+            attachment_id,
+            "00000000-0000-4000-8000-000000000000",
+        )?;
+        encoded_size(&sizing_context, self.key_id(), plaintext_size_bytes)
+    }
+
+    pub fn blind_attachment_backup_ref(
+        &self,
+        workspace_id: &str,
+        attachment_id: &str,
+    ) -> AttachmentBlobResult<String> {
+        validate_identifier(workspace_id, MAX_WORKSPACE_ID_BYTES)?;
+        validate_identifier(attachment_id, MAX_ATTACHMENT_ID_BYTES)?;
+        let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(self.bytes.as_slice())
+            .expect("HMAC accepts 32-byte keys");
+        update_mac_components(
+            &mut mac,
+            [
+                ATTACHMENT_BACKUP_REF_DOMAIN,
+                workspace_id.as_bytes(),
+                attachment_id.as_bytes(),
+            ],
+        );
+        Ok(URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes()))
+    }
+
+    pub fn blind_attachment_backup_version_ref(
+        &self,
+        workspace_id: &str,
+        attachment_id: &str,
+        plaintext: &AttachmentBlobPlaintextMetadata,
+    ) -> AttachmentBlobResult<String> {
+        validate_plaintext_metadata(plaintext)?;
+        let attachment_ref = self.blind_attachment_backup_ref(workspace_id, attachment_id)?;
+        let mut mac = <Hmac<Sha256> as Mac>::new_from_slice(self.bytes.as_slice())
+            .expect("HMAC accepts 32-byte keys");
+        let size = plaintext.size_bytes.to_be_bytes();
+        update_mac_components(
+            &mut mac,
+            [
+                ATTACHMENT_BACKUP_VERSION_REF_DOMAIN,
+                attachment_ref.as_bytes(),
+                plaintext.sha256.as_slice(),
+                size.as_slice(),
+            ],
+        );
+        Ok(URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes()))
+    }
+
+    /// Streams a blob into `destination`. The destination must be discarded if this returns an
+    /// error because source validation completes after the encrypted chunks are written.
+    pub fn seal_attachment_blob<R: Read, W: Write>(
+        &self,
+        context: &AttachmentBlobContext,
+        source: &mut R,
+        destination: &mut W,
+        expected_plaintext: &AttachmentBlobPlaintextMetadata,
+    ) -> AttachmentBlobResult<AttachmentBlobMetadata> {
+        validate_plaintext_metadata(expected_plaintext)?;
+        let chunk_count = chunk_count(expected_plaintext.size_bytes);
+        let keys = derive_blob_keys(self, context)?;
+        let mut chunk_nonce_prefix = [0_u8; CHUNK_NONCE_PREFIX_BYTES];
+        getrandom::fill(&mut chunk_nonce_prefix)
+            .map_err(|_| AttachmentBlobError::RandomnessUnavailable)?;
+        let header = Header {
+            workspace_id: context.workspace_id.clone(),
+            attachment_id: context.attachment_id.clone(),
+            object_id: context.object_id.clone(),
+            key_id: self.key_id().to_string(),
+            plaintext_size: expected_plaintext.size_bytes,
+            plaintext_sha256: expected_plaintext.sha256,
+            chunk_size: ATTACHMENT_BLOB_CHUNK_SIZE as u32,
+            chunk_count,
+            chunk_nonce_prefix,
+        };
+        let mut header_plaintext = Zeroizing::new(encode_header(&header)?);
+        let mut header_nonce = [0_u8; HEADER_NONCE_BYTES];
+        getrandom::fill(&mut header_nonce)
+            .map_err(|_| AttachmentBlobError::RandomnessUnavailable)?;
+        let header_aad = header_aad(context, self.key_id());
+        let header_cipher = XChaCha20Poly1305::new_from_slice(keys.header.as_slice())
+            .expect("XChaCha20Poly1305 accepts 32-byte keys");
+        let header_nonce = XNonce::from(header_nonce);
+        header_cipher
+            .encrypt_in_place(&header_nonce, &header_aad, &mut *header_plaintext)
+            .map_err(|_| AttachmentBlobError::AuthenticationFailed)?;
+        let header_ciphertext_len = u32::try_from(header_plaintext.len())
+            .map_err(|_| AttachmentBlobError::InvalidHeader)?;
+
+        let mut fixed_prefix = [0_u8; FIXED_PREFIX_BYTES];
+        fixed_prefix[..MAGIC.len()].copy_from_slice(MAGIC);
+        fixed_prefix[MAGIC.len()] = VERSION;
+        fixed_prefix[MAGIC.len() + 1..MAGIC.len() + 1 + HEADER_NONCE_BYTES]
+            .copy_from_slice(&header_nonce);
+        fixed_prefix[FIXED_PREFIX_BYTES - 4..]
+            .copy_from_slice(&header_ciphertext_len.to_be_bytes());
+        let authenticated_header_hash = Sha256::new()
+            .chain_update(fixed_prefix)
+            .chain_update(header_plaintext.as_slice())
+            .finalize();
+
+        let mut ciphertext_hasher = Sha256::new();
+        let mut ciphertext_size = 0_u64;
+        write_ciphertext(
+            destination,
+            &mut ciphertext_hasher,
+            &mut ciphertext_size,
+            &fixed_prefix,
+        )?;
+        write_ciphertext(
+            destination,
+            &mut ciphertext_hasher,
+            &mut ciphertext_size,
+            header_plaintext.as_slice(),
+        )?;
+
+        let chunk_cipher = XChaCha20Poly1305::new_from_slice(keys.chunk.as_slice())
+            .expect("XChaCha20Poly1305 accepts 32-byte keys");
+        let mut plaintext_hasher = Sha256::new();
+        let mut remaining = expected_plaintext.size_bytes;
+        for index in 0..chunk_count {
+            let plaintext_len = remaining.min(ATTACHMENT_BLOB_CHUNK_SIZE as u64) as usize;
+            let mut chunk =
+                Zeroizing::new(Vec::with_capacity(plaintext_len + AEAD_TAG_BYTES as usize));
+            chunk.resize(plaintext_len, 0);
+            read_plaintext_exact(source, chunk.as_mut_slice())?;
+            plaintext_hasher.update(chunk.as_slice());
+            let nonce = chunk_nonce(&chunk_nonce_prefix, u64::from(index));
+            let nonce = XNonce::from(nonce);
+            let aad = chunk_aad(&authenticated_header_hash, index, chunk_count);
+            chunk_cipher
+                .encrypt_in_place(&nonce, &aad, &mut *chunk)
+                .map_err(|_| AttachmentBlobError::AuthenticationFailed)?;
+            write_ciphertext(
+                destination,
+                &mut ciphertext_hasher,
+                &mut ciphertext_size,
+                chunk.as_slice(),
+            )?;
+            remaining -= plaintext_len as u64;
+        }
+        if read_one(source)?.is_some() {
+            return Err(AttachmentBlobError::SourceMismatch);
+        }
+        let plaintext_sha256: [u8; 32] = plaintext_hasher.finalize().into();
+        if plaintext_sha256 != expected_plaintext.sha256 {
+            return Err(AttachmentBlobError::SourceMismatch);
+        }
+        let expected_ciphertext_size =
+            encoded_size(context, self.key_id(), expected_plaintext.size_bytes)?;
+        if ciphertext_size != expected_ciphertext_size {
+            return Err(AttachmentBlobError::InvalidMetadata);
+        }
+
+        Ok(AttachmentBlobMetadata {
+            version: VERSION,
+            plaintext: expected_plaintext.clone(),
+            ciphertext: AttachmentBlobCiphertextMetadata {
+                size_bytes: ciphertext_size,
+                sha256: ciphertext_hasher.finalize().into(),
+            },
+        })
+    }
+
+    /// Streams authenticated plaintext into `destination`. Callers must write to a temporary
+    /// destination and discard it on error because the whole-ciphertext digest is verified last.
+    pub fn open_attachment_blob<R: Read, W: Write>(
+        &self,
+        context: &AttachmentBlobContext,
+        source: &mut R,
+        destination: &mut W,
+        expected: &AttachmentBlobMetadata,
+    ) -> AttachmentBlobResult<AttachmentBlobMetadata> {
+        validate_blob_metadata(context, self.key_id(), expected)?;
+        let keys = derive_blob_keys(self, context)?;
+        let mut ciphertext_hasher = Sha256::new();
+        let mut ciphertext_size = 0_u64;
+        let mut fixed_prefix = [0_u8; FIXED_PREFIX_BYTES];
+        read_ciphertext_exact(
+            source,
+            &mut ciphertext_hasher,
+            &mut ciphertext_size,
+            &mut fixed_prefix,
+        )?;
+        if &fixed_prefix[..MAGIC.len()] != MAGIC {
+            return Err(AttachmentBlobError::InvalidHeader);
+        }
+        if fixed_prefix[MAGIC.len()] != VERSION {
+            return Err(AttachmentBlobError::UnsupportedVersion);
+        }
+        let header_nonce_start = MAGIC.len() + 1;
+        let header_nonce: [u8; HEADER_NONCE_BYTES] = fixed_prefix
+            [header_nonce_start..header_nonce_start + HEADER_NONCE_BYTES]
+            .try_into()
+            .expect("header nonce length is fixed");
+        let header_ciphertext_len = u32::from_be_bytes(
+            fixed_prefix[FIXED_PREFIX_BYTES - 4..]
+                .try_into()
+                .expect("header length field is fixed"),
+        ) as usize;
+        let expected_header_ciphertext_len = encoded_header_len(context, self.key_id())?
+            .checked_add(AEAD_TAG_BYTES as usize)
+            .ok_or(AttachmentBlobError::InvalidHeader)?;
+        if header_ciphertext_len != expected_header_ciphertext_len {
+            return Err(AttachmentBlobError::InvalidHeader);
+        }
+
+        let mut header_ciphertext = Zeroizing::new(vec![0_u8; header_ciphertext_len]);
+        read_ciphertext_exact(
+            source,
+            &mut ciphertext_hasher,
+            &mut ciphertext_size,
+            header_ciphertext.as_mut_slice(),
+        )?;
+        let authenticated_header_hash = Sha256::new()
+            .chain_update(fixed_prefix)
+            .chain_update(header_ciphertext.as_slice())
+            .finalize();
+        let header_cipher = XChaCha20Poly1305::new_from_slice(keys.header.as_slice())
+            .expect("XChaCha20Poly1305 accepts 32-byte keys");
+        let header_aad = header_aad(context, self.key_id());
+        let header_nonce = XNonce::from(header_nonce);
+        header_cipher
+            .decrypt_in_place(&header_nonce, &header_aad, &mut *header_ciphertext)
+            .map_err(|_| AttachmentBlobError::AuthenticationFailed)?;
+        let header = decode_header(header_ciphertext.as_slice())?;
+        validate_header(&header, context, self.key_id(), &expected.plaintext)?;
+
+        let chunk_cipher = XChaCha20Poly1305::new_from_slice(keys.chunk.as_slice())
+            .expect("XChaCha20Poly1305 accepts 32-byte keys");
+        let mut plaintext_hasher = Sha256::new();
+        let mut plaintext_size = 0_u64;
+        let mut remaining = header.plaintext_size;
+        for index in 0..header.chunk_count {
+            let plaintext_len = remaining.min(ATTACHMENT_BLOB_CHUNK_SIZE as u64) as usize;
+            let ciphertext_len = plaintext_len + AEAD_TAG_BYTES as usize;
+            let mut chunk = Zeroizing::new(vec![0_u8; ciphertext_len]);
+            read_ciphertext_exact(
+                source,
+                &mut ciphertext_hasher,
+                &mut ciphertext_size,
+                chunk.as_mut_slice(),
+            )?;
+            let nonce = chunk_nonce(&header.chunk_nonce_prefix, u64::from(index));
+            let nonce = XNonce::from(nonce);
+            let aad = chunk_aad(&authenticated_header_hash, index, header.chunk_count);
+            chunk_cipher
+                .decrypt_in_place(&nonce, &aad, &mut *chunk)
+                .map_err(|_| AttachmentBlobError::AuthenticationFailed)?;
+            if chunk.len() != plaintext_len {
+                return Err(AttachmentBlobError::InvalidHeader);
+            }
+            destination.write_all(chunk.as_slice())?;
+            plaintext_hasher.update(chunk.as_slice());
+            plaintext_size += chunk.len() as u64;
+            remaining -= chunk.len() as u64;
+        }
+        if read_one(source)?.is_some() {
+            return Err(AttachmentBlobError::TrailingData);
+        }
+        if remaining != 0 || plaintext_size != header.plaintext_size {
+            return Err(AttachmentBlobError::InvalidHeader);
+        }
+        let plaintext_sha256: [u8; 32] = plaintext_hasher.finalize().into();
+        if plaintext_sha256 != header.plaintext_sha256 {
+            return Err(AttachmentBlobError::AuthenticationFailed);
+        }
+        let ciphertext_sha256: [u8; 32] = ciphertext_hasher.finalize().into();
+        if ciphertext_size != expected.ciphertext.size_bytes
+            || ciphertext_sha256 != expected.ciphertext.sha256
+        {
+            return Err(AttachmentBlobError::CiphertextMismatch);
+        }
+
+        Ok(AttachmentBlobMetadata {
+            version: VERSION,
+            plaintext: AttachmentBlobPlaintextMetadata {
+                size_bytes: plaintext_size,
+                sha256: plaintext_sha256,
+            },
+            ciphertext: AttachmentBlobCiphertextMetadata {
+                size_bytes: ciphertext_size,
+                sha256: ciphertext_sha256,
+            },
+        })
+    }
+}
+
+struct BlobKeys {
+    header: Zeroizing<[u8; 32]>,
+    chunk: Zeroizing<[u8; 32]>,
+}
+
+struct Header {
+    workspace_id: String,
+    attachment_id: String,
+    object_id: String,
+    key_id: String,
+    plaintext_size: u64,
+    plaintext_sha256: [u8; 32],
+    chunk_size: u32,
+    chunk_count: u32,
+    chunk_nonce_prefix: [u8; CHUNK_NONCE_PREFIX_BYTES],
+}
+
+fn validate_identifier(value: &str, max_bytes: usize) -> AttachmentBlobResult<()> {
+    if value.is_empty()
+        || value.len() > max_bytes
+        || value.trim() != value
+        || value.chars().any(char::is_control)
+    {
+        return Err(AttachmentBlobError::InvalidContext);
+    }
+    Ok(())
+}
+
+fn update_mac_components<const N: usize>(mac: &mut Hmac<Sha256>, components: [&[u8]; N]) {
+    for component in components {
+        mac.update(&(component.len() as u64).to_be_bytes());
+        mac.update(component);
+    }
+}
+
+fn is_canonical_uuid(value: &str) -> bool {
+    value.len() == CANONICAL_UUID_BYTES
+        && matches!(value.as_bytes()[14], b'4' | b'7')
+        && matches!(value.as_bytes()[19], b'8' | b'9' | b'a' | b'b')
+        && value.bytes().enumerate().all(|(index, byte)| {
+            if matches!(index, 8 | 13 | 18 | 23) {
+                byte == b'-'
+            } else {
+                byte.is_ascii_digit() || matches!(byte, b'a'..=b'f')
+            }
+        })
+}
+
+fn validate_plaintext_metadata(
+    metadata: &AttachmentBlobPlaintextMetadata,
+) -> AttachmentBlobResult<()> {
+    if metadata.size_bytes > ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES {
+        return Err(AttachmentBlobError::PlaintextTooLarge);
+    }
+    Ok(())
+}
+
+fn validate_blob_metadata(
+    context: &AttachmentBlobContext,
+    key_id: &str,
+    metadata: &AttachmentBlobMetadata,
+) -> AttachmentBlobResult<()> {
+    if metadata.version != VERSION {
+        return Err(AttachmentBlobError::UnsupportedVersion);
+    }
+    validate_plaintext_metadata(&metadata.plaintext)?;
+    let expected_size = encoded_size(context, key_id, metadata.plaintext.size_bytes)?;
+    if metadata.ciphertext.size_bytes != expected_size {
+        return Err(AttachmentBlobError::InvalidMetadata);
+    }
+    Ok(())
+}
+
+fn derive_blob_keys(
+    workspace_key: &WorkspaceKey,
+    context: &AttachmentBlobContext,
+) -> AttachmentBlobResult<BlobKeys> {
+    let hkdf = Hkdf::<Sha256>::new(Some(BLOB_KEY_SALT), workspace_key.bytes.as_slice());
+    let mut root = Zeroizing::new([0_u8; 32]);
+    hkdf.expand(
+        &context_bytes(BLOB_KEY_INFO_DOMAIN, context, workspace_key.key_id()),
+        &mut *root,
+    )
+    .map_err(|_| AttachmentBlobError::InvalidContext)?;
+    let hkdf = Hkdf::<Sha256>::from_prk(root.as_slice())
+        .map_err(|_| AttachmentBlobError::InvalidContext)?;
+    let mut header = Zeroizing::new([0_u8; 32]);
+    let mut chunk = Zeroizing::new([0_u8; 32]);
+    hkdf.expand(HEADER_KEY_INFO, &mut *header)
+        .map_err(|_| AttachmentBlobError::InvalidContext)?;
+    hkdf.expand(CHUNK_KEY_INFO, &mut *chunk)
+        .map_err(|_| AttachmentBlobError::InvalidContext)?;
+    Ok(BlobKeys { header, chunk })
+}
+
+fn header_aad(context: &AttachmentBlobContext, key_id: &str) -> Vec<u8> {
+    context_bytes(HEADER_AAD_DOMAIN, context, key_id)
+}
+
+fn context_bytes(domain: &[u8], context: &AttachmentBlobContext, key_id: &str) -> Vec<u8> {
+    let mut output = Vec::new();
+    for value in [
+        domain,
+        MAGIC.as_slice(),
+        &[VERSION],
+        context.workspace_id.as_bytes(),
+        context.attachment_id.as_bytes(),
+        context.object_id.as_bytes(),
+        key_id.as_bytes(),
+    ] {
+        output.extend_from_slice(&(value.len() as u64).to_be_bytes());
+        output.extend_from_slice(value);
+    }
+    output
+}
+
+fn chunk_aad(header_hash: &[u8], index: u32, chunk_count: u32) -> Vec<u8> {
+    let mut output = Vec::with_capacity(CHUNK_AAD_DOMAIN.len() + header_hash.len() + 24);
+    for value in [CHUNK_AAD_DOMAIN, header_hash] {
+        output.extend_from_slice(&(value.len() as u64).to_be_bytes());
+        output.extend_from_slice(value);
+    }
+    output.extend_from_slice(&index.to_be_bytes());
+    output.extend_from_slice(&chunk_count.to_be_bytes());
+    output
+}
+
+fn chunk_nonce(prefix: &[u8; CHUNK_NONCE_PREFIX_BYTES], index: u64) -> [u8; 24] {
+    let mut nonce = [0_u8; 24];
+    nonce[..CHUNK_NONCE_PREFIX_BYTES].copy_from_slice(prefix);
+    nonce[CHUNK_NONCE_PREFIX_BYTES..].copy_from_slice(&index.to_be_bytes());
+    nonce
+}
+
+fn encode_header(header: &Header) -> AttachmentBlobResult<Vec<u8>> {
+    let mut output = Vec::with_capacity(encoded_header_len_values(
+        &header.workspace_id,
+        &header.attachment_id,
+        &header.object_id,
+        &header.key_id,
+    )?);
+    output.push(HEADER_SCHEMA_VERSION);
+    push_string(&mut output, &header.workspace_id)?;
+    push_string(&mut output, &header.attachment_id)?;
+    push_string(&mut output, &header.object_id)?;
+    push_string(&mut output, &header.key_id)?;
+    output.extend_from_slice(&header.plaintext_size.to_be_bytes());
+    output.extend_from_slice(&header.plaintext_sha256);
+    output.extend_from_slice(&header.chunk_size.to_be_bytes());
+    output.extend_from_slice(&header.chunk_count.to_be_bytes());
+    output.extend_from_slice(&header.chunk_nonce_prefix);
+    Ok(output)
+}
+
+fn decode_header(bytes: &[u8]) -> AttachmentBlobResult<Header> {
+    let mut decoder = Decoder::new(bytes);
+    if decoder.take_u8()? != HEADER_SCHEMA_VERSION {
+        return Err(AttachmentBlobError::InvalidHeader);
+    }
+    let workspace_id = decoder.take_string(MAX_WORKSPACE_ID_BYTES)?;
+    let attachment_id = decoder.take_string(MAX_ATTACHMENT_ID_BYTES)?;
+    let object_id = decoder.take_string(CANONICAL_UUID_BYTES)?;
+    let key_id = decoder.take_string(64)?;
+    let plaintext_size = decoder.take_u64()?;
+    let plaintext_sha256 = decoder.take_array::<32>()?;
+    let chunk_size = decoder.take_u32()?;
+    let chunk_count = decoder.take_u32()?;
+    let chunk_nonce_prefix = decoder.take_array::<CHUNK_NONCE_PREFIX_BYTES>()?;
+    if !decoder.is_empty() {
+        return Err(AttachmentBlobError::InvalidHeader);
+    }
+    Ok(Header {
+        workspace_id,
+        attachment_id,
+        object_id,
+        key_id,
+        plaintext_size,
+        plaintext_sha256,
+        chunk_size,
+        chunk_count,
+        chunk_nonce_prefix,
+    })
+}
+
+fn validate_header(
+    header: &Header,
+    context: &AttachmentBlobContext,
+    key_id: &str,
+    expected_plaintext: &AttachmentBlobPlaintextMetadata,
+) -> AttachmentBlobResult<()> {
+    if header.workspace_id != context.workspace_id
+        || header.attachment_id != context.attachment_id
+        || header.object_id != context.object_id
+        || header.key_id != key_id
+        || header.plaintext_size != expected_plaintext.size_bytes
+        || header.plaintext_sha256 != expected_plaintext.sha256
+        || header.chunk_size != ATTACHMENT_BLOB_CHUNK_SIZE as u32
+        || header.chunk_count != chunk_count(header.plaintext_size)
+    {
+        return Err(AttachmentBlobError::InvalidHeader);
+    }
+    validate_plaintext_metadata(expected_plaintext)
+}
+
+fn encoded_size(
+    context: &AttachmentBlobContext,
+    key_id: &str,
+    plaintext_size: u64,
+) -> AttachmentBlobResult<u64> {
+    if plaintext_size > ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES {
+        return Err(AttachmentBlobError::PlaintextTooLarge);
+    }
+    let header_size = encoded_header_len(context, key_id)? as u64 + AEAD_TAG_BYTES;
+    let chunk_overhead = u64::from(chunk_count(plaintext_size))
+        .checked_mul(AEAD_TAG_BYTES)
+        .ok_or(AttachmentBlobError::InvalidMetadata)?;
+    (FIXED_PREFIX_BYTES as u64)
+        .checked_add(header_size)
+        .and_then(|size| size.checked_add(plaintext_size))
+        .and_then(|size| size.checked_add(chunk_overhead))
+        .ok_or(AttachmentBlobError::InvalidMetadata)
+}
+
+fn encoded_header_len(
+    context: &AttachmentBlobContext,
+    key_id: &str,
+) -> AttachmentBlobResult<usize> {
+    encoded_header_len_values(
+        &context.workspace_id,
+        &context.attachment_id,
+        &context.object_id,
+        key_id,
+    )
+}
+
+fn encoded_header_len_values(
+    workspace_id: &str,
+    attachment_id: &str,
+    object_id: &str,
+    key_id: &str,
+) -> AttachmentBlobResult<usize> {
+    let string_bytes = [workspace_id, attachment_id, object_id, key_id]
+        .into_iter()
+        .try_fold(0_usize, |total, value| {
+            u16::try_from(value.len())
+                .map_err(|_| AttachmentBlobError::InvalidHeader)
+                .and_then(|_| {
+                    total
+                        .checked_add(2 + value.len())
+                        .ok_or(AttachmentBlobError::InvalidHeader)
+                })
+        })?;
+    1_usize
+        .checked_add(string_bytes)
+        .and_then(|size| size.checked_add(8 + 32 + 4 + 4 + CHUNK_NONCE_PREFIX_BYTES))
+        .ok_or(AttachmentBlobError::InvalidHeader)
+}
+
+fn chunk_count(size: u64) -> u32 {
+    if size == 0 {
+        return 0;
+    }
+    size.div_ceil(ATTACHMENT_BLOB_CHUNK_SIZE as u64) as u32
+}
+
+fn push_string(output: &mut Vec<u8>, value: &str) -> AttachmentBlobResult<()> {
+    let length = u16::try_from(value.len()).map_err(|_| AttachmentBlobError::InvalidHeader)?;
+    output.extend_from_slice(&length.to_be_bytes());
+    output.extend_from_slice(value.as_bytes());
+    Ok(())
+}
+
+fn write_ciphertext<W: Write>(
+    destination: &mut W,
+    hasher: &mut Sha256,
+    size: &mut u64,
+    bytes: &[u8],
+) -> AttachmentBlobResult<()> {
+    destination.write_all(bytes)?;
+    hasher.update(bytes);
+    *size = size
+        .checked_add(bytes.len() as u64)
+        .ok_or(AttachmentBlobError::InvalidMetadata)?;
+    Ok(())
+}
+
+fn read_plaintext_exact<R: Read>(source: &mut R, buffer: &mut [u8]) -> AttachmentBlobResult<()> {
+    read_exact(source, buffer).map_err(|error| match error.kind() {
+        io::ErrorKind::UnexpectedEof => AttachmentBlobError::SourceMismatch,
+        _ => AttachmentBlobError::Io(error),
+    })
+}
+
+fn read_ciphertext_exact<R: Read>(
+    source: &mut R,
+    hasher: &mut Sha256,
+    size: &mut u64,
+    buffer: &mut [u8],
+) -> AttachmentBlobResult<()> {
+    read_exact(source, buffer).map_err(|error| match error.kind() {
+        io::ErrorKind::UnexpectedEof => AttachmentBlobError::Truncated,
+        _ => AttachmentBlobError::Io(error),
+    })?;
+    hasher.update(&*buffer);
+    *size = size
+        .checked_add(buffer.len() as u64)
+        .ok_or(AttachmentBlobError::InvalidMetadata)?;
+    Ok(())
+}
+
+fn read_exact<R: Read>(source: &mut R, mut buffer: &mut [u8]) -> io::Result<()> {
+    while !buffer.is_empty() {
+        match source.read(buffer) {
+            Ok(0) => return Err(io::ErrorKind::UnexpectedEof.into()),
+            Ok(read) => buffer = &mut buffer[read..],
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(error),
+        }
+    }
+    Ok(())
+}
+
+fn read_one<R: Read>(source: &mut R) -> AttachmentBlobResult<Option<u8>> {
+    let mut byte = [0_u8; 1];
+    loop {
+        match source.read(&mut byte) {
+            Ok(0) => return Ok(None),
+            Ok(_) => return Ok(Some(byte[0])),
+            Err(error) if error.kind() == io::ErrorKind::Interrupted => {}
+            Err(error) => return Err(AttachmentBlobError::Io(error)),
+        }
+    }
+}
+
+fn decode_sha256_hex(value: &str) -> AttachmentBlobResult<[u8; 32]> {
+    if value.len() != 64
+        || !value
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+    {
+        return Err(AttachmentBlobError::InvalidMetadata);
+    }
+    let mut output = [0_u8; 32];
+    for (index, byte) in output.iter_mut().enumerate() {
+        let offset = index * 2;
+        *byte = u8::from_str_radix(&value[offset..offset + 2], 16)
+            .map_err(|_| AttachmentBlobError::InvalidMetadata)?;
+    }
+    Ok(output)
+}
+
+fn encode_sha256_hex(value: &[u8; 32]) -> String {
+    use std::fmt::Write as _;
+
+    let mut output = String::with_capacity(64);
+    for byte in value {
+        write!(&mut output, "{byte:02x}").expect("writing to a String cannot fail");
+    }
+    output
+}
+
+struct Decoder<'a> {
+    remaining: &'a [u8],
+}
+
+impl<'a> Decoder<'a> {
+    fn new(bytes: &'a [u8]) -> Self {
+        Self { remaining: bytes }
+    }
+
+    fn take_u8(&mut self) -> AttachmentBlobResult<u8> {
+        Ok(self.take_array::<1>()?[0])
+    }
+
+    fn take_u32(&mut self) -> AttachmentBlobResult<u32> {
+        Ok(u32::from_be_bytes(self.take_array()?))
+    }
+
+    fn take_u64(&mut self) -> AttachmentBlobResult<u64> {
+        Ok(u64::from_be_bytes(self.take_array()?))
+    }
+
+    fn take_string(&mut self, max_bytes: usize) -> AttachmentBlobResult<String> {
+        let length = u16::from_be_bytes(self.take_array()?) as usize;
+        if length == 0 || length > max_bytes {
+            return Err(AttachmentBlobError::InvalidHeader);
+        }
+        let bytes = self.take(length)?;
+        String::from_utf8(bytes.to_vec()).map_err(|_| AttachmentBlobError::InvalidHeader)
+    }
+
+    fn take_array<const N: usize>(&mut self) -> AttachmentBlobResult<[u8; N]> {
+        self.take(N)?
+            .try_into()
+            .map_err(|_| AttachmentBlobError::InvalidHeader)
+    }
+
+    fn take(&mut self, length: usize) -> AttachmentBlobResult<&'a [u8]> {
+        if self.remaining.len() < length {
+            return Err(AttachmentBlobError::InvalidHeader);
+        }
+        let (value, remaining) = self.remaining.split_at(length);
+        self.remaining = remaining;
+        Ok(value)
+    }
+
+    fn is_empty(&self) -> bool {
+        self.remaining.is_empty()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::io::Cursor;
+
+    use super::*;
+    use crate::RecoveryKey;
+
+    const OBJECT_ID: &str = "019f6b9d-5ca3-7e61-8414-2be0ad5d9712";
+
+    fn key(seed: u8) -> WorkspaceKey {
+        RecoveryKey::parse(&format!(
+            "anarlog-e2ee-v1:{}",
+            base64_url_no_pad(&[seed; 32])
+        ))
+        .unwrap()
+        .workspace_key("workspace-a")
+        .unwrap()
+    }
+
+    fn context() -> AttachmentBlobContext {
+        AttachmentBlobContext::new("workspace-a", "attachment-1", OBJECT_ID).unwrap()
+    }
+
+    fn plaintext_metadata(bytes: &[u8]) -> AttachmentBlobPlaintextMetadata {
+        AttachmentBlobPlaintextMetadata::new(bytes.len() as u64, Sha256::digest(bytes).into())
+    }
+
+    fn seal(bytes: &[u8]) -> (Vec<u8>, AttachmentBlobMetadata) {
+        let mut source = Cursor::new(bytes);
+        let mut ciphertext = Vec::new();
+        let metadata = key(7)
+            .seal_attachment_blob(
+                &context(),
+                &mut source,
+                &mut ciphertext,
+                &plaintext_metadata(bytes),
+            )
+            .unwrap();
+        (ciphertext, metadata)
+    }
+
+    fn open(ciphertext: &[u8], metadata: &AttachmentBlobMetadata) -> AttachmentBlobResult<Vec<u8>> {
+        let mut source = Cursor::new(ciphertext);
+        let mut plaintext = Vec::new();
+        key(7).open_attachment_blob(&context(), &mut source, &mut plaintext, metadata)?;
+        Ok(plaintext)
+    }
+
+    #[test]
+    fn multi_chunk_blob_round_trips_with_both_hashes() {
+        let plaintext = patterned_bytes(ATTACHMENT_BLOB_CHUNK_SIZE + 731);
+        let (ciphertext, metadata) = seal(&plaintext);
+
+        let opened = open(&ciphertext, &metadata).unwrap();
+        let expected_ciphertext_sha256: [u8; 32] = Sha256::digest(&ciphertext).into();
+
+        assert_eq!(opened, plaintext);
+        assert_eq!(metadata.version, VERSION);
+        assert_eq!(metadata.plaintext, plaintext_metadata(&plaintext));
+        assert_eq!(metadata.ciphertext.size_bytes, ciphertext.len() as u64);
+        assert_eq!(metadata.ciphertext.sha256, expected_ciphertext_sha256);
+        assert!(!contains_bytes(
+            &ciphertext,
+            context().workspace_id().as_bytes()
+        ));
+        assert!(!contains_bytes(
+            &ciphertext,
+            context().attachment_id().as_bytes()
+        ));
+        assert!(!contains_bytes(&ciphertext, &plaintext[..64]));
+        assert_eq!(metadata.plaintext.sha256_hex().len(), 64);
+        assert_eq!(
+            AttachmentBlobCiphertextMetadata::from_hex(
+                metadata.ciphertext.size_bytes,
+                &metadata.ciphertext.sha256_hex(),
+            )
+            .unwrap(),
+            metadata.ciphertext,
+        );
+    }
+
+    #[test]
+    fn empty_blob_round_trips_without_chunks() {
+        let (ciphertext, metadata) = seal(&[]);
+
+        assert_eq!(open(&ciphertext, &metadata).unwrap(), Vec::<u8>::new());
+        assert_eq!(metadata.plaintext.size_bytes, 0);
+        assert_eq!(
+            ciphertext.len() as u64,
+            encoded_size(&context(), key(7).key_id(), 0).unwrap()
+        );
+    }
+
+    #[test]
+    fn ciphertext_size_is_available_before_object_reservation() {
+        for plaintext_size in [
+            0,
+            1,
+            ATTACHMENT_BLOB_CHUNK_SIZE as u64,
+            ATTACHMENT_BLOB_CHUNK_SIZE as u64 + 1,
+            ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES,
+        ] {
+            assert_eq!(
+                key(7)
+                    .attachment_blob_ciphertext_size(
+                        context().workspace_id(),
+                        context().attachment_id(),
+                        plaintext_size,
+                    )
+                    .unwrap(),
+                encoded_size(&context(), key(7).key_id(), plaintext_size).unwrap(),
+            );
+        }
+    }
+
+    #[test]
+    fn repeated_seals_use_fresh_header_and_chunk_nonces() {
+        let plaintext = patterned_bytes(ATTACHMENT_BLOB_CHUNK_SIZE + 1);
+        let (first, first_metadata) = seal(&plaintext);
+        let (second, second_metadata) = seal(&plaintext);
+
+        assert_ne!(first, second);
+        assert_ne!(
+            first_metadata.ciphertext.sha256,
+            second_metadata.ciphertext.sha256
+        );
+        assert_eq!(open(&first, &first_metadata).unwrap(), plaintext);
+        assert_eq!(open(&second, &second_metadata).unwrap(), plaintext);
+
+        let keys = derive_blob_keys(&key(7), &context()).unwrap();
+        assert_ne!(keys.header.as_slice(), keys.chunk.as_slice());
+    }
+
+    #[test]
+    fn blind_backup_refs_are_stable_opaque_and_domain_separated() {
+        let workspace_key = key(7);
+        let plaintext = plaintext_metadata(b"payload");
+        let attachment_ref = workspace_key
+            .blind_attachment_backup_ref("workspace-a", "attachment-1")
+            .unwrap();
+        let version_ref = workspace_key
+            .blind_attachment_backup_version_ref("workspace-a", "attachment-1", &plaintext)
+            .unwrap();
+
+        assert_eq!(attachment_ref.len(), 43);
+        assert_eq!(version_ref.len(), 43);
+        assert_eq!(URL_SAFE_NO_PAD.decode(&attachment_ref).unwrap().len(), 32);
+        assert_eq!(URL_SAFE_NO_PAD.decode(&version_ref).unwrap().len(), 32);
+        assert_ne!(attachment_ref, version_ref);
+        assert_eq!(
+            workspace_key
+                .blind_attachment_backup_ref("workspace-a", "attachment-1")
+                .unwrap(),
+            attachment_ref
+        );
+        assert_eq!(
+            workspace_key
+                .blind_attachment_backup_version_ref("workspace-a", "attachment-1", &plaintext,)
+                .unwrap(),
+            version_ref
+        );
+    }
+
+    #[test]
+    fn blind_backup_refs_change_with_identity_key_content_and_size() {
+        let workspace_key = key(7);
+        let attachment_ref = workspace_key
+            .blind_attachment_backup_ref("workspace-a", "attachment-1")
+            .unwrap();
+        assert_ne!(
+            workspace_key
+                .blind_attachment_backup_ref("workspace-b", "attachment-1")
+                .unwrap(),
+            attachment_ref
+        );
+        assert_ne!(
+            workspace_key
+                .blind_attachment_backup_ref("workspace-a", "attachment-2")
+                .unwrap(),
+            attachment_ref
+        );
+        assert_ne!(
+            key(8)
+                .blind_attachment_backup_ref("workspace-a", "attachment-1")
+                .unwrap(),
+            attachment_ref
+        );
+
+        let original = plaintext_metadata(b"payload");
+        let original_ref = workspace_key
+            .blind_attachment_backup_version_ref("workspace-a", "attachment-1", &original)
+            .unwrap();
+        let changed_hash = AttachmentBlobPlaintextMetadata::new(original.size_bytes, [9; 32]);
+        let changed_size =
+            AttachmentBlobPlaintextMetadata::new(original.size_bytes + 1, original.sha256);
+        assert_ne!(
+            workspace_key
+                .blind_attachment_backup_version_ref("workspace-a", "attachment-1", &changed_hash,)
+                .unwrap(),
+            original_ref
+        );
+        assert_ne!(
+            workspace_key
+                .blind_attachment_backup_version_ref("workspace-a", "attachment-1", &changed_size,)
+                .unwrap(),
+            original_ref
+        );
+
+        let other_object = AttachmentBlobContext::new(
+            "workspace-a",
+            "attachment-1",
+            "019f6b9d-5ca3-7e61-8414-2be0ad5d9713",
+        )
+        .unwrap();
+        assert_eq!(
+            workspace_key
+                .blind_attachment_backup_ref(
+                    other_object.workspace_id(),
+                    other_object.attachment_id(),
+                )
+                .unwrap(),
+            attachment_ref
+        );
+    }
+
+    #[test]
+    fn blind_backup_refs_validate_identity_and_plaintext_size() {
+        let workspace_key = key(7);
+        let plaintext = plaintext_metadata(b"payload");
+        assert!(
+            workspace_key
+                .blind_attachment_backup_ref("", "attachment-1")
+                .is_err()
+        );
+        assert!(
+            workspace_key
+                .blind_attachment_backup_ref("workspace-a", " attachment-1")
+                .is_err()
+        );
+        assert!(
+            workspace_key
+                .blind_attachment_backup_ref(
+                    "workspace-a",
+                    &"a".repeat(MAX_ATTACHMENT_ID_BYTES + 1),
+                )
+                .is_err()
+        );
+        assert!(
+            workspace_key
+                .blind_attachment_backup_version_ref(
+                    "workspace-a",
+                    "attachment-1",
+                    &AttachmentBlobPlaintextMetadata::new(
+                        ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES + 1,
+                        plaintext.sha256,
+                    ),
+                )
+                .is_err()
+        );
+    }
+
+    #[test]
+    fn header_and_chunk_tampering_fail_authentication() {
+        let plaintext = patterned_bytes(ATTACHMENT_BLOB_CHUNK_SIZE + 1);
+        let (ciphertext, metadata) = seal(&plaintext);
+        let chunk_start = chunk_start(&ciphertext);
+
+        let mut header_tampered = ciphertext.clone();
+        header_tampered[FIXED_PREFIX_BYTES] ^= 0x80;
+        assert!(matches!(
+            open(&header_tampered, &metadata),
+            Err(AttachmentBlobError::AuthenticationFailed)
+        ));
+
+        let mut chunk_tampered = ciphertext;
+        chunk_tampered[chunk_start] ^= 0x80;
+        assert!(matches!(
+            open(&chunk_tampered, &metadata),
+            Err(AttachmentBlobError::AuthenticationFailed)
+        ));
+    }
+
+    #[test]
+    fn truncation_and_trailing_data_are_rejected() {
+        let (mut ciphertext, metadata) = seal(b"payload");
+        let last = ciphertext.pop().unwrap();
+        assert!(matches!(
+            open(&ciphertext, &metadata),
+            Err(AttachmentBlobError::Truncated)
+        ));
+
+        ciphertext.push(last);
+        ciphertext.push(0);
+        assert!(matches!(
+            open(&ciphertext, &metadata),
+            Err(AttachmentBlobError::TrailingData)
+        ));
+    }
+
+    #[test]
+    fn reordered_chunks_are_rejected() {
+        let plaintext = patterned_bytes(ATTACHMENT_BLOB_CHUNK_SIZE * 2);
+        let (mut ciphertext, metadata) = seal(&plaintext);
+        let first_start = chunk_start(&ciphertext);
+        let chunk_ciphertext_size = ATTACHMENT_BLOB_CHUNK_SIZE + AEAD_TAG_BYTES as usize;
+        let second_start = first_start + chunk_ciphertext_size;
+        for offset in 0..chunk_ciphertext_size {
+            ciphertext.swap(first_start + offset, second_start + offset);
+        }
+
+        assert!(matches!(
+            open(&ciphertext, &metadata),
+            Err(AttachmentBlobError::AuthenticationFailed)
+        ));
+    }
+
+    #[test]
+    fn wrong_context_key_and_version_are_rejected() {
+        let (mut ciphertext, metadata) = seal(b"secret");
+
+        for wrong_context in [
+            AttachmentBlobContext::new("workspace-b", "attachment-1", OBJECT_ID).unwrap(),
+            AttachmentBlobContext::new("workspace-a", "attachment-2", OBJECT_ID).unwrap(),
+            AttachmentBlobContext::new(
+                "workspace-a",
+                "attachment-1",
+                "019f6b9d-5ca3-7e61-8414-2be0ad5d9713",
+            )
+            .unwrap(),
+        ] {
+            let mut source = Cursor::new(&ciphertext);
+            let mut plaintext = Vec::new();
+            assert!(
+                key(7)
+                    .open_attachment_blob(&wrong_context, &mut source, &mut plaintext, &metadata,)
+                    .is_err()
+            );
+        }
+
+        let mut source = Cursor::new(&ciphertext);
+        let mut plaintext = Vec::new();
+        assert!(
+            key(8)
+                .open_attachment_blob(&context(), &mut source, &mut plaintext, &metadata,)
+                .is_err()
+        );
+
+        ciphertext[MAGIC.len()] = 2;
+        assert!(matches!(
+            open(&ciphertext, &metadata),
+            Err(AttachmentBlobError::UnsupportedVersion)
+        ));
+    }
+
+    #[test]
+    fn source_size_and_hash_mismatches_are_rejected() {
+        let bytes = b"payload";
+        let mut destination = Vec::new();
+        let mut shorter_source = Cursor::new(bytes);
+        let too_large = AttachmentBlobPlaintextMetadata::new(
+            bytes.len() as u64 + 1,
+            Sha256::digest(bytes).into(),
+        );
+        assert!(matches!(
+            key(7).seal_attachment_blob(
+                &context(),
+                &mut shorter_source,
+                &mut destination,
+                &too_large,
+            ),
+            Err(AttachmentBlobError::SourceMismatch)
+        ));
+
+        destination.clear();
+        let mut longer_source = Cursor::new(bytes);
+        let too_small = AttachmentBlobPlaintextMetadata::new(
+            bytes.len() as u64 - 1,
+            Sha256::digest(&bytes[..bytes.len() - 1]).into(),
+        );
+        assert!(matches!(
+            key(7).seal_attachment_blob(
+                &context(),
+                &mut longer_source,
+                &mut destination,
+                &too_small,
+            ),
+            Err(AttachmentBlobError::SourceMismatch)
+        ));
+
+        destination.clear();
+        let mut source = Cursor::new(bytes);
+        let wrong_hash = AttachmentBlobPlaintextMetadata::new(bytes.len() as u64, [0; 32]);
+        assert!(matches!(
+            key(7).seal_attachment_blob(&context(), &mut source, &mut destination, &wrong_hash,),
+            Err(AttachmentBlobError::SourceMismatch)
+        ));
+    }
+
+    #[test]
+    fn ciphertext_digest_mismatch_is_rejected() {
+        let (ciphertext, mut metadata) = seal(b"payload");
+        metadata.ciphertext.sha256 = [0; 32];
+
+        assert!(matches!(
+            open(&ciphertext, &metadata),
+            Err(AttachmentBlobError::CiphertextMismatch)
+        ));
+    }
+
+    #[test]
+    fn plaintext_limit_is_enforced_before_reading() {
+        let metadata =
+            AttachmentBlobPlaintextMetadata::new(ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES + 1, [0; 32]);
+        let mut source = Cursor::new(Vec::<u8>::new());
+        let mut destination = Vec::new();
+
+        assert!(matches!(
+            key(7).seal_attachment_blob(&context(), &mut source, &mut destination, &metadata,),
+            Err(AttachmentBlobError::PlaintextTooLarge)
+        ));
+        assert!(destination.is_empty());
+
+        let (ciphertext, mut blob_metadata) = seal(&[]);
+        blob_metadata.plaintext.size_bytes = ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES + 1;
+        let mut source = Cursor::new(ciphertext);
+        let mut destination = Vec::new();
+        assert!(matches!(
+            key(7).open_attachment_blob(&context(), &mut source, &mut destination, &blob_metadata,),
+            Err(AttachmentBlobError::PlaintextTooLarge)
+        ));
+        assert_eq!(source.position(), 0);
+        assert!(destination.is_empty());
+        assert_eq!(
+            chunk_count(ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES),
+            (ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES / ATTACHMENT_BLOB_CHUNK_SIZE as u64) as u32
+        );
+        assert!(
+            encoded_size(
+                &context(),
+                key(7).key_id(),
+                ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES,
+            )
+            .is_ok()
+        );
+    }
+
+    #[test]
+    fn context_and_hex_metadata_are_strict() {
+        assert!(AttachmentBlobContext::new("", "attachment", OBJECT_ID).is_err());
+        assert!(AttachmentBlobContext::new("workspace", " attachment", OBJECT_ID).is_err());
+        assert!(
+            AttachmentBlobContext::new(
+                "workspace",
+                "attachment",
+                "019F6B9D-5CA3-7E61-8414-2BE0AD5D9712",
+            )
+            .is_err()
+        );
+        assert!(
+            AttachmentBlobContext::new(
+                "workspace",
+                "attachment",
+                "00000000-0000-0000-0000-000000000000",
+            )
+            .is_err()
+        );
+        assert!(AttachmentBlobPlaintextMetadata::from_hex(1, "not-a-hash").is_err());
+        assert!(
+            AttachmentBlobPlaintextMetadata::from_hex(
+                1,
+                "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA",
+            )
+            .is_err()
+        );
+    }
+
+    fn patterned_bytes(length: usize) -> Vec<u8> {
+        (0..length).map(|index| (index % 251) as u8).collect()
+    }
+
+    fn chunk_start(ciphertext: &[u8]) -> usize {
+        let header_length = u32::from_be_bytes(
+            ciphertext[FIXED_PREFIX_BYTES - 4..FIXED_PREFIX_BYTES]
+                .try_into()
+                .unwrap(),
+        ) as usize;
+        FIXED_PREFIX_BYTES + header_length
+    }
+
+    fn contains_bytes(haystack: &[u8], needle: &[u8]) -> bool {
+        haystack
+            .windows(needle.len())
+            .any(|window| window == needle)
+    }
+
+    fn base64_url_no_pad(bytes: &[u8]) -> String {
+        use base64::Engine as _;
+
+        base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(bytes)
+    }
+}

--- a/crates/e2ee/src/lib.rs
+++ b/crates/e2ee/src/lib.rs
@@ -1,5 +1,13 @@
 #![forbid(unsafe_code)]
 
+mod blob;
+
+pub use blob::{
+    ATTACHMENT_BLOB_CHUNK_SIZE, ATTACHMENT_BLOB_MAX_PLAINTEXT_BYTES,
+    AttachmentBlobCiphertextMetadata, AttachmentBlobContext, AttachmentBlobError,
+    AttachmentBlobMetadata, AttachmentBlobPlaintextMetadata, AttachmentBlobResult,
+};
+
 use base64::Engine;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use chacha20poly1305::aead::{Aead, Payload};

--- a/crates/supabase-storage/Cargo.toml
+++ b/crates/supabase-storage/Cargo.toml
@@ -6,10 +6,14 @@ edition = "2024"
 [dependencies]
 hypr-observability = { workspace = true }
 
-reqwest = { workspace = true, features = ["json"] }
+futures-util = { workspace = true }
+reqwest = { workspace = true, features = ["json", "stream"] }
 serde = { workspace = true, features = ["derive"] }
 serde_json = { workspace = true }
+sha2 = { workspace = true }
 thiserror = { workspace = true }
+urlencoding = { workspace = true }
 
 [dev-dependencies]
 tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+wiremock = { workspace = true }

--- a/crates/supabase-storage/src/lib.rs
+++ b/crates/supabase-storage/src/lib.rs
@@ -1,9 +1,18 @@
+use std::time::Duration;
+
+use futures_util::StreamExt;
 use serde::Deserialize;
+use sha2::{Digest, Sha256};
+
+const MAX_STORAGE_RESPONSE_BYTES: usize = 64 * 1024;
+const OBJECT_VERIFICATION_TIMEOUT: Duration = Duration::from_secs(10 * 60);
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
     #[error("request failed: {0}")]
     Request(#[from] reqwest::Error),
+    #[error("the storage object path is invalid")]
+    InvalidPath,
     #[error("{0}")]
     Api(String),
 }
@@ -19,6 +28,64 @@ pub struct SupabaseStorage {
 struct SignedUrlResponse {
     #[serde(alias = "signedURL")]
     signed_url: Option<String>,
+}
+
+#[derive(Clone, PartialEq, Eq)]
+pub struct SignedUpload {
+    pub signed_url: String,
+    pub token: String,
+}
+
+impl std::fmt::Debug for SignedUpload {
+    fn fmt(&self, formatter: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        formatter
+            .debug_struct("SignedUpload")
+            .field("signed_url", &"[REDACTED]")
+            .field("token", &"[REDACTED]")
+            .finish()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObjectInfo {
+    pub size_bytes: u64,
+    pub content_type: String,
+    pub ciphertext_sha256: String,
+    pub format_version: u8,
+}
+
+#[derive(Deserialize)]
+struct SignedUploadResponse {
+    url: String,
+}
+
+#[derive(Deserialize)]
+struct ObjectInfoResponse {
+    size: Option<u64>,
+    content_type: Option<String>,
+    metadata: Option<ObjectMetadata>,
+    user_metadata: Option<ObjectUserMetadata>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectMetadata {
+    size: Option<u64>,
+    mimetype: Option<String>,
+    ciphertext_sha256: Option<String>,
+    format_version: Option<u8>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ObjectUserMetadata {
+    ciphertext_sha256: Option<String>,
+    format_version: Option<u8>,
+}
+
+#[derive(Deserialize)]
+struct StorageErrorResponse {
+    code: Option<String>,
 }
 
 impl SupabaseStorage {
@@ -38,56 +105,307 @@ impl SupabaseStorage {
         )
     }
 
+    async fn read_response(
+        response: reqwest::Response,
+        operation: &str,
+    ) -> Result<(reqwest::StatusCode, Vec<u8>), Error> {
+        let status = response.status();
+        if response
+            .content_length()
+            .is_some_and(|length| length > MAX_STORAGE_RESPONSE_BYTES as u64)
+        {
+            return Err(Error::Api(format!(
+                "{operation} response from Supabase Storage was too large"
+            )));
+        }
+
+        let mut body = Vec::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            if body.len().saturating_add(chunk.len()) > MAX_STORAGE_RESPONSE_BYTES {
+                return Err(Error::Api(format!(
+                    "{operation} response from Supabase Storage was too large"
+                )));
+            }
+            body.extend_from_slice(&chunk);
+        }
+        Ok((status, body))
+    }
+
+    fn object_url(
+        &self,
+        operation: &str,
+        bucket: &str,
+        object_path: &str,
+    ) -> Result<String, Error> {
+        if bucket.is_empty()
+            || bucket.len() > 100
+            || bucket.contains(['/', '\\'])
+            || bucket.chars().any(char::is_control)
+            || object_path.is_empty()
+            || object_path.len() > 1024
+            || object_path.contains('\\')
+            || object_path.chars().any(char::is_control)
+        {
+            return Err(Error::InvalidPath);
+        }
+
+        let segments = object_path
+            .split('/')
+            .map(|segment| {
+                if segment.is_empty() || matches!(segment, "." | "..") {
+                    return Err(Error::InvalidPath);
+                }
+                Ok(urlencoding::encode(segment))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(format!(
+            "{}/storage/v1/{operation}/{}/{}",
+            self.base_url,
+            urlencoding::encode(bucket),
+            segments.join("/")
+        ))
+    }
+
+    fn validate_signed_object_url(
+        &self,
+        raw_url: &str,
+        operation: &str,
+        bucket: &str,
+        object_path: &str,
+        require_token: bool,
+    ) -> Result<String, Error> {
+        let expected = reqwest::Url::parse(&self.object_url(operation, bucket, object_path)?)
+            .map_err(|_| Error::Api("Supabase Storage URL is invalid".to_string()))?;
+        let absolute = if raw_url.starts_with('/') {
+            format!("{}/storage/v1{raw_url}", self.base_url)
+        } else {
+            raw_url.to_string()
+        };
+        let signed = reqwest::Url::parse(&absolute)
+            .map_err(|_| Error::Api("signed URL was not returned by Supabase Storage".into()))?;
+        let has_token = signed
+            .query_pairs()
+            .any(|(name, value)| name == "token" && !value.is_empty());
+
+        if signed.scheme() != expected.scheme()
+            || signed.host_str() != expected.host_str()
+            || signed.port_or_known_default() != expected.port_or_known_default()
+            || !signed.username().is_empty()
+            || signed.password().is_some()
+            || signed.path() != expected.path()
+            || signed.fragment().is_some()
+            || (require_token && !has_token)
+        {
+            return Err(Error::Api(
+                "signed URL was not returned by Supabase Storage".to_string(),
+            ));
+        }
+
+        Ok(absolute)
+    }
+
     pub async fn create_signed_url(
         &self,
         bucket: &str,
         object_path: &str,
         expires_in_seconds: u64,
     ) -> Result<String, Error> {
+        let url = self.object_url("object/sign", bucket, object_path)?;
         let response = self
-            .auth_headers(self.client.post(format!(
-                "{}/storage/v1/object/sign/{bucket}/{object_path}",
-                self.base_url
-            )))
+            .auth_headers(self.client.post(url))
             .json(&serde_json::json!({ "expiresIn": expires_in_seconds }))
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            return Err(Error::Api(format!(
-                "failed to create signed URL: {status} {body}"
-            )));
+        let (status, body) = Self::read_response(response, "signed URL").await?;
+        if !status.is_success() {
+            return Err(Error::Api(format!("failed to create signed URL: {status}")));
         }
 
-        let data: SignedUrlResponse = response.json().await?;
-        let signed_url = data
+        let data: SignedUrlResponse = serde_json::from_slice(&body)
+            .map_err(|_| Error::Api("signed URL response was invalid".to_string()))?;
+        let raw_url = data
             .signed_url
             .ok_or_else(|| Error::Api("signed URL not returned from Supabase".into()))?;
-
-        if signed_url.starts_with("http") {
-            Ok(signed_url)
-        } else {
-            Ok(format!("{}/storage/v1{signed_url}", self.base_url))
-        }
+        self.validate_signed_object_url(&raw_url, "object/sign", bucket, object_path, true)
     }
 
-    pub async fn delete_file(&self, bucket: &str, object_path: &str) -> Result<(), Error> {
+    pub async fn create_signed_upload(
+        &self,
+        bucket: &str,
+        object_path: &str,
+    ) -> Result<SignedUpload, Error> {
+        let url = self.object_url("object/upload/sign", bucket, object_path)?;
         let response = self
-            .auth_headers(self.client.delete(format!(
-                "{}/storage/v1/object/{bucket}/{object_path}",
-                self.base_url
-            )))
+            .auth_headers(self.client.post(url))
+            .json(&serde_json::json!({}))
             .send()
             .await?;
 
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
+        let (status, body) = Self::read_response(response, "signed upload").await?;
+        if !status.is_success() {
             return Err(Error::Api(format!(
-                "failed to delete file: {status} {body}"
+                "failed to create signed upload: {status}"
             )));
+        }
+
+        let data: SignedUploadResponse = serde_json::from_slice(&body)
+            .map_err(|_| Error::Api("signed upload response was invalid".to_string()))?;
+        let signed_url = self
+            .validate_signed_object_url(&data.url, "object/upload/sign", bucket, object_path, false)
+            .map_err(|_| {
+                Error::Api("signed upload URL was not returned by Supabase Storage".to_string())
+            })?;
+        let token = reqwest::Url::parse(&signed_url)
+            .ok()
+            .and_then(|url| {
+                url.query_pairs()
+                    .find(|(name, _)| name == "token")
+                    .map(|(_, value)| value.into_owned())
+            })
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| Error::Api("signed upload token was not returned".to_string()))?;
+
+        Ok(SignedUpload { signed_url, token })
+    }
+
+    pub async fn object_info(&self, bucket: &str, object_path: &str) -> Result<ObjectInfo, Error> {
+        let url = self.object_url("object/info", bucket, object_path)?;
+        let response = self.auth_headers(self.client.get(url)).send().await?;
+        let (status, body) = Self::read_response(response, "object info").await?;
+        if !status.is_success() {
+            return Err(Error::Api(format!("failed to read object info: {status}")));
+        }
+
+        let data: ObjectInfoResponse = serde_json::from_slice(&body)
+            .map_err(|_| Error::Api("storage object info response was invalid".to_string()))?;
+        let size_bytes = data
+            .size
+            .or_else(|| data.metadata.as_ref().and_then(|metadata| metadata.size))
+            .ok_or_else(|| Error::Api("storage object size was not returned".to_string()))?;
+        let content_type = data
+            .content_type
+            .or_else(|| {
+                data.metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.mimetype.clone())
+            })
+            .filter(|value| !value.trim().is_empty())
+            .ok_or_else(|| {
+                Error::Api("storage object content type was not returned".to_string())
+            })?;
+        let ciphertext_sha256 = data
+            .user_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.ciphertext_sha256.clone())
+            .or_else(|| {
+                data.metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.ciphertext_sha256.clone())
+            })
+            .filter(|value| {
+                value.len() == 64
+                    && value
+                        .bytes()
+                        .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
+            })
+            .ok_or_else(|| {
+                Error::Api("storage object ciphertext checksum was not returned".to_string())
+            })?;
+        let format_version = data
+            .user_metadata
+            .as_ref()
+            .and_then(|metadata| metadata.format_version)
+            .or_else(|| {
+                data.metadata
+                    .as_ref()
+                    .and_then(|metadata| metadata.format_version)
+            })
+            .filter(|version| *version == 1)
+            .ok_or_else(|| {
+                Error::Api("storage object format version was not returned".to_string())
+            })?;
+
+        Ok(ObjectInfo {
+            size_bytes,
+            content_type,
+            ciphertext_sha256,
+            format_version,
+        })
+    }
+
+    pub async fn object_sha256(
+        &self,
+        bucket: &str,
+        object_path: &str,
+        expected_size_bytes: u64,
+    ) -> Result<String, Error> {
+        let url = self.object_url("object/authenticated", bucket, object_path)?;
+        let response = self
+            .auth_headers(self.client.get(url))
+            .timeout(OBJECT_VERIFICATION_TIMEOUT)
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            let (status, _) = Self::read_response(response, "object verification").await?;
+            return Err(Error::Api(format!(
+                "failed to verify storage object: {status}"
+            )));
+        }
+        if response
+            .content_length()
+            .is_some_and(|size| size != expected_size_bytes)
+        {
+            return Err(Error::Api(
+                "storage object size did not match its reservation".to_string(),
+            ));
+        }
+
+        let mut size_bytes = 0_u64;
+        let mut digest = Sha256::new();
+        let mut stream = response.bytes_stream();
+        while let Some(chunk) = stream.next().await {
+            let chunk = chunk?;
+            size_bytes = size_bytes
+                .checked_add(chunk.len() as u64)
+                .ok_or_else(|| Error::Api("storage object was too large".to_string()))?;
+            if size_bytes > expected_size_bytes {
+                return Err(Error::Api(
+                    "storage object size did not match its reservation".to_string(),
+                ));
+            }
+            digest.update(&chunk);
+        }
+        if size_bytes != expected_size_bytes {
+            return Err(Error::Api(
+                "storage object size did not match its reservation".to_string(),
+            ));
+        }
+
+        let checksum = digest.finalize();
+        let mut encoded = String::with_capacity(checksum.len() * 2);
+        for byte in checksum {
+            encoded.push(char::from(b"0123456789abcdef"[(byte >> 4) as usize]));
+            encoded.push(char::from(b"0123456789abcdef"[(byte & 0x0f) as usize]));
+        }
+        Ok(encoded)
+    }
+
+    pub async fn delete_file(&self, bucket: &str, object_path: &str) -> Result<(), Error> {
+        let url = self.object_url("object", bucket, object_path)?;
+        let response = self.auth_headers(self.client.delete(url)).send().await?;
+        let (status, body) = Self::read_response(response, "delete").await?;
+        if !status.is_success() {
+            let code = serde_json::from_slice::<StorageErrorResponse>(&body)
+                .ok()
+                .and_then(|error| error.code);
+            if status == reqwest::StatusCode::NOT_FOUND && code.as_deref() == Some("NoSuchKey") {
+                return Ok(());
+            }
+            return Err(Error::Api(format!("failed to delete file: {status}")));
         }
 
         Ok(())

--- a/crates/supabase-storage/tests/client.rs
+++ b/crates/supabase-storage/tests/client.rs
@@ -1,0 +1,389 @@
+use supabase_storage::{Error, SupabaseStorage};
+use wiremock::matchers::{body_json, header, method, path};
+use wiremock::{Mock, MockServer, ResponseTemplate};
+
+fn storage(server: &MockServer) -> SupabaseStorage {
+    SupabaseStorage::new(reqwest::Client::new(), &server.uri(), "service-secret")
+}
+
+#[tokio::test]
+async fn creates_an_origin_and_path_bound_signed_download() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/storage/v1/object/sign/attachment-backups/user-id/object.anb1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "signedURL": "/object/sign/attachment-backups/user-id/object.anb1?token=download-token"
+        })))
+        .mount(&server)
+        .await;
+
+    let url = storage(&server)
+        .create_signed_url("attachment-backups", "user-id/object.anb1", 300)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        url,
+        format!(
+            "{}/storage/v1/object/sign/attachment-backups/user-id/object.anb1?token=download-token",
+            server.uri()
+        )
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_signed_download_for_another_origin_or_object() {
+    for returned_url in [
+        "https://attacker.example/object?token=stolen",
+        "/object/sign/attachment-backups/user-id/other.anb1?token=valid",
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "signedURL": returned_url
+            })))
+            .mount(&server)
+            .await;
+
+        let error = storage(&server)
+            .create_signed_url("attachment-backups", "user-id/object.anb1", 300)
+            .await
+            .unwrap_err();
+
+        assert!(
+            error
+                .to_string()
+                .contains("not returned by Supabase Storage")
+        );
+    }
+}
+
+#[tokio::test]
+async fn bounds_and_redacts_storage_responses() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_string("x".repeat(64 * 1024 + 1)))
+        .mount(&server)
+        .await;
+
+    let error = storage(&server)
+        .create_signed_url("attachment-backups", "user-id/object.anb1", 300)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("too large"));
+    assert!(!error.to_string().contains(&"x".repeat(100)));
+}
+
+#[tokio::test]
+async fn creates_an_immutable_signed_upload() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path(
+            "/storage/v1/object/upload/sign/attachment-backups/user-id/object.anb1",
+        ))
+        .and(header("authorization", "Bearer service-secret"))
+        .and(header("apikey", "service-secret"))
+        .and(body_json(serde_json::json!({})))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "url": "/object/upload/sign/attachment-backups/user-id/object.anb1?token=upload-token"
+        })))
+        .mount(&server)
+        .await;
+
+    let upload = storage(&server)
+        .create_signed_upload("attachment-backups", "user-id/object.anb1")
+        .await
+        .unwrap();
+
+    assert_eq!(upload.token, "upload-token");
+    assert_eq!(
+        format!("{upload:?}"),
+        "SignedUpload { signed_url: \"[REDACTED]\", token: \"[REDACTED]\" }"
+    );
+    assert_eq!(
+        upload.signed_url,
+        format!(
+            "{}/storage/v1/object/upload/sign/attachment-backups/user-id/object.anb1?token=upload-token",
+            server.uri()
+        )
+    );
+}
+
+#[tokio::test]
+async fn rejects_a_signed_upload_without_a_token() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "url": "/object/upload/sign/attachment-backups/user-id/object.anb1"
+        })))
+        .mount(&server)
+        .await;
+
+    let error = storage(&server)
+        .create_signed_upload("attachment-backups", "user-id/object.anb1")
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("token was not returned"));
+}
+
+#[tokio::test]
+async fn rejects_a_signed_upload_from_an_unexpected_origin() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "url": "https://attacker.example/upload?token=stolen"
+        })))
+        .mount(&server)
+        .await;
+
+    let error = storage(&server)
+        .create_signed_upload("attachment-backups", "user-id/object.anb1")
+        .await
+        .unwrap_err();
+
+    assert!(
+        error
+            .to_string()
+            .contains("not returned by Supabase Storage")
+    );
+}
+
+#[tokio::test]
+async fn reads_storage_object_metadata() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/storage/v1/object/info/attachment-backups/user-id/object.anb1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "id": "object-id",
+            "size": 6291456,
+            "content_type": "application/octet-stream",
+            "metadata": {
+                "ciphertextSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "formatVersion": 1
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let info = storage(&server)
+        .object_info("attachment-backups", "user-id/object.anb1")
+        .await
+        .unwrap();
+
+    assert_eq!(info.size_bytes, 6_291_456);
+    assert_eq!(info.content_type, "application/octet-stream");
+    assert_eq!(info.ciphertext_sha256, "a".repeat(64));
+    assert_eq!(info.format_version, 1);
+}
+
+#[tokio::test]
+async fn reads_legacy_storage_object_metadata() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+            "metadata": {
+                "size": 42,
+                "mimetype": "application/octet-stream"
+            },
+            "user_metadata": {
+                "ciphertextSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                "formatVersion": 1
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let info = storage(&server)
+        .object_info("attachment-backups", "user-id/object.anb1")
+        .await
+        .unwrap();
+
+    assert_eq!(info.size_bytes, 42);
+    assert_eq!(info.content_type, "application/octet-stream");
+    assert_eq!(info.ciphertext_sha256, "a".repeat(64));
+    assert_eq!(info.format_version, 1);
+}
+
+#[tokio::test]
+async fn reads_storage_object_metadata_split_across_response_fields() {
+    for metadata in [
+        serde_json::json!({
+            "size": 42,
+            "content_type": "application/octet-stream",
+            "metadata": {
+                "ciphertextSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            },
+            "user_metadata": {
+                "formatVersion": 1
+            }
+        }),
+        serde_json::json!({
+            "size": 42,
+            "content_type": "application/octet-stream",
+            "metadata": {
+                "formatVersion": 1
+            },
+            "user_metadata": {
+                "ciphertextSha256": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+            }
+        }),
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(metadata))
+            .mount(&server)
+            .await;
+
+        let info = storage(&server)
+            .object_info("attachment-backups", "user-id/object.anb1")
+            .await
+            .unwrap();
+
+        assert_eq!(info.ciphertext_sha256, "a".repeat(64));
+        assert_eq!(info.format_version, 1);
+    }
+}
+
+#[tokio::test]
+async fn rejects_missing_or_malformed_private_object_metadata() {
+    for user_metadata in [
+        serde_json::json!(null),
+        serde_json::json!({
+            "ciphertextSha256": "not-a-checksum",
+            "formatVersion": 1
+        }),
+        serde_json::json!({
+            "ciphertextSha256": "a".repeat(64),
+            "formatVersion": 2
+        }),
+    ] {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "size": 42,
+                "content_type": "application/octet-stream",
+                "metadata": user_metadata
+            })))
+            .mount(&server)
+            .await;
+
+        let error = storage(&server)
+            .object_info("attachment-backups", "user-id/object.anb1")
+            .await
+            .unwrap_err();
+
+        assert!(error.to_string().contains("storage object"));
+    }
+}
+
+#[tokio::test]
+async fn streams_a_trusted_storage_object_checksum() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .and(path(
+            "/storage/v1/object/authenticated/attachment-backups/user-id/object.anb1",
+        ))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes(vec![0_u8; 1_234]))
+        .mount(&server)
+        .await;
+
+    let checksum = storage(&server)
+        .object_sha256("attachment-backups", "user-id/object.anb1", 1_234)
+        .await
+        .unwrap();
+
+    assert_eq!(
+        checksum,
+        "ad47fd9e87159d651a53b3dfba3ef200684a9ed88c2528b62e18f3881fe203b0"
+    );
+}
+
+#[tokio::test]
+async fn rejects_storage_object_size_mismatches_while_hashing() {
+    let server = MockServer::start().await;
+    Mock::given(method("GET"))
+        .respond_with(ResponseTemplate::new(200).set_body_bytes([1_u8, 2, 3]))
+        .mount(&server)
+        .await;
+
+    let error = storage(&server)
+        .object_sha256("attachment-backups", "user-id/object.anb1", 4)
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("size did not match"));
+}
+
+#[tokio::test]
+async fn percent_encodes_object_path_segments() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .and(path(
+            "/storage/v1/object/attachment-backups/user-id/object%20name.anb1",
+        ))
+        .respond_with(ResponseTemplate::new(200))
+        .mount(&server)
+        .await;
+
+    storage(&server)
+        .delete_file("attachment-backups", "user-id/object name.anb1")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn deleting_a_missing_object_is_idempotent() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "statusCode": "404",
+            "code": "NoSuchKey",
+            "message": "Object not found"
+        })))
+        .mount(&server)
+        .await;
+
+    storage(&server)
+        .delete_file("attachment-backups", "user-id/missing.anb1")
+        .await
+        .unwrap();
+}
+
+#[tokio::test]
+async fn does_not_hide_other_not_found_errors() {
+    let server = MockServer::start().await;
+    Mock::given(method("DELETE"))
+        .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+            "statusCode": "404",
+            "code": "NoSuchBucket",
+            "message": "Bucket not found"
+        })))
+        .mount(&server)
+        .await;
+
+    let error = storage(&server)
+        .delete_file("attachment-backups", "user-id/object.anb1")
+        .await
+        .unwrap_err();
+
+    assert!(error.to_string().contains("failed to delete file: 404"));
+    assert!(!error.to_string().contains("Bucket not found"));
+}
+
+#[tokio::test]
+async fn rejects_traversal_before_sending_a_request() {
+    let server = MockServer::start().await;
+    let error = storage(&server)
+        .delete_file("attachment-backups", "user-id/../object.anb1")
+        .await
+        .unwrap_err();
+
+    assert!(matches!(error, Error::InvalidPath));
+    assert!(server.received_requests().await.unwrap().is_empty());
+}

--- a/packages/db/src/schema.ts
+++ b/packages/db/src/schema.ts
@@ -5,6 +5,7 @@ import {
   primaryKey,
   sqliteTable,
   text,
+  uniqueIndex,
 } from "drizzle-orm/sqlite-core";
 
 const currentTimestamp = sql`(strftime('%Y-%m-%dT%H:%M:%fZ', 'now'))`;
@@ -350,6 +351,62 @@ export const attachmentLocalState = sqliteTable(
   },
   (table) => [
     index("idx_attachment_local_state_session_id").on(table.sessionId),
+  ],
+);
+
+export const attachmentTransferJobs = sqliteTable(
+  "attachment_transfer_jobs",
+  {
+    id: text("id").primaryKey().notNull(),
+    attachmentId: text("attachment_id").notNull(),
+    sessionId: text("session_id").notNull(),
+    workspaceId: text("workspace_id").notNull(),
+    direction: text("direction").notNull(),
+    expectedSha256: text("expected_sha256").notNull(),
+    expectedSizeBytes: integer("expected_size_bytes").notNull().default(0),
+    ciphertextSha256: text("ciphertext_sha256").notNull().default(""),
+    ciphertextSizeBytes: integer("ciphertext_size_bytes").notNull().default(0),
+    remoteObjectId: text("remote_object_id").notNull().default(""),
+    objectKey: text("object_key").notNull().default(""),
+    cacheId: text("cache_id").notNull().default(""),
+    phase: text("phase").notNull().default("queued"),
+    attemptCount: integer("attempt_count").notNull().default(0),
+    nextAttemptAt: text("next_attempt_at").notNull().default(currentTimestamp),
+    lastAttemptAt: text("last_attempt_at"),
+    lastError: text("last_error").notNull().default(""),
+    createdAt: text("created_at").notNull().default(currentTimestamp),
+    updatedAt: text("updated_at").notNull().default(currentTimestamp),
+    completedAt: text("completed_at"),
+  },
+  (table) => [
+    uniqueIndex("idx_attachment_transfer_jobs_live_version")
+      .on(table.attachmentId, table.expectedSha256, table.expectedSizeBytes)
+      .where(
+        sql`${table.direction} IN ('upload', 'download') AND ${table.phase} <> 'completed'`,
+      ),
+    uniqueIndex("idx_attachment_transfer_jobs_delete_object")
+      .on(table.objectKey)
+      .where(sql`${table.direction} = 'delete'`),
+    uniqueIndex("idx_attachment_transfer_jobs_upload_object_id")
+      .on(table.remoteObjectId)
+      .where(
+        sql`${table.direction} = 'upload' AND ${table.remoteObjectId} <> ''`,
+      ),
+    uniqueIndex("idx_attachment_transfer_jobs_delete_object_id")
+      .on(table.remoteObjectId)
+      .where(
+        sql`${table.direction} = 'delete' AND ${table.remoteObjectId} <> ''`,
+      ),
+    uniqueIndex("idx_attachment_transfer_jobs_cache_id")
+      .on(table.cacheId)
+      .where(sql`${table.cacheId} <> ''`),
+    index("idx_attachment_transfer_jobs_due").on(
+      table.phase,
+      table.nextAttemptAt,
+      table.createdAt,
+    ),
+    index("idx_attachment_transfer_jobs_attachment_id").on(table.attachmentId),
+    index("idx_attachment_transfer_jobs_session_id").on(table.sessionId),
   ],
 );
 

--- a/packages/supabase/package.json
+++ b/packages/supabase/package.json
@@ -11,7 +11,8 @@
     "tus-js-client": "^4.3.1"
   },
   "devDependencies": {
-    "@types/node": "^22.19.17"
+    "@types/node": "^22.19.17",
+    "vitest": "^4.1.4"
   },
   "peerDependencies": {
     "hono": "^4.0.0"
@@ -22,6 +23,7 @@
     }
   },
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc --noEmit"
   }
 }

--- a/packages/supabase/src/storage.test.ts
+++ b/packages/supabase/src/storage.test.ts
@@ -1,0 +1,265 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+  abort: vi.fn().mockResolvedValue(undefined),
+  findPreviousUploads: vi.fn().mockResolvedValue([]),
+  instances: [] as Array<{
+    file: unknown;
+    options: Record<string, any>;
+    resumeFromPreviousUpload: ReturnType<typeof vi.fn>;
+    start: ReturnType<typeof vi.fn>;
+  }>,
+}));
+
+vi.mock("tus-js-client", () => ({
+  Upload: class {
+    file: unknown;
+    options: Record<string, any>;
+    resumeFromPreviousUpload = vi.fn();
+    start = vi.fn(() => this.options.onSuccess?.({}));
+
+    constructor(file: unknown, options: Record<string, any>) {
+      this.file = file;
+      this.options = options;
+      mocks.instances.push(this);
+    }
+
+    findPreviousUploads() {
+      return mocks.findPreviousUploads();
+    }
+
+    abort() {
+      return mocks.abort();
+    }
+  },
+}));
+
+import {
+  PRIVATE_ATTACHMENT_STORAGE_CONFIG,
+  uploadPrivateAttachment,
+} from "./storage";
+
+const USER_ID = "11111111-1111-4111-8111-111111111111";
+const OBJECT_ID = "22222222-2222-4222-8222-222222222222";
+const OBJECT_KEY = `${USER_ID}/${OBJECT_ID}.anb1`;
+
+function startUpload(
+  overrides: Partial<Parameters<typeof uploadPrivateAttachment>[0]> = {},
+) {
+  return uploadPrivateAttachment({
+    objectKey: OBJECT_KEY,
+    signedUploadToken: "signed-token",
+    ciphertextSha256: "a".repeat(64),
+    ciphertextSizeBytes: 12,
+    supabaseUrl: "https://project.supabase.co",
+    readRange: vi.fn(async (start, end) => new Uint8Array(end - start).fill(7)),
+    ...overrides,
+  });
+}
+
+describe("private attachment storage", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.instances.length = 0;
+    mocks.findPreviousUploads.mockResolvedValue([]);
+  });
+
+  it("uploads immutable ciphertext with a signed TUS grant", async () => {
+    const onProgress = vi.fn();
+    const transfer = startUpload({ onProgress });
+    const instance = mocks.instances[0]!;
+
+    instance.options.onProgress(3, 12);
+    await expect(transfer.promise).resolves.toBe(OBJECT_KEY);
+
+    expect(instance.options.endpoint).toBe(
+      "https://project.storage.supabase.co/storage/v1/upload/resumable/sign",
+    );
+    expect(instance.options.headers).toEqual({
+      "x-signature": "signed-token",
+    });
+    expect(instance.options.headers).not.toHaveProperty("authorization");
+    expect(instance.options.headers).not.toHaveProperty("x-upsert");
+    expect(instance.options.uploadSize).toBe(12);
+    expect(instance.options.chunkSize).toBe(6 * 1024 * 1024);
+    expect(instance.options.metadata).toMatchObject({
+      bucketName: "attachment-backups",
+      objectName: OBJECT_KEY,
+      contentType: "application/octet-stream",
+      cacheControl: "0",
+    });
+    expect(JSON.parse(instance.options.metadata.metadata)).toEqual({
+      formatVersion: 1,
+      ciphertextSha256: "a".repeat(64),
+    });
+    expect(onProgress).toHaveBeenCalledWith(25);
+  });
+
+  it("reads only the bounded ciphertext range requested by TUS", async () => {
+    const readRange = vi.fn(async () => new Uint8Array([1, 2, 3, 4]));
+    startUpload({ ciphertextSizeBytes: 4, readRange });
+    const source = await mocks.instances[0]!.options.fileReader.openFile();
+
+    const result = await source.slice(0, 4);
+    expect(result.done).toBe(true);
+    expect(result.value).toBeInstanceOf(Blob);
+    expect(result.value.size).toBe(4);
+    expect(new Uint8Array(await result.value.arrayBuffer())).toEqual(
+      new Uint8Array([1, 2, 3, 4]),
+    );
+    expect(readRange).toHaveBeenCalledWith(0, 4);
+    await expect(source.slice(0, 5)).rejects.toThrow("read range");
+    await expect(
+      source.slice(0, PRIVATE_ATTACHMENT_STORAGE_CONFIG.chunkSize + 1),
+    ).rejects.toThrow("read range");
+  });
+
+  it("fails closed when Rust returns an incomplete chunk", async () => {
+    startUpload({
+      ciphertextSizeBytes: 4,
+      readRange: vi.fn(async () => new Uint8Array([1, 2, 3])),
+    });
+    const source = await mocks.instances[0]!.options.fileReader.openFile();
+
+    await expect(source.slice(0, 4)).rejects.toThrow("incomplete");
+  });
+
+  it("resumes only the same ciphertext size", async () => {
+    const matching = { size: 12, uploadUrl: "matching" };
+    mocks.findPreviousUploads.mockResolvedValue([
+      { size: 9, uploadUrl: "different" },
+      matching,
+    ]);
+
+    const transfer = startUpload();
+    await transfer.promise;
+
+    expect(mocks.instances[0]!.resumeFromPreviousUpload).toHaveBeenCalledWith(
+      matching,
+    );
+  });
+
+  it("does not start after cancellation while resume lookup is pending", async () => {
+    let resolvePreviousUploads!: (value: unknown[]) => void;
+    mocks.findPreviousUploads.mockReturnValue(
+      new Promise((resolve) => {
+        resolvePreviousUploads = resolve;
+      }),
+    );
+    const transfer = startUpload();
+    const rejection = expect(transfer.promise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+
+    await transfer.abort();
+    resolvePreviousUploads([]);
+    await rejection;
+    await Promise.resolve();
+
+    expect(mocks.instances[0]!.start).not.toHaveBeenCalled();
+    expect(mocks.abort).toHaveBeenCalledOnce();
+  });
+
+  it("settles the wrapper promise when an in-flight upload is aborted", async () => {
+    const transfer = startUpload();
+    const instance = mocks.instances[0]!;
+    instance.start.mockImplementation(() => {});
+    await Promise.resolve();
+    expect(instance.start).toHaveBeenCalledOnce();
+
+    const rejection = expect(transfer.promise).rejects.toMatchObject({
+      name: "AbortError",
+    });
+    await transfer.abort();
+    await rejection;
+  });
+
+  it("feeds sized Blob chunks to the pinned TUS client", async () => {
+    startUpload({
+      ciphertextSizeBytes: 4,
+      readRange: vi.fn(async () => new Uint8Array([1, 2, 3, 4])),
+    });
+    const fileReader = mocks.instances[0]!.options.fileReader;
+    const { Upload: ActualUpload } =
+      await vi.importActual<typeof import("tus-js-client")>("tus-js-client");
+    const requestBodies: Blob[] = [];
+    const response = {
+      getStatus: () => 201,
+      getHeader: (name: string) => {
+        if (name.toLowerCase() === "location") {
+          return "/storage/v1/upload/resumable/upload-id";
+        }
+        if (name.toLowerCase() === "upload-offset") {
+          return "4";
+        }
+        return undefined;
+      },
+      getBody: () => "",
+      getUnderlyingObject: () => null,
+    };
+    const httpStack = {
+      getName: () => "test-http-stack",
+      createRequest: (method: string, url: string) => {
+        const headers = new Map<string, string>();
+        let reportProgress = (_bytesSent: number) => {};
+        return {
+          getMethod: () => method,
+          getURL: () => url,
+          setHeader: (name: string, value: string) => {
+            headers.set(name, value);
+          },
+          getHeader: (name: string) => headers.get(name),
+          setProgressHandler: (handler: (bytesSent: number) => void) => {
+            reportProgress = handler;
+          },
+          send: async (body: Blob) => {
+            requestBodies.push(body);
+            reportProgress(body.size);
+            return response;
+          },
+          abort: async () => {},
+          getUnderlyingObject: () => null,
+        };
+      },
+    };
+
+    await new Promise<void>((resolve, reject) => {
+      new ActualUpload(new Blob([]), {
+        endpoint:
+          "https://project.storage.supabase.co/storage/v1/upload/resumable/sign",
+        fileReader,
+        httpStack,
+        uploadSize: 4,
+        chunkSize: PRIVATE_ATTACHMENT_STORAGE_CONFIG.chunkSize,
+        uploadDataDuringCreation: true,
+        storeFingerprintForResuming: false,
+        retryDelays: null,
+        onSuccess: () => resolve(),
+        onError: reject,
+      }).start();
+    });
+
+    expect(requestBodies).toHaveLength(1);
+    expect(requestBodies[0]).toBeInstanceOf(Blob);
+    expect(requestBodies[0]!.size).toBe(4);
+  });
+
+  it("rejects malformed grants and object metadata before upload", () => {
+    expect(() => startUpload({ objectKey: "../object.anb1" })).toThrow(
+      "object key",
+    );
+    expect(() => startUpload({ signedUploadToken: "" })).toThrow(
+      "upload token",
+    );
+    expect(() => startUpload({ ciphertextSha256: "not-a-checksum" })).toThrow(
+      "checksum",
+    );
+    expect(() => startUpload({ ciphertextSizeBytes: 0 })).toThrow("size");
+  });
+
+  it("accepts UUID v7 attachment object keys", async () => {
+    const objectKey = `${USER_ID}/22222222-2222-7222-8222-222222222222.anb1`;
+
+    await expect(startUpload({ objectKey }).promise).resolves.toBe(objectKey);
+  });
+});

--- a/packages/supabase/src/storage.ts
+++ b/packages/supabase/src/storage.ts
@@ -6,6 +6,18 @@ export const STORAGE_CONFIG = {
   retryDelays: [0, 3000, 5000, 10000, 20000],
 } as const;
 
+export const PRIVATE_ATTACHMENT_STORAGE_CONFIG = {
+  bucketName: "attachment-backups",
+  contentType: "application/octet-stream",
+  chunkSize: 6 * 1024 * 1024,
+  maxCiphertextSizeBytes: 520 * 1024 * 1024,
+  retryDelays: [0, 3000, 5000, 10000, 20000],
+} as const;
+
+const PRIVATE_ATTACHMENT_OBJECT_KEY_PATTERN =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\/[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.anb1$/;
+const SHA256_PATTERN = /^[0-9a-f]{64}$/;
+
 export function getTusEndpoint(supabaseUrl: string): string {
   const parsed = new URL(supabaseUrl);
   const isHostedSupabase = parsed.hostname.endsWith(".supabase.co");
@@ -16,6 +28,10 @@ export function getTusEndpoint(supabaseUrl: string): string {
   }
 
   return new URL("/storage/v1/upload/resumable", parsed.origin).toString();
+}
+
+function getSignedTusEndpoint(supabaseUrl: string): string {
+  return `${getTusEndpoint(supabaseUrl)}/sign`;
 }
 
 export function buildObjectName(userId: string, fileName: string): string {
@@ -78,6 +94,160 @@ export function uploadAudio(options: {
     promise,
     abort: () => {
       upload?.abort();
+    },
+  };
+}
+
+export function uploadPrivateAttachment(options: {
+  objectKey: string;
+  signedUploadToken: string;
+  ciphertextSha256: string;
+  ciphertextSizeBytes: number;
+  supabaseUrl: string;
+  readRange: (start: number, end: number) => Promise<Uint8Array>;
+  onProgress?: (percentage: number) => void;
+}): { promise: Promise<string>; abort: () => Promise<void> } {
+  if (!PRIVATE_ATTACHMENT_OBJECT_KEY_PATTERN.test(options.objectKey)) {
+    throw new Error("invalid private attachment object key");
+  }
+  if (
+    options.signedUploadToken.length === 0 ||
+    options.signedUploadToken.length > 8192 ||
+    /[\u0000-\u001f\u007f]/.test(options.signedUploadToken)
+  ) {
+    throw new Error("invalid private attachment upload token");
+  }
+  if (!SHA256_PATTERN.test(options.ciphertextSha256)) {
+    throw new Error("invalid private attachment checksum");
+  }
+  if (
+    !Number.isSafeInteger(options.ciphertextSizeBytes) ||
+    options.ciphertextSizeBytes <= 0 ||
+    options.ciphertextSizeBytes >
+      PRIVATE_ATTACHMENT_STORAGE_CONFIG.maxCiphertextSizeBytes
+  ) {
+    throw new Error("invalid private attachment size");
+  }
+
+  const endpoint = getSignedTusEndpoint(options.supabaseUrl);
+  const fingerprint = [
+    "anarlog-private-attachment-v1",
+    options.objectKey,
+    options.ciphertextSizeBytes,
+    options.ciphertextSha256,
+  ].join(":");
+  let upload: Upload | null = null;
+  let cancelled = false;
+  let settled = false;
+  let rejectTransfer = (_error: Error) => {};
+
+  const promise = new Promise<string>((resolve, reject) => {
+    const settleResolve = (value: string) => {
+      if (!settled) {
+        settled = true;
+        resolve(value);
+      }
+    };
+    const settleReject = (error: Error) => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    };
+    rejectTransfer = settleReject;
+
+    upload = new Upload(new Blob([]), {
+      endpoint,
+      retryDelays: [...PRIVATE_ATTACHMENT_STORAGE_CONFIG.retryDelays],
+      headers: {
+        "x-signature": options.signedUploadToken,
+      },
+      uploadSize: options.ciphertextSizeBytes,
+      uploadDataDuringCreation: true,
+      removeFingerprintOnSuccess: true,
+      fingerprint: async () => fingerprint,
+      fileReader: {
+        openFile: async () => ({
+          size: options.ciphertextSizeBytes,
+          slice: async (start: number, end: number) => {
+            if (
+              !Number.isSafeInteger(start) ||
+              !Number.isSafeInteger(end) ||
+              start < 0 ||
+              end <= start ||
+              end > options.ciphertextSizeBytes ||
+              end - start > PRIVATE_ATTACHMENT_STORAGE_CONFIG.chunkSize
+            ) {
+              throw new Error("invalid private attachment read range");
+            }
+
+            const bytes = await options.readRange(start, end);
+            if (
+              !(bytes instanceof Uint8Array) ||
+              bytes.byteLength !== end - start
+            ) {
+              throw new Error("private attachment read was incomplete");
+            }
+
+            return {
+              value: new Blob([bytes]),
+              done: end === options.ciphertextSizeBytes,
+            };
+          },
+          close: () => {},
+        }),
+      },
+      metadata: {
+        bucketName: PRIVATE_ATTACHMENT_STORAGE_CONFIG.bucketName,
+        objectName: options.objectKey,
+        contentType: PRIVATE_ATTACHMENT_STORAGE_CONFIG.contentType,
+        cacheControl: "0",
+        metadata: JSON.stringify({
+          formatVersion: 1,
+          ciphertextSha256: options.ciphertextSha256,
+        }),
+      },
+      chunkSize: PRIVATE_ATTACHMENT_STORAGE_CONFIG.chunkSize,
+      onError: settleReject,
+      onProgress: (bytesUploaded, bytesTotal) => {
+        if (options.onProgress && bytesTotal > 0) {
+          options.onProgress((bytesUploaded / bytesTotal) * 100);
+        }
+      },
+      onSuccess: () => settleResolve(options.objectKey),
+    });
+
+    upload
+      .findPreviousUploads()
+      .then((previousUploads) => {
+        if (cancelled) {
+          return;
+        }
+        const previous = previousUploads.find(
+          (candidate) => candidate.size === options.ciphertextSizeBytes,
+        );
+        if (previous) {
+          upload!.resumeFromPreviousUpload(previous);
+        }
+        if (cancelled) {
+          return;
+        }
+        upload!.start();
+      })
+      .catch(settleReject);
+  });
+
+  return {
+    promise,
+    abort: async () => {
+      if (cancelled || settled) {
+        return;
+      }
+      cancelled = true;
+      const error = new Error("private attachment upload aborted");
+      error.name = "AbortError";
+      rejectTransfer(error);
+      await upload?.abort();
     },
   };
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1231,6 +1231,9 @@ importers:
       '@types/node':
         specifier: ^22.19.17
         version: 22.19.17
+      vitest:
+        specifier: ^4.1.4
+        version: 4.1.4(@opentelemetry/api@1.9.1)(@types/node@22.19.17)(jsdom@26.1.0)(vite@8.0.8(@types/node@22.19.17)(esbuild@0.27.7)(jiti@2.7.0)(tsx@4.21.0)(yaml@2.9.0))
 
   packages/ui:
     dependencies:

--- a/supabase/migrations/20260717160000_private_attachment_backups.sql
+++ b/supabase/migrations/20260717160000_private_attachment_backups.sql
@@ -1,0 +1,1139 @@
+INSERT INTO storage.buckets (
+  id,
+  name,
+  public,
+  file_size_limit,
+  allowed_mime_types
+)
+VALUES (
+  'attachment-backups',
+  'attachment-backups',
+  false,
+  545259520,
+  ARRAY['application/octet-stream']::text[]
+)
+ON CONFLICT (id) DO UPDATE SET
+  name = EXCLUDED.name,
+  public = EXCLUDED.public,
+  file_size_limit = EXCLUDED.file_size_limit,
+  allowed_mime_types = EXCLUDED.allowed_mime_types;
+
+DROP POLICY IF EXISTS attachment_backups_deny_client_select
+  ON storage.objects;
+CREATE POLICY attachment_backups_deny_client_select
+  ON storage.objects
+  AS RESTRICTIVE
+  FOR SELECT
+  TO anon, authenticated
+  USING (bucket_id <> 'attachment-backups');
+
+DROP POLICY IF EXISTS attachment_backups_deny_client_insert
+  ON storage.objects;
+CREATE POLICY attachment_backups_deny_client_insert
+  ON storage.objects
+  AS RESTRICTIVE
+  FOR INSERT
+  TO anon, authenticated
+  WITH CHECK (bucket_id <> 'attachment-backups');
+
+DROP POLICY IF EXISTS attachment_backups_deny_client_update
+  ON storage.objects;
+CREATE POLICY attachment_backups_deny_client_update
+  ON storage.objects
+  AS RESTRICTIVE
+  FOR UPDATE
+  TO anon, authenticated
+  USING (bucket_id <> 'attachment-backups')
+  WITH CHECK (bucket_id <> 'attachment-backups');
+
+DROP POLICY IF EXISTS attachment_backups_deny_client_delete
+  ON storage.objects;
+CREATE POLICY attachment_backups_deny_client_delete
+  ON storage.objects
+  AS RESTRICTIVE
+  FOR DELETE
+  TO anon, authenticated
+  USING (bucket_id <> 'attachment-backups');
+
+CREATE TABLE public.attachment_backup_objects (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  owner_user_id uuid NOT NULL REFERENCES auth.users(id) ON DELETE RESTRICT,
+  attachment_ref text NOT NULL,
+  version_ref text NOT NULL,
+  object_key text NOT NULL,
+  ciphertext_size_bytes bigint NOT NULL,
+  ciphertext_sha256 text,
+  format_version smallint NOT NULL DEFAULT 1,
+  state text NOT NULL DEFAULT 'reserved',
+  reservation_expires_at timestamptz NOT NULL DEFAULT (now() + interval '15 minutes'),
+  last_signed_at timestamptz,
+  upload_expires_at timestamptz,
+  cleanup_not_before timestamptz NOT NULL DEFAULT (now() + interval '15 minutes'),
+  finalized_at timestamptz,
+  deletion_requested_at timestamptz,
+  gc_lease_id uuid,
+  gc_lease_expires_at timestamptz,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT attachment_backup_objects_attachment_ref_check CHECK (
+    attachment_ref ~ '^[A-Za-z0-9_-]{43}$'
+  ),
+  CONSTRAINT attachment_backup_objects_version_ref_check CHECK (
+    version_ref ~ '^[A-Za-z0-9_-]{43}$'
+    AND version_ref <> attachment_ref
+  ),
+  CONSTRAINT attachment_backup_objects_object_key_check CHECK (
+    object_key ~ (
+      '^'
+      || owner_user_id::text
+      || '/[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.anb1$'
+    )
+  ),
+  CONSTRAINT attachment_backup_objects_size_check CHECK (
+    ciphertext_size_bytes BETWEEN 1 AND 545259520
+  ),
+  CONSTRAINT attachment_backup_objects_sha256_check CHECK (
+    ciphertext_sha256 IS NULL
+    OR ciphertext_sha256 ~ '^[0-9a-f]{64}$'
+  ),
+  CONSTRAINT attachment_backup_objects_format_check CHECK (format_version = 1),
+  CONSTRAINT attachment_backup_objects_state_check CHECK (
+    state IN ('reserved', 'ready', 'current', 'deleting')
+  ),
+  CONSTRAINT attachment_backup_objects_signing_check CHECK (
+    (last_signed_at IS NULL AND upload_expires_at IS NULL)
+    OR (
+      last_signed_at IS NOT NULL
+      AND upload_expires_at IS NOT NULL
+      AND upload_expires_at > last_signed_at
+    )
+  ),
+  CONSTRAINT attachment_backup_objects_lifecycle_check CHECK (
+    (
+      state = 'reserved'
+      AND finalized_at IS NULL
+      AND deletion_requested_at IS NULL
+    )
+    OR (
+      state IN ('ready', 'current')
+      AND finalized_at IS NOT NULL
+      AND deletion_requested_at IS NULL
+      AND ciphertext_sha256 IS NOT NULL
+    )
+    OR (
+      state = 'deleting'
+      AND deletion_requested_at IS NOT NULL
+    )
+  ),
+  CONSTRAINT attachment_backup_objects_lease_check CHECK (
+    (gc_lease_id IS NULL AND gc_lease_expires_at IS NULL)
+    OR (
+      gc_lease_id IS NOT NULL
+      AND gc_lease_expires_at IS NOT NULL
+    )
+  ),
+  CONSTRAINT attachment_backup_objects_time_check CHECK (
+    reservation_expires_at > created_at
+    AND cleanup_not_before >= reservation_expires_at
+    AND (
+      upload_expires_at IS NULL
+      OR cleanup_not_before >= upload_expires_at + interval '24 hours 5 minutes'
+    )
+    AND updated_at >= created_at
+  ),
+  CONSTRAINT attachment_backup_objects_owner_version_key UNIQUE (
+    owner_user_id,
+    version_ref
+  ),
+  CONSTRAINT attachment_backup_objects_object_key_key UNIQUE (object_key)
+);
+
+CREATE INDEX attachment_backup_objects_owner_ready_idx
+  ON public.attachment_backup_objects(
+    owner_user_id,
+    attachment_ref,
+    finalized_at DESC
+  )
+  WHERE state = 'ready';
+
+CREATE UNIQUE INDEX attachment_backup_objects_owner_current_idx
+  ON public.attachment_backup_objects(owner_user_id, attachment_ref)
+  WHERE state = 'current';
+
+CREATE INDEX attachment_backup_objects_owner_state_idx
+  ON public.attachment_backup_objects(owner_user_id, state, created_at);
+
+CREATE INDEX attachment_backup_objects_gc_idx
+  ON public.attachment_backup_objects(
+    cleanup_not_before,
+    gc_lease_expires_at,
+    created_at
+  )
+  WHERE state IN ('reserved', 'ready', 'deleting');
+
+ALTER TABLE public.attachment_backup_objects ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.attachment_backup_objects
+  FROM PUBLIC, anon, authenticated;
+GRANT ALL ON TABLE public.attachment_backup_objects TO service_role;
+
+CREATE POLICY attachment_backup_objects_service_all
+  ON public.attachment_backup_objects
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+GRANT USAGE ON SCHEMA private TO service_role;
+
+CREATE OR REPLACE FUNCTION private.require_attachment_backup_owner(
+  p_owner_user_id uuid
+)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM 1
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_owner_user_id
+    AND workspace.owner_user_id = p_owner_user_id
+    AND workspace.kind = 'personal'
+    AND workspace.e2ee_key_id IS NOT NULL
+    AND workspace.deleted_at IS NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'active personal E2EE workspace required'
+      USING ERRCODE = '42501';
+  END IF;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.require_attachment_backup_owner(uuid)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION private.require_attachment_backup_owner(uuid)
+  TO service_role;
+
+CREATE OR REPLACE FUNCTION private.enforce_attachment_backup_identity()
+RETURNS trigger
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF NEW.id IS DISTINCT FROM OLD.id
+    OR NEW.owner_user_id IS DISTINCT FROM OLD.owner_user_id
+    OR NEW.attachment_ref IS DISTINCT FROM OLD.attachment_ref
+    OR NEW.version_ref IS DISTINCT FROM OLD.version_ref
+    OR NEW.object_key IS DISTINCT FROM OLD.object_key
+    OR NEW.ciphertext_size_bytes IS DISTINCT FROM OLD.ciphertext_size_bytes
+    OR NEW.format_version IS DISTINCT FROM OLD.format_version
+    OR (
+      OLD.ciphertext_sha256 IS NOT NULL
+      AND NEW.ciphertext_sha256 IS DISTINCT FROM OLD.ciphertext_sha256
+    )
+  THEN
+    RAISE EXCEPTION 'attachment backup identity is immutable'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION private.enforce_attachment_backup_identity()
+  FROM PUBLIC, anon, authenticated;
+
+CREATE TRIGGER attachment_backup_objects_immutable_identity
+  BEFORE UPDATE ON public.attachment_backup_objects
+  FOR EACH ROW
+  EXECUTE FUNCTION private.enforce_attachment_backup_identity();
+
+CREATE OR REPLACE FUNCTION public.read_attachment_backup_by_key(
+  p_owner_user_id uuid,
+  p_object_key text
+)
+RETURNS TABLE (
+  object_id uuid,
+  attachment_ref text,
+  version_ref text,
+  object_key text,
+  object_state text,
+  ciphertext_sha256 text,
+  ciphertext_size_bytes bigint,
+  format_version smallint,
+  reservation_expires_at timestamptz,
+  upload_expires_at timestamptz,
+  cleanup_not_before timestamptz
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  IF p_object_key IS NULL
+    OR p_object_key !~ (
+      '^'
+      || p_owner_user_id::text
+      || '/[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.anb1$'
+    )
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup object key'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    backup.id,
+    backup.attachment_ref,
+    backup.version_ref,
+    backup.object_key,
+    backup.state,
+    backup.ciphertext_sha256,
+    backup.ciphertext_size_bytes,
+    backup.format_version,
+    backup.reservation_expires_at,
+    backup.upload_expires_at,
+    backup.cleanup_not_before
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.object_key = p_object_key;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.read_current_attachment_backup(
+  p_owner_user_id uuid,
+  p_attachment_ref text
+)
+RETURNS TABLE (
+  object_id uuid,
+  version_ref text,
+  object_key text,
+  ciphertext_sha256 text,
+  ciphertext_size_bytes bigint,
+  format_version smallint
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  IF p_attachment_ref IS NULL
+    OR p_attachment_ref !~ '^[A-Za-z0-9_-]{43}$'
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup reference'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    backup.id,
+    backup.version_ref,
+    backup.object_key,
+    backup.ciphertext_sha256,
+    backup.ciphertext_size_bytes,
+    backup.format_version
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.attachment_ref = p_attachment_ref
+    AND backup.state = 'current';
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.reserve_attachment_backup(
+  p_owner_user_id uuid,
+  p_attachment_ref text,
+  p_version_ref text,
+  p_ciphertext_size_bytes bigint,
+  p_format_version smallint DEFAULT 1
+)
+RETURNS TABLE (
+  object_id uuid,
+  object_key text,
+  object_state text,
+  ciphertext_sha256 text,
+  ciphertext_size_bytes bigint,
+  format_version smallint,
+  reservation_expires_at timestamptz,
+  cleanup_not_before timestamptz,
+  was_created boolean
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_existing public.attachment_backup_objects%ROWTYPE;
+  v_created public.attachment_backup_objects%ROWTYPE;
+  v_account_bytes bigint;
+  v_object_count bigint;
+  v_active_reservations bigint;
+BEGIN
+  IF p_attachment_ref IS NULL
+    OR p_attachment_ref !~ '^[A-Za-z0-9_-]{43}$'
+    OR p_version_ref IS NULL
+    OR p_version_ref !~ '^[A-Za-z0-9_-]{43}$'
+    OR p_attachment_ref = p_version_ref
+    OR p_ciphertext_size_bytes IS NULL
+    OR p_ciphertext_size_bytes < 1
+    OR p_ciphertext_size_bytes > 545259520
+    OR p_format_version <> 1
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup reservation'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  SELECT backup.*
+  INTO v_existing
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.version_ref = p_version_ref
+  FOR UPDATE;
+
+  IF FOUND THEN
+    IF v_existing.attachment_ref <> p_attachment_ref
+      OR v_existing.ciphertext_size_bytes <> p_ciphertext_size_bytes
+      OR v_existing.format_version <> p_format_version
+    THEN
+      RAISE EXCEPTION 'attachment backup version conflicts with existing reservation'
+        USING ERRCODE = '40001';
+    END IF;
+
+    IF v_existing.state = 'deleting'
+      OR (
+        v_existing.state = 'reserved'
+        AND v_existing.cleanup_not_before <= v_now
+      )
+    THEN
+      RAISE EXCEPTION 'attachment backup reservation is no longer reusable'
+        USING ERRCODE = '55000';
+    END IF;
+
+    RETURN QUERY
+    SELECT
+      v_existing.id,
+      v_existing.object_key,
+      v_existing.state,
+      v_existing.ciphertext_sha256,
+      v_existing.ciphertext_size_bytes,
+      v_existing.format_version,
+      v_existing.reservation_expires_at,
+      v_existing.cleanup_not_before,
+      false;
+    RETURN;
+  END IF;
+
+  SELECT
+    COALESCE(sum(backup.ciphertext_size_bytes), 0),
+    count(*)
+  INTO v_account_bytes, v_object_count
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id;
+
+  IF v_object_count >= 10000 THEN
+    RAISE EXCEPTION 'attachment backup object limit exceeded'
+      USING ERRCODE = '54000';
+  END IF;
+
+  IF p_ciphertext_size_bytes > 5368709120 - v_account_bytes THEN
+    RAISE EXCEPTION 'attachment backup storage quota exceeded'
+      USING ERRCODE = '54000';
+  END IF;
+
+  SELECT count(*)
+  INTO v_active_reservations
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.state = 'reserved'
+    AND backup.cleanup_not_before > v_now;
+
+  IF v_active_reservations >= 5 THEN
+    RAISE EXCEPTION 'attachment backup reservation limit exceeded'
+      USING ERRCODE = '55000';
+  END IF;
+
+  INSERT INTO public.attachment_backup_objects (
+    owner_user_id,
+    attachment_ref,
+    version_ref,
+    object_key,
+    ciphertext_size_bytes,
+    format_version,
+    reservation_expires_at,
+    cleanup_not_before,
+    created_at,
+    updated_at
+  ) VALUES (
+    p_owner_user_id,
+    p_attachment_ref,
+    p_version_ref,
+    p_owner_user_id::text || '/' || extensions.gen_random_uuid()::text || '.anb1',
+    p_ciphertext_size_bytes,
+    p_format_version,
+    v_now + interval '15 minutes',
+    v_now + interval '15 minutes',
+    v_now,
+    v_now
+  )
+  RETURNING * INTO v_created;
+
+  RETURN QUERY
+  SELECT
+    v_created.id,
+    v_created.object_key,
+    v_created.state,
+    v_created.ciphertext_sha256,
+    v_created.ciphertext_size_bytes,
+    v_created.format_version,
+    v_created.reservation_expires_at,
+    v_created.cleanup_not_before,
+    true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_attachment_backup_signed(
+  p_owner_user_id uuid,
+  p_object_id uuid,
+  p_ciphertext_sha256 text,
+  p_upload_expires_at timestamptz
+)
+RETURNS TABLE (
+  object_id uuid,
+  object_key text,
+  ciphertext_sha256 text,
+  last_signed_at timestamptz,
+  upload_expires_at timestamptz,
+  cleanup_not_before timestamptz
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_backup public.attachment_backup_objects%ROWTYPE;
+BEGIN
+  IF p_ciphertext_sha256 IS NULL
+    OR p_ciphertext_sha256 !~ '^[0-9a-f]{64}$'
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup ciphertext hash'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_object_id IS NULL
+    OR p_upload_expires_at IS NULL
+    OR p_upload_expires_at <= v_now
+    OR p_upload_expires_at > v_now + interval '2 hours 5 minutes'
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup upload expiry'
+      USING ERRCODE = '22023';
+  END IF;
+
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  SELECT backup.*
+  INTO v_backup
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.id = p_object_id
+    AND backup.owner_user_id = p_owner_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND
+    OR v_backup.state <> 'reserved'
+    OR v_backup.cleanup_not_before <= v_now
+  THEN
+    RAISE EXCEPTION 'attachment backup reservation is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF v_backup.ciphertext_sha256 IS NOT NULL
+    AND v_backup.ciphertext_sha256 <> p_ciphertext_sha256
+  THEN
+    RAISE EXCEPTION 'attachment backup ciphertext hash conflicts with reservation'
+      USING ERRCODE = '40001';
+  END IF;
+
+  UPDATE public.attachment_backup_objects AS backup
+  SET
+    ciphertext_sha256 = COALESCE(
+      backup.ciphertext_sha256,
+      p_ciphertext_sha256
+    ),
+    last_signed_at = v_now,
+    upload_expires_at = GREATEST(
+      COALESCE(backup.upload_expires_at, p_upload_expires_at),
+      p_upload_expires_at
+    ),
+    cleanup_not_before = GREATEST(
+      backup.cleanup_not_before,
+      p_upload_expires_at + interval '24 hours 5 minutes'
+    ),
+    updated_at = v_now
+  WHERE backup.id = v_backup.id
+  RETURNING backup.* INTO v_backup;
+
+  RETURN QUERY
+  SELECT
+    v_backup.id,
+    v_backup.object_key,
+    v_backup.ciphertext_sha256,
+    v_backup.last_signed_at,
+    v_backup.upload_expires_at,
+    v_backup.cleanup_not_before;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.finalize_attachment_backup(
+  p_owner_user_id uuid,
+  p_object_id uuid,
+  p_object_key text,
+  p_observed_ciphertext_size_bytes bigint
+)
+RETURNS TABLE (
+  object_id uuid,
+  object_key text,
+  object_state text,
+  was_finalized boolean
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_backup public.attachment_backup_objects%ROWTYPE;
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  SELECT backup.*
+  INTO v_backup
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.id = p_object_id
+    AND backup.owner_user_id = p_owner_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'attachment backup reservation is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF p_object_key IS NULL
+    OR p_observed_ciphertext_size_bytes IS NULL
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup finalization'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_object_key <> v_backup.object_key
+    OR p_observed_ciphertext_size_bytes <> v_backup.ciphertext_size_bytes
+  THEN
+    RAISE EXCEPTION 'attachment backup object does not match reservation'
+      USING ERRCODE = '40001';
+  END IF;
+
+  IF v_backup.ciphertext_sha256 IS NULL THEN
+    RAISE EXCEPTION 'attachment backup ciphertext hash is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF v_backup.state IN ('ready', 'current') THEN
+    RETURN QUERY
+    SELECT v_backup.id, v_backup.object_key, v_backup.state, false;
+    RETURN;
+  END IF;
+
+  IF v_backup.state <> 'reserved'
+    OR v_backup.last_signed_at IS NULL
+    OR v_backup.cleanup_not_before <= v_now
+  THEN
+    RAISE EXCEPTION 'attachment backup reservation is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  UPDATE public.attachment_backup_objects AS backup
+  SET
+    state = 'ready',
+    cleanup_not_before = GREATEST(
+      backup.cleanup_not_before,
+      v_now + interval '24 hours'
+    ),
+    finalized_at = v_now,
+    updated_at = v_now
+  WHERE backup.id = v_backup.id
+  RETURNING backup.* INTO v_backup;
+
+  RETURN QUERY
+  SELECT
+    v_backup.id,
+    v_backup.object_key,
+    v_backup.state,
+    true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.promote_attachment_backup(
+  p_owner_user_id uuid,
+  p_candidate_object_id uuid,
+  p_candidate_object_key text,
+  p_expected_current_object_key text DEFAULT NULL
+)
+RETURNS TABLE (
+  current_object_id uuid,
+  current_object_key text,
+  current_version_ref text,
+  current_ciphertext_sha256 text,
+  displaced_object_id uuid,
+  displaced_object_key text,
+  was_promoted boolean
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_candidate public.attachment_backup_objects%ROWTYPE;
+  v_current public.attachment_backup_objects%ROWTYPE;
+  v_displaced public.attachment_backup_objects%ROWTYPE;
+  v_has_current boolean := false;
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  SELECT backup.*
+  INTO v_candidate
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.id = p_candidate_object_id
+    AND backup.owner_user_id = p_owner_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'attachment backup candidate is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF p_candidate_object_key IS NULL
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup candidate key'
+      USING ERRCODE = '22023';
+  END IF;
+
+  IF p_candidate_object_key <> v_candidate.object_key
+  THEN
+    RAISE EXCEPTION 'attachment backup candidate key does not match'
+      USING ERRCODE = '40001';
+  END IF;
+
+  IF v_candidate.state = 'current' THEN
+    RETURN QUERY
+    SELECT
+      v_candidate.id,
+      v_candidate.object_key,
+      v_candidate.version_ref,
+      v_candidate.ciphertext_sha256,
+      NULL::uuid,
+      NULL::text,
+      false;
+    RETURN;
+  END IF;
+
+  IF v_candidate.state <> 'ready'
+    OR v_candidate.cleanup_not_before <= v_now
+  THEN
+    RAISE EXCEPTION 'attachment backup candidate is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  SELECT backup.*
+  INTO v_current
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.attachment_ref = v_candidate.attachment_ref
+    AND backup.state = 'current'
+  FOR UPDATE;
+
+  v_has_current := FOUND;
+
+  IF (p_expected_current_object_key IS NULL AND v_has_current)
+    OR (
+      p_expected_current_object_key IS NOT NULL
+      AND (
+        NOT v_has_current
+        OR v_current.object_key <> p_expected_current_object_key
+      )
+    )
+  THEN
+    RAISE EXCEPTION 'attachment backup head changed'
+      USING ERRCODE = '40001';
+  END IF;
+
+  IF v_has_current THEN
+    v_displaced := v_current;
+
+    UPDATE public.attachment_backup_objects AS backup
+    SET
+      state = 'deleting',
+      deletion_requested_at = v_now,
+      gc_lease_id = NULL,
+      gc_lease_expires_at = NULL,
+      updated_at = v_now
+    WHERE backup.id = v_current.id;
+  END IF;
+
+  UPDATE public.attachment_backup_objects AS backup
+  SET
+    state = 'current',
+    updated_at = v_now
+  WHERE backup.id = v_candidate.id
+  RETURNING backup.* INTO v_candidate;
+
+  RETURN QUERY
+  SELECT
+    v_candidate.id,
+    v_candidate.object_key,
+    v_candidate.version_ref,
+    v_candidate.ciphertext_sha256,
+    v_displaced.id,
+    v_displaced.object_key,
+    true;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.prepare_attachment_backup_download(
+  p_owner_user_id uuid,
+  p_object_key text,
+  p_download_expires_at timestamptz
+)
+RETURNS TABLE (
+  object_id uuid,
+  object_key text,
+  ciphertext_sha256 text,
+  ciphertext_size_bytes bigint,
+  format_version smallint,
+  cleanup_not_before timestamptz
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_backup public.attachment_backup_objects%ROWTYPE;
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  IF p_object_key IS NULL
+    OR p_object_key !~ (
+      '^'
+      || p_owner_user_id::text
+      || '/[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.anb1$'
+    )
+    OR p_download_expires_at IS NULL
+    OR p_download_expires_at <= v_now
+    OR p_download_expires_at > v_now + interval '2 hours 5 minutes'
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup download request'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT backup.*
+  INTO v_backup
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.object_key = p_object_key
+  FOR UPDATE;
+
+  IF NOT FOUND OR v_backup.state <> 'current' THEN
+    RAISE EXCEPTION 'attachment backup current object is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  UPDATE public.attachment_backup_objects AS backup
+  SET
+    cleanup_not_before = GREATEST(
+      backup.cleanup_not_before,
+      p_download_expires_at + interval '5 minutes'
+    ),
+    updated_at = v_now
+  WHERE backup.id = v_backup.id
+  RETURNING backup.* INTO v_backup;
+
+  RETURN QUERY
+  SELECT
+    v_backup.id,
+    v_backup.object_key,
+    v_backup.ciphertext_sha256,
+    v_backup.ciphertext_size_bytes,
+    v_backup.format_version,
+    v_backup.cleanup_not_before;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_attachment_backup_deleting(
+  p_owner_user_id uuid,
+  p_object_id uuid
+)
+RETURNS TABLE (
+  object_id uuid,
+  object_key text,
+  ciphertext_size_bytes bigint,
+  cleanup_not_before timestamptz,
+  was_marked boolean
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_backup public.attachment_backup_objects%ROWTYPE;
+  v_was_marked boolean;
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  SELECT backup.*
+  INTO v_backup
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.id = p_object_id
+    AND backup.owner_user_id = p_owner_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'attachment backup object is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  v_was_marked := v_backup.state <> 'deleting';
+  IF v_was_marked THEN
+    UPDATE public.attachment_backup_objects AS backup
+    SET
+      state = 'deleting',
+      deletion_requested_at = v_now,
+      gc_lease_id = NULL,
+      gc_lease_expires_at = NULL,
+      updated_at = v_now
+    WHERE backup.id = v_backup.id
+    RETURNING backup.* INTO v_backup;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    v_backup.id,
+    v_backup.object_key,
+    v_backup.ciphertext_size_bytes,
+    v_backup.cleanup_not_before,
+    v_was_marked;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.mark_attachment_backup_deleting_by_key(
+  p_owner_user_id uuid,
+  p_object_key text
+)
+RETURNS TABLE (
+  object_id uuid,
+  object_key text,
+  ciphertext_size_bytes bigint,
+  cleanup_not_before timestamptz,
+  was_marked boolean
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_object_id uuid;
+BEGIN
+  PERFORM private.require_attachment_backup_owner(p_owner_user_id);
+
+  IF p_object_key IS NULL
+    OR p_object_key !~ (
+      '^'
+      || p_owner_user_id::text
+      || '/[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.anb1$'
+    )
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup object key'
+      USING ERRCODE = '22023';
+  END IF;
+
+  SELECT backup.id
+  INTO v_object_id
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.owner_user_id = p_owner_user_id
+    AND backup.object_key = p_object_key
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'attachment backup object is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    marked.object_id,
+    marked.object_key,
+    marked.ciphertext_size_bytes,
+    marked.cleanup_not_before,
+    marked.was_marked
+  FROM public.mark_attachment_backup_deleting(
+    p_owner_user_id,
+    v_object_id
+  ) AS marked;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.claim_attachment_backup_gc_leases(
+  p_lease_id uuid,
+  p_limit integer DEFAULT 100,
+  p_lease_seconds integer DEFAULT 300
+)
+RETURNS TABLE (
+  object_id uuid,
+  owner_user_id uuid,
+  object_key text,
+  ciphertext_size_bytes bigint,
+  gc_lease_id uuid,
+  gc_lease_expires_at timestamptz
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+BEGIN
+  IF p_lease_id IS NULL
+    OR p_limit IS NULL
+    OR p_limit < 1
+    OR p_limit > 1000
+    OR p_lease_seconds IS NULL
+    OR p_lease_seconds < 30
+    OR p_lease_seconds > 3600
+  THEN
+    RAISE EXCEPTION 'invalid attachment backup GC lease'
+      USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  WITH candidates AS (
+    SELECT backup.id
+    FROM public.attachment_backup_objects AS backup
+    WHERE backup.state IN ('reserved', 'ready', 'deleting')
+      AND backup.cleanup_not_before <= v_now
+      AND (
+        backup.gc_lease_expires_at IS NULL
+        OR backup.gc_lease_expires_at <= v_now
+      )
+    ORDER BY backup.cleanup_not_before, backup.created_at, backup.id
+    FOR UPDATE SKIP LOCKED
+    LIMIT p_limit
+  ), leased AS (
+    UPDATE public.attachment_backup_objects AS backup
+    SET
+      state = 'deleting',
+      deletion_requested_at = COALESCE(backup.deletion_requested_at, v_now),
+      gc_lease_id = p_lease_id,
+      gc_lease_expires_at = v_now + make_interval(secs => p_lease_seconds),
+      updated_at = v_now
+    FROM candidates
+    WHERE backup.id = candidates.id
+    RETURNING backup.*
+  )
+  SELECT
+    leased.id,
+    leased.owner_user_id,
+    leased.object_key,
+    leased.ciphertext_size_bytes,
+    leased.gc_lease_id,
+    leased.gc_lease_expires_at
+  FROM leased
+  ORDER BY leased.cleanup_not_before, leased.created_at, leased.id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.finish_attachment_backup_deletion(
+  p_owner_user_id uuid,
+  p_object_id uuid,
+  p_object_key text,
+  p_gc_lease_id uuid DEFAULT NULL
+)
+RETURNS boolean
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz := clock_timestamp();
+  v_backup public.attachment_backup_objects%ROWTYPE;
+BEGIN
+  SELECT backup.*
+  INTO v_backup
+  FROM public.attachment_backup_objects AS backup
+  WHERE backup.id = p_object_id
+    AND backup.owner_user_id = p_owner_user_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN false;
+  END IF;
+
+  IF v_backup.state <> 'deleting'
+    OR v_backup.object_key <> p_object_key
+    OR v_backup.cleanup_not_before > v_now
+    OR (
+      v_backup.gc_lease_id IS NOT NULL
+      AND v_backup.gc_lease_id IS DISTINCT FROM p_gc_lease_id
+    )
+  THEN
+    RAISE EXCEPTION 'attachment backup deletion is unavailable'
+      USING ERRCODE = '55000';
+  END IF;
+
+  DELETE FROM public.attachment_backup_objects AS backup
+  WHERE backup.id = v_backup.id;
+
+  RETURN true;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.read_attachment_backup_by_key(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.read_current_attachment_backup(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.reserve_attachment_backup(uuid, text, text, bigint, smallint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.mark_attachment_backup_signed(uuid, uuid, text, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.finalize_attachment_backup(uuid, uuid, text, bigint)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.promote_attachment_backup(uuid, uuid, text, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.prepare_attachment_backup_download(uuid, text, timestamptz)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.mark_attachment_backup_deleting(uuid, uuid)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.mark_attachment_backup_deleting_by_key(uuid, text)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.claim_attachment_backup_gc_leases(uuid, integer, integer)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.finish_attachment_backup_deletion(uuid, uuid, text, uuid)
+  FROM PUBLIC, anon, authenticated;
+
+GRANT EXECUTE ON FUNCTION public.read_attachment_backup_by_key(uuid, text)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.read_current_attachment_backup(uuid, text)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.reserve_attachment_backup(uuid, text, text, bigint, smallint)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.mark_attachment_backup_signed(uuid, uuid, text, timestamptz)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.finalize_attachment_backup(uuid, uuid, text, bigint)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.promote_attachment_backup(uuid, uuid, text, text)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.prepare_attachment_backup_download(uuid, text, timestamptz)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.mark_attachment_backup_deleting(uuid, uuid)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.mark_attachment_backup_deleting_by_key(uuid, text)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.claim_attachment_backup_gc_leases(uuid, integer, integer)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.finish_attachment_backup_deletion(uuid, uuid, text, uuid)
+  TO service_role;

--- a/supabase/tests/015-attachment-backups.sql
+++ b/supabase/tests/015-attachment-backups.sql
@@ -1,0 +1,1685 @@
+begin;
+select plan(88);
+
+select tests.create_supabase_user('backup_owner', 'backup-owner@example.com');
+select tests.create_supabase_user('backup_other', 'backup-other@example.com');
+select tests.create_supabase_user('backup_no_e2ee', 'backup-no-e2ee@example.com');
+select tests.create_supabase_user('backup_limit', 'backup-limit@example.com');
+select tests.create_supabase_user('backup_quota', 'backup-quota@example.com');
+select tests.create_supabase_user('backup_count', 'backup-count@example.com');
+
+create temporary table attachment_backup_test_state (
+  name text primary key,
+  object_id uuid,
+  object_key text,
+  version_ref text,
+  object_state text,
+  ciphertext_sha256 text,
+  ciphertext_size_bytes bigint,
+  reservation_expires_at timestamptz,
+  last_signed_at timestamptz,
+  upload_expires_at timestamptz,
+  cleanup_not_before timestamptz,
+  was_created boolean,
+  was_finalized boolean,
+  displaced_object_id uuid,
+  displaced_object_key text,
+  was_promoted boolean,
+  gc_lease_id uuid,
+  gc_lease_expires_at timestamptz
+);
+
+grant all on attachment_backup_test_state to anon, authenticated, service_role;
+
+insert into attachment_backup_test_state (name, object_id)
+values ('quota_owner', tests.get_supabase_uid('backup_quota'));
+
+select has_table(
+  'public',
+  'attachment_backup_objects',
+  'Attachment backup authority has a durable ledger'
+);
+
+select is(
+  (select bucket."public" from storage.buckets as bucket where bucket.id = 'attachment-backups'),
+  false,
+  'Attachment backup bucket is private'
+);
+
+select is(
+  (select bucket.file_size_limit from storage.buckets as bucket where bucket.id = 'attachment-backups'),
+  545259520::bigint,
+  'Attachment backup bucket permits only the bounded ciphertext envelope'
+);
+
+select results_eq(
+  $$
+    select unnest(bucket.allowed_mime_types)
+    from storage.buckets as bucket
+    where bucket.id = 'attachment-backups'
+  $$,
+  array['application/octet-stream'::text],
+  'Attachment backup bucket accepts only opaque ciphertext'
+);
+
+select ok(
+  (
+    select class.relrowsecurity
+    from pg_class as class
+    join pg_namespace as namespace on namespace.oid = class.relnamespace
+    where namespace.nspname = 'public'
+      and class.relname = 'attachment_backup_objects'
+  ),
+  'Attachment backup ledger has RLS enabled'
+);
+
+select ok(
+  not has_table_privilege('anon', 'public.attachment_backup_objects', 'SELECT')
+    and not has_table_privilege('authenticated', 'public.attachment_backup_objects', 'SELECT')
+    and not has_table_privilege('authenticated', 'public.attachment_backup_objects', 'INSERT')
+    and not has_table_privilege('authenticated', 'public.attachment_backup_objects', 'UPDATE')
+    and not has_table_privilege('authenticated', 'public.attachment_backup_objects', 'DELETE')
+    and has_table_privilege('service_role', 'public.attachment_backup_objects', 'SELECT')
+    and has_table_privilege('service_role', 'public.attachment_backup_objects', 'INSERT')
+    and has_table_privilege('service_role', 'public.attachment_backup_objects', 'UPDATE')
+    and has_table_privilege('service_role', 'public.attachment_backup_objects', 'DELETE'),
+  'Only the service role has direct ledger privileges'
+);
+
+select ok(
+  not has_function_privilege(
+      'authenticated',
+      'public.read_attachment_backup_by_key(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.read_current_attachment_backup(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.reserve_attachment_backup(uuid,text,text,bigint,smallint)',
+      'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.mark_attachment_backup_signed(uuid,uuid,text,timestamptz)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.finalize_attachment_backup(uuid,uuid,text,bigint)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.mark_attachment_backup_deleting(uuid,uuid)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.promote_attachment_backup(uuid,uuid,text,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.prepare_attachment_backup_download(uuid,text,timestamptz)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.mark_attachment_backup_deleting_by_key(uuid,text)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.claim_attachment_backup_gc_leases(uuid,integer,integer)',
+      'EXECUTE'
+    )
+    and not has_function_privilege(
+      'authenticated',
+      'public.finish_attachment_backup_deletion(uuid,uuid,text,uuid)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.read_attachment_backup_by_key(uuid,text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.read_current_attachment_backup(uuid,text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.reserve_attachment_backup(uuid,text,text,bigint,smallint)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.mark_attachment_backup_signed(uuid,uuid,text,timestamptz)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.claim_attachment_backup_gc_leases(uuid,integer,integer)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.promote_attachment_backup(uuid,uuid,text,text)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.prepare_attachment_backup_download(uuid,text,timestamptz)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.mark_attachment_backup_deleting_by_key(uuid,text)',
+      'EXECUTE'
+    ),
+  'Attachment backup RPC authority is service-role-only'
+);
+
+select ok(
+  not exists (
+    select 1
+    from pg_proc as proc
+    join pg_namespace as namespace on namespace.oid = proc.pronamespace
+    where namespace.nspname = 'public'
+      and proc.proname in (
+        'read_attachment_backup_by_key',
+        'read_current_attachment_backup',
+        'reserve_attachment_backup',
+        'mark_attachment_backup_signed',
+        'finalize_attachment_backup',
+        'promote_attachment_backup',
+        'prepare_attachment_backup_download',
+        'mark_attachment_backup_deleting',
+        'mark_attachment_backup_deleting_by_key',
+        'claim_attachment_backup_gc_leases',
+        'finish_attachment_backup_deletion'
+      )
+      and (
+        proc.prosecdef
+        or not ('search_path=""' = any(coalesce(proc.proconfig, array[]::text[])))
+      )
+  ),
+  'Public backup functions are security invokers with an empty search path'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from information_schema.columns
+    where table_schema = 'public'
+      and table_name = 'attachment_backup_objects'
+      and column_name in ('session_id', 'filename', 'sha256', 'content_type')
+  $$,
+  array[0::bigint],
+  'The server ledger stores no plaintext note, filename, MIME, or plaintext digest metadata'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from pg_policies
+    where schemaname = 'storage'
+      and tablename = 'objects'
+      and policyname like 'attachment_backups_deny_client_%'
+      and permissive = 'RESTRICTIVE'
+      and 'anon' = any(roles)
+      and 'authenticated' = any(roles)
+  $$,
+  array[4::bigint],
+  'Restrictive policies deny every direct client operation on backup objects'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from pg_policies
+    where schemaname = 'public'
+      and tablename = 'attachment_backup_objects'
+      and policyname = 'attachment_backup_objects_service_all'
+      and 'service_role' = any(roles)
+  $$,
+  array[1::bigint],
+  'The service role is the only ledger policy principal'
+);
+
+select tests.authenticate_as('backup_owner');
+
+select throws_ok(
+  $$
+    insert into storage.objects (bucket_id, name, owner_id)
+    values (
+      'attachment-backups',
+      auth.uid()::text || '/00000000-0000-4000-8000-000000000001.anb1',
+      auth.uid()::text
+    )
+  $$,
+  '42501',
+  null,
+  'Authenticated clients cannot upload directly to the private backup bucket'
+);
+
+select results_eq(
+  $$select count(*) from storage.objects where bucket_id = 'attachment-backups'$$,
+  array[0::bigint],
+  'Authenticated clients cannot list private backup objects'
+);
+
+select throws_ok(
+  $$
+    insert into public.attachment_backup_objects (
+      owner_user_id,
+      attachment_ref,
+      version_ref,
+      object_key,
+      ciphertext_size_bytes
+    ) values (
+      auth.uid(),
+      repeat('A', 43),
+      repeat('B', 43),
+      auth.uid()::text || '/00000000-0000-4000-8000-000000000001.anb1',
+      1
+    )
+  $$,
+  '42501',
+  null,
+  'Authenticated clients cannot write the backup ledger'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      auth.uid(),
+      repeat('A', 43),
+      repeat('B', 43),
+      1,
+      1::smallint
+    )
+  $$,
+  '42501',
+  null,
+  'Authenticated clients cannot bypass the trusted backup API'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as_service_role();
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_no_e2ee'),
+      repeat('A', 43),
+      repeat('B', 43),
+      1,
+      1::smallint
+    )
+  $$,
+  '42501',
+  'active personal E2EE workspace required',
+  'Backup cannot start before the personal workspace claims an E2EE identity'
+);
+
+do $$
+begin
+  perform * from public.claim_personal_workspace_e2ee_key(
+    tests.get_supabase_uid('backup_owner'),
+    'abcdefghijklmnopqrstuv'
+  );
+  perform * from public.claim_personal_workspace_e2ee_key(
+    tests.get_supabase_uid('backup_other'),
+    'bcdefghijklmnopqrstuvw'
+  );
+  perform * from public.claim_personal_workspace_e2ee_key(
+    tests.get_supabase_uid('backup_limit'),
+    'cdefghijklmnopqrstuvwx'
+  );
+  perform * from public.claim_personal_workspace_e2ee_key(
+    tests.get_supabase_uid('backup_quota'),
+    'defghijklmnopqrstuvwxy'
+  );
+  perform * from public.claim_personal_workspace_e2ee_key(
+    tests.get_supabase_uid('backup_count'),
+    'efghijklmnopqrstuvwxyz'
+  );
+end;
+$$;
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      'short',
+      repeat('B', 43),
+      1,
+      1::smallint
+    )
+  $$,
+  '22023',
+  'invalid attachment backup reservation',
+  'Malformed blinded references are rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43),
+      repeat('B', 43),
+      545259521,
+      1::smallint
+    )
+  $$,
+  '22023',
+  'invalid attachment backup reservation',
+  'Ciphertext larger than the bucket cap is rejected before reservation'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_sha256,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    )
+    select
+      'first',
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_sha256,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43),
+      repeat('B', 43),
+      1048576,
+      1::smallint
+    )
+  $$,
+  'A valid encrypted attachment reserves an opaque object atomically'
+);
+
+select ok(
+  (
+    select object_state = 'reserved'
+      and ciphertext_sha256 is null
+      and ciphertext_size_bytes = 1048576
+      and was_created
+    from attachment_backup_test_state
+    where name = 'first'
+  ),
+  'A new reservation returns its bounded state and size'
+);
+
+select ok(
+  (
+    select object_key ~ (
+      '^'
+      || tests.get_supabase_uid('backup_owner')::text
+      || '/[0-9a-f]{8}-[0-9a-f]{4}-[47][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}\.anb1$'
+    )
+      and object_key not like '%' || repeat('A', 43) || '%'
+      and object_key not like '%' || repeat('B', 43) || '%'
+    from attachment_backup_test_state
+    where name = 'first'
+  ),
+  'Object keys expose only the owner prefix and a server-random identifier'
+);
+
+select throws_ok(
+  format(
+    $sql$
+      update public.attachment_backup_objects
+      set object_key = %L
+      where id = %L::uuid
+    $sql$,
+    tests.get_supabase_uid('backup_owner')::text
+      || '/00000000-0000-4000-8000-000000000099.anb1',
+    (select object_id from attachment_backup_test_state where name = 'first')
+  ),
+  '22023',
+  'attachment backup identity is immutable',
+  'The object key used as the head compare token is immutable'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select
+        object_id,
+        attachment_ref,
+        version_ref,
+        object_key,
+        object_state,
+        ciphertext_sha256,
+        ciphertext_size_bytes,
+        format_version
+      from public.read_attachment_backup_by_key(%L::uuid, %L)
+    $sql$,
+    tests.get_supabase_uid('backup_owner'),
+    (select object_key from attachment_backup_test_state where name = 'first')
+  ),
+  $$
+    select
+      object_id,
+      repeat('A', 43),
+      repeat('B', 43),
+      object_key,
+      'reserved'::text,
+      null::text,
+      1048576::bigint,
+      1::smallint
+    from attachment_backup_test_state
+    where name = 'first'
+  $$,
+  'The trusted finalize path can resolve exact owner-scoped reservation metadata'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.read_attachment_backup_by_key(
+      tests.get_supabase_uid('backup_owner'),
+      'not-a-canonical-object-key'
+    )
+  $$,
+  '22023',
+  'invalid attachment backup object key',
+  'Object-key reads reject noncanonical or cross-owner paths'
+);
+
+select ok(
+  (
+    select reservation_expires_at > now()
+      and cleanup_not_before = reservation_expires_at
+    from attachment_backup_test_state
+    where name = 'first'
+  ),
+  'Unsigned reservations have a bounded cleanup horizon'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_sha256,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    )
+    select
+      'first_retry',
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_sha256,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43),
+      repeat('B', 43),
+      1048576,
+      1::smallint
+    )
+  $$,
+  'Retrying the same blinded version is idempotent'
+);
+
+select ok(
+  (
+    select retry.object_id = original.object_id
+      and retry.object_key = original.object_key
+      and retry.ciphertext_sha256 is null
+      and not retry.was_created
+    from attachment_backup_test_state as retry
+    cross join attachment_backup_test_state as original
+    where retry.name = 'first_retry'
+      and original.name = 'first'
+  ),
+  'Idempotent reservation returns the existing object without quota duplication'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.attachment_backup_objects
+    where owner_user_id = tests.get_supabase_uid('backup_owner')
+      and version_ref = repeat('B', 43)
+  $$,
+  array[1::bigint],
+  'A blinded version has exactly one owner-scoped ledger row'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('C', 43),
+      repeat('B', 43),
+      1048576,
+      1::smallint
+    )
+  $$,
+  '40001',
+  'attachment backup version conflicts with existing reservation',
+  'A version reference cannot be rebound to different attachment metadata'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    )
+    select
+      'unsigned',
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('C', 43),
+      repeat('D', 43),
+      2048,
+      1::smallint
+    )
+  $$,
+  'A second attachment can reserve independently'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      repeat('A', 64),
+      now() + interval '1 hour'
+    )
+  $$,
+  '22023',
+  'invalid attachment backup ciphertext hash',
+  'Upload signing requires a strict lowercase ciphertext SHA-256'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      repeat('a', 64),
+      now() - interval '1 second'
+    )
+  $$,
+  '22023',
+  'invalid attachment backup upload expiry',
+  'Expired signed-upload grants are rejected'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      repeat('a', 64),
+      now() + interval '3 hours'
+    )
+  $$,
+  '22023',
+  'invalid attachment backup upload expiry',
+  'Overlong signed-upload grants are rejected'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      ciphertext_sha256,
+      last_signed_at,
+      upload_expires_at,
+      cleanup_not_before
+    )
+    select
+      'first_signed',
+      object_id,
+      object_key,
+      ciphertext_sha256,
+      last_signed_at,
+      upload_expires_at,
+      cleanup_not_before
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      repeat('a', 64),
+      now() + interval '2 hours'
+    )
+  $$,
+  'Trusted code records the signed-upload lifetime'
+);
+
+select ok(
+  (
+    select last_signed_at <= upload_expires_at
+      and ciphertext_sha256 = repeat('a', 64)
+      and cleanup_not_before >= upload_expires_at + interval '24 hours 5 minutes'
+      and (
+        select exact.ciphertext_sha256
+        from public.read_attachment_backup_by_key(
+          tests.get_supabase_uid('backup_owner'),
+          signed.object_key
+        ) as exact
+      ) = repeat('a', 64)
+    from attachment_backup_test_state as signed
+    where signed.name = 'first_signed'
+  ),
+  'Signing writes the exact hash and protects the signed-token lifetime'
+);
+
+select ok(
+  (
+    select ciphertext_sha256 = repeat('a', 64)
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      repeat('a', 64),
+      now() + interval '1 hour'
+    )
+  ),
+  'Retrying upload signing with the same ciphertext hash is idempotent'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      repeat('b', 64),
+      now() + interval '1 hour'
+    )
+  $$,
+  '40001',
+  'attachment backup ciphertext hash conflicts with reservation',
+  'A reservation ciphertext hash is write-once'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      null,
+      1048576
+    )
+  $$,
+  '22023',
+  'invalid attachment backup finalization',
+  'Finalize rejects missing trusted observations as invalid input'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'unsigned'),
+      (select object_key from attachment_backup_test_state where name = 'unsigned'),
+      2048
+    )
+  $$,
+  '55000',
+  'attachment backup ciphertext hash is unavailable',
+  'A reservation cannot finalize before its ciphertext hash is established'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      tests.get_supabase_uid('backup_owner')::text || '/00000000-0000-4000-8000-000000000099.anb1',
+      1048576
+    )
+  $$,
+  '40001',
+  'attachment backup object does not match reservation',
+  'Finalize rejects a confused object key'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      1048575
+    )
+  $$,
+  '40001',
+  'attachment backup object does not match reservation',
+  'Finalize requires the exact observed ciphertext size'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      was_finalized
+    )
+    select
+      'first_finalized',
+      object_id,
+      object_key,
+      object_state,
+      was_finalized
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      1048576
+    )
+  $$,
+  'Exact observed storage metadata finalizes the reservation'
+);
+
+select ok(
+  (
+    select backup.state = 'ready'
+      and backup.finalized_at is not null
+      and backup.cleanup_not_before >= backup.finalized_at + interval '24 hours'
+      and result.was_finalized
+    from public.attachment_backup_objects as backup
+    join attachment_backup_test_state as result on result.object_id = backup.id
+    where result.name = 'first_finalized'
+  ),
+  'The first exact upload becomes a bounded ready candidate'
+);
+
+select ok(
+  not (
+    select was_finalized
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      1048576
+    )
+  ),
+  'Finalize is idempotent after the exact version is ready'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    )
+    select
+      'second',
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43),
+      repeat('E', 43),
+      1048577,
+      1::smallint
+    )
+  $$,
+  'A new blinded version reserves a new random object key'
+);
+
+select lives_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'second'),
+      repeat('b', 64),
+      now() + interval '2 hours'
+    )
+  $$,
+  'The replacement version receives its own signed-upload horizon'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      was_finalized
+    )
+    select
+      'second_finalized',
+      object_id,
+      object_key,
+      object_state,
+      was_finalized
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'second'),
+      (select object_key from attachment_backup_test_state where name = 'second'),
+      1048577
+    )
+  $$,
+  'Finalizing a replacement records only the newly uploaded version'
+);
+
+select ok(
+  (
+    select result.was_finalized
+      and old_backup.state = 'ready'
+      and old_backup.deletion_requested_at is null
+      and new_backup.state = 'ready'
+    from attachment_backup_test_state as result
+    join attachment_backup_test_state as original on original.name = 'first'
+    join public.attachment_backup_objects as old_backup on old_backup.id = original.object_id
+    join public.attachment_backup_objects as new_backup on new_backup.id = result.object_id
+    where result.name = 'second_finalized'
+  ),
+  'Finalize preserves the prior ready backup until desktop commits the new key'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.attachment_backup_objects
+    where owner_user_id = tests.get_supabase_uid('backup_owner')
+      and attachment_ref = repeat('A', 43)
+      and state = 'ready'
+  $$,
+  array[2::bigint],
+  'Finalize alone does not choose or delete the canonical backup version'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.read_current_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43)
+    )
+  $$,
+  array[0::bigint],
+  'A finalized candidate is not current before an explicit promotion'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.read_current_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      'short'
+    )
+  $$,
+  '22023',
+  'invalid attachment backup reference',
+  'Current-head reads require a canonical blinded attachment reference'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.promote_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      null,
+      null
+    )
+  $$,
+  '22023',
+  'invalid attachment backup candidate key',
+  'Promotion rejects a missing trusted candidate key as invalid input'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.promote_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      tests.get_supabase_uid('backup_owner')::text || '/00000000-0000-4000-8000-000000000099.anb1',
+      null
+    )
+  $$,
+  '40001',
+  'attachment backup candidate key does not match',
+  'Promotion classifies a stale candidate identity as a conflict'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      version_ref,
+      ciphertext_sha256,
+      displaced_object_id,
+      displaced_object_key,
+      was_promoted
+    )
+    select
+      'initial_promote',
+      current_object_id,
+      current_object_key,
+      current_version_ref,
+      current_ciphertext_sha256,
+      displaced_object_id,
+      displaced_object_key,
+      was_promoted
+    from public.promote_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      null
+    )
+  $$,
+  'A null expected head atomically promotes the first finalized candidate'
+);
+
+select ok(
+  (
+    select result.was_promoted
+      and result.version_ref = repeat('B', 43)
+      and result.ciphertext_sha256 = repeat('a', 64)
+      and result.displaced_object_id is null
+      and result.displaced_object_key is null
+      and promoted.state = 'current'
+      and candidate.state = 'ready'
+    from attachment_backup_test_state as result
+    join public.attachment_backup_objects as promoted on promoted.id = result.object_id
+    join attachment_backup_test_state as second on second.name = 'second'
+    join public.attachment_backup_objects as candidate on candidate.id = second.object_id
+    where result.name = 'initial_promote'
+  ),
+  'Initial promotion creates exactly one current head without displacing a candidate'
+);
+
+select ok(
+  (
+    select current_object_id = (
+        select object_id from attachment_backup_test_state where name = 'first'
+      )
+      and current_object_key = (
+        select object_key from attachment_backup_test_state where name = 'first'
+      )
+      and current_version_ref = repeat('B', 43)
+      and current_ciphertext_sha256 = repeat('a', 64)
+      and displaced_object_id is null
+      and displaced_object_key is null
+      and not was_promoted
+    from public.promote_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      null
+    )
+  ),
+  'Retrying promotion of the same current object is idempotent'
+);
+
+select ok(
+  not (
+    select was_finalized
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'first'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      1048576
+    )
+  ),
+  'Finalize retries recognize an already promoted current object'
+);
+
+select ok(
+  (
+    select object_state = 'current'
+      and ciphertext_sha256 = repeat('a', 64)
+      and not was_created
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43),
+      repeat('B', 43),
+      1048576,
+      1::smallint
+    )
+  ),
+  'Reservation retries return the stored hash for an already current version'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.prepare_attachment_backup_download(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      now() + interval '3 hours'
+    )
+  $$,
+  '22023',
+  'invalid attachment backup download request',
+  'Download preparation rejects overlong signed-link lifetimes'
+);
+
+update public.attachment_backup_objects
+set
+  created_at = now() - interval '30 hours',
+  reservation_expires_at = now() - interval '29 hours',
+  last_signed_at = now() - interval '28 hours',
+  upload_expires_at = now() - interval '27 hours',
+  cleanup_not_before = now() - interval '2 hours',
+  finalized_at = now() - interval '26 hours',
+  updated_at = now()
+where id = (select object_id from attachment_backup_test_state where name = 'first');
+
+select ok(
+  (
+    select ciphertext_sha256 = repeat('a', 64)
+      and cleanup_not_before >= now() + interval '1 hour 4 minutes'
+    from public.prepare_attachment_backup_download(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_key from attachment_backup_test_state where name = 'first'),
+      now() + interval '1 hour'
+    )
+  ),
+  'Download preparation extends deletion safety beyond the signed-link lifetime'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.prepare_attachment_backup_download(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_key from attachment_backup_test_state where name = 'second'),
+      now() + interval '1 hour'
+    )
+  $$,
+  '55000',
+  'attachment backup current object is unavailable',
+  'Only the committed current object can receive a signed download'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      version_ref,
+      ciphertext_sha256,
+      displaced_object_id,
+      displaced_object_key,
+      was_promoted
+    )
+    select
+      'replacement_promote',
+      current_object_id,
+      current_object_key,
+      current_version_ref,
+      current_ciphertext_sha256,
+      displaced_object_id,
+      displaced_object_key,
+      was_promoted
+    from public.promote_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'second'),
+      (select object_key from attachment_backup_test_state where name = 'second'),
+      (select object_key from attachment_backup_test_state where name = 'first')
+    )
+  $$,
+  'Replacement promotion compares the immutable expected current key'
+);
+
+select ok(
+  (
+    select result.was_promoted
+      and result.version_ref = repeat('E', 43)
+      and result.ciphertext_sha256 = repeat('b', 64)
+      and result.displaced_object_id = original.object_id
+      and result.displaced_object_key = original.object_key
+      and old_backup.state = 'deleting'
+      and old_backup.deletion_requested_at is not null
+      and new_backup.state = 'current'
+    from attachment_backup_test_state as result
+    join attachment_backup_test_state as original on original.name = 'first'
+    join public.attachment_backup_objects as old_backup on old_backup.id = original.object_id
+    join public.attachment_backup_objects as new_backup on new_backup.id = result.object_id
+    where result.name = 'replacement_promote'
+  ),
+  'Successful CAS returns and retires the displaced head only after promotion'
+);
+
+select results_eq(
+  format(
+    $sql$
+      select
+        object_id,
+        version_ref,
+        object_key,
+        ciphertext_sha256,
+        ciphertext_size_bytes,
+        format_version
+      from public.read_current_attachment_backup(%L::uuid, %L)
+    $sql$,
+    tests.get_supabase_uid('backup_owner'),
+    repeat('A', 43)
+  ),
+  $$
+    select
+      object_id,
+      repeat('E', 43),
+      object_key,
+      repeat('b', 64),
+      1048577::bigint,
+      1::smallint
+    from attachment_backup_test_state
+    where name = 'second'
+  $$,
+  'Current-head reads return only the CAS winner'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    )
+    select
+      'stale_candidate',
+      object_id,
+      object_key,
+      object_state,
+      ciphertext_size_bytes,
+      reservation_expires_at,
+      cleanup_not_before,
+      was_created
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      repeat('A', 43),
+      repeat('F', 43),
+      1048578,
+      1::smallint
+    )
+  $$,
+  'A concurrent replacement writer can reserve another candidate'
+);
+
+select lives_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'stale_candidate'),
+      repeat('c', 64),
+      now() + interval '2 hours'
+    )
+  $$,
+  'The concurrent replacement candidate receives an upload horizon'
+);
+
+select lives_ok(
+  $$
+    select *
+    from public.finalize_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'stale_candidate'),
+      (select object_key from attachment_backup_test_state where name = 'stale_candidate'),
+      1048578
+    )
+  $$,
+  'The concurrent replacement upload finalizes independently'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.promote_attachment_backup(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'stale_candidate'),
+      (select object_key from attachment_backup_test_state where name = 'stale_candidate'),
+      (select object_key from attachment_backup_test_state where name = 'first')
+    )
+  $$,
+  '40001',
+  'attachment backup head changed',
+  'A stale concurrent CAS cannot replace the winning current head'
+);
+
+select ok(
+  (
+    select stale.state = 'ready'
+      and stale.deletion_requested_at is null
+      and current.state = 'current'
+    from attachment_backup_test_state as stale_result
+    join public.attachment_backup_objects as stale on stale.id = stale_result.object_id
+    join attachment_backup_test_state as current_result on current_result.name = 'second'
+    join public.attachment_backup_objects as current on current.id = current_result.object_id
+    where stale_result.name = 'stale_candidate'
+  ),
+  'A CAS loser remains an independently GC-bounded ready candidate'
+);
+
+update public.attachment_backup_objects
+set
+  created_at = now() - interval '30 hours',
+  reservation_expires_at = now() - interval '29 hours',
+  last_signed_at = now() - interval '28 hours',
+  upload_expires_at = now() - interval '27 hours',
+  cleanup_not_before = now() - interval '2 hours',
+  finalized_at = now() - interval '26 hours',
+  updated_at = now()
+where id = (select object_id from attachment_backup_test_state where name = 'second');
+
+select is(
+  (
+    select count(*)
+    from public.claim_attachment_backup_gc_leases(
+      '00000000-0000-4000-8000-000000000200'::uuid,
+      10,
+      300
+    )
+  ),
+  0::bigint,
+  'GC excludes the current head even after its cleanup horizon passes'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.mark_attachment_backup_signed(
+      tests.get_supabase_uid('backup_other'),
+      (select object_id from attachment_backup_test_state where name = 'second'),
+      repeat('b', 64),
+      now() + interval '2 hours'
+    )
+  $$,
+  '55000',
+  'attachment backup reservation is unavailable',
+  'Trusted calls still enforce ledger ownership'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      ciphertext_size_bytes,
+      cleanup_not_before,
+      was_created
+    )
+    select
+      'unsigned_deleting',
+      object_id,
+      object_key,
+      ciphertext_size_bytes,
+      cleanup_not_before,
+      was_marked
+    from public.mark_attachment_backup_deleting_by_key(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_key from attachment_backup_test_state where name = 'unsigned')
+    )
+  $$,
+  'Explicit deletion first marks the logical object for cleanup'
+);
+
+select ok(
+  not (
+    select was_marked
+    from public.mark_attachment_backup_deleting_by_key(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_key from attachment_backup_test_state where name = 'unsigned')
+    )
+  ),
+  'Marking an already deleting object is idempotent'
+);
+
+select throws_ok(
+  $$
+    select public.finish_attachment_backup_deletion(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'unsigned'),
+      (select object_key from attachment_backup_test_state where name = 'unsigned'),
+      null
+    )
+  $$,
+  '55000',
+  'attachment backup deletion is unavailable',
+  'Ledger quota cannot be released before late upload URLs are harmless'
+);
+
+update public.attachment_backup_objects
+set
+  created_at = now() - interval '30 hours',
+  reservation_expires_at = now() - interval '29 hours',
+  last_signed_at = now() - interval '28 hours',
+  upload_expires_at = now() - interval '27 hours',
+  cleanup_not_before = now() - interval '2 hours',
+  finalized_at = now() - interval '26 hours',
+  updated_at = now()
+where id = (select object_id from attachment_backup_test_state where name = 'stale_candidate');
+
+select throws_ok(
+  $$select * from public.claim_attachment_backup_gc_leases(null, 1, 300)$$,
+  '22023',
+  'invalid attachment backup GC lease',
+  'GC requires a bounded explicit lease'
+);
+
+select lives_ok(
+  $$
+    insert into attachment_backup_test_state (
+      name,
+      object_id,
+      object_key,
+      ciphertext_size_bytes,
+      gc_lease_id,
+      gc_lease_expires_at
+    )
+    select
+      'gc_claim',
+      object_id,
+      object_key,
+      ciphertext_size_bytes,
+      gc_lease_id,
+      gc_lease_expires_at
+    from public.claim_attachment_backup_gc_leases(
+      '00000000-0000-4000-8000-000000000101'::uuid,
+      1,
+      300
+    )
+  $$,
+  'GC claims an abandoned ready CAS loser with a bounded lease'
+);
+
+select ok(
+  (
+    select backup.state = 'deleting'
+      and backup.deletion_requested_at is not null
+      and backup.gc_lease_id = '00000000-0000-4000-8000-000000000101'::uuid
+      and backup.gc_lease_expires_at > now()
+    from public.attachment_backup_objects as backup
+    join attachment_backup_test_state as claim on claim.object_id = backup.id
+    where claim.name = 'gc_claim'
+  ),
+  'GC atomically transitions an expired ready candidate to leased deletion'
+);
+
+select is(
+  (
+    select count(*)
+    from public.claim_attachment_backup_gc_leases(
+      '00000000-0000-4000-8000-000000000102'::uuid,
+      1,
+      300
+    )
+  ),
+  0::bigint,
+  'An active GC lease prevents duplicate workers from claiming the same object'
+);
+
+select throws_ok(
+  $$
+    select public.finish_attachment_backup_deletion(
+      tests.get_supabase_uid('backup_owner'),
+      (select object_id from attachment_backup_test_state where name = 'gc_claim'),
+      (select object_key from attachment_backup_test_state where name = 'gc_claim'),
+      '00000000-0000-4000-8000-000000000199'::uuid
+    )
+  $$,
+  '55000',
+  'attachment backup deletion is unavailable',
+  'Only the current GC lease can finish a claimed deletion'
+);
+
+select ok(
+  public.finish_attachment_backup_deletion(
+    tests.get_supabase_uid('backup_owner'),
+    (select object_id from attachment_backup_test_state where name = 'gc_claim'),
+    (select object_key from attachment_backup_test_state where name = 'gc_claim'),
+    '00000000-0000-4000-8000-000000000101'::uuid
+  ),
+  'The current GC lease can release the ledger row after physical deletion'
+);
+
+select ok(
+  not public.finish_attachment_backup_deletion(
+    tests.get_supabase_uid('backup_owner'),
+    (select object_id from attachment_backup_test_state where name = 'gc_claim'),
+    (select object_key from attachment_backup_test_state where name = 'gc_claim'),
+    '00000000-0000-4000-8000-000000000101'::uuid
+  ),
+  'Finishing an already removed ledger row is idempotent'
+);
+
+select results_eq(
+  $$
+    select count(*)
+    from public.attachment_backup_objects
+    where id = (select object_id from attachment_backup_test_state where name = 'gc_claim')
+  $$,
+  array[0::bigint],
+  'Finished deletion frees the object and its reserved quota'
+);
+
+select lives_ok(
+  $sql$
+    do $body$
+    declare
+      index integer;
+    begin
+      for index in 1..5 loop
+        perform *
+        from public.reserve_attachment_backup(
+          tests.get_supabase_uid('backup_limit'),
+          lpad('limit-attachment-' || index::text, 43, 'A'),
+          lpad('limit-version-' || index::text, 43, 'B'),
+          1,
+          1::smallint
+        );
+      end loop;
+    end;
+    $body$;
+  $sql$,
+  'An account can hold five active upload reservations'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_limit'),
+      lpad('limit-attachment-6', 43, 'A'),
+      lpad('limit-version-6', 43, 'B'),
+      1,
+      1::smallint
+    )
+  $$,
+  '55000',
+  'attachment backup reservation limit exceeded',
+  'A sixth active upload reservation is rejected'
+);
+
+insert into public.attachment_backup_objects (
+  owner_user_id,
+  attachment_ref,
+  version_ref,
+  object_key,
+  ciphertext_size_bytes,
+  ciphertext_sha256,
+  state,
+  finalized_at
+)
+select
+  tests.get_supabase_uid('backup_quota'),
+  lpad('quota-attachment-' || item::text, 43, 'A'),
+  lpad('quota-version-' || item::text, 43, 'B'),
+  tests.get_supabase_uid('backup_quota')::text
+    || '/'
+    || extensions.gen_random_uuid()::text
+    || '.anb1',
+  545259520,
+  md5(item::text) || md5(item::text),
+  'ready',
+  now()
+from generate_series(1, 9) as item;
+
+select lives_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_quota'),
+      lpad('quota-boundary-attachment', 43, 'A'),
+      lpad('quota-boundary-version', 43, 'B'),
+      461373440,
+      1::smallint
+    )
+  $$,
+  'An account may reserve ciphertext up to exactly 5 GiB'
+);
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_quota'),
+      lpad('quota-over-attachment', 43, 'A'),
+      lpad('quota-over-version', 43, 'B'),
+      1,
+      1::smallint
+    )
+  $$,
+  '54000',
+  'attachment backup storage quota exceeded',
+  'The 5 GiB account quota counts reserved and ready ciphertext'
+);
+
+insert into public.attachment_backup_objects (
+  owner_user_id,
+  attachment_ref,
+  version_ref,
+  object_key,
+  ciphertext_size_bytes,
+  ciphertext_sha256,
+  state,
+  finalized_at
+)
+select
+  tests.get_supabase_uid('backup_count'),
+  lpad('count-attachment-' || item::text, 43, 'A'),
+  lpad('count-version-' || item::text, 43, 'B'),
+  tests.get_supabase_uid('backup_count')::text
+    || '/'
+    || extensions.gen_random_uuid()::text
+    || '.anb1',
+  1,
+  md5(item::text) || md5(item::text),
+  'ready',
+  now()
+from generate_series(1, 10000) as item;
+
+select throws_ok(
+  $$
+    select *
+    from public.reserve_attachment_backup(
+      tests.get_supabase_uid('backup_count'),
+      lpad('count-over-attachment', 43, 'A'),
+      lpad('count-over-version', 43, 'B'),
+      1,
+      1::smallint
+    )
+  $$,
+  '54000',
+  'attachment backup object limit exceeded',
+  'An account cannot exceed 10,000 tracked backup objects'
+);
+
+select tests.clear_authentication();
+reset role;
+
+select throws_ok(
+  $$
+    delete from auth.users
+    where id = (
+      select object_id
+      from attachment_backup_test_state
+      where name = 'quota_owner'
+    )
+  $$,
+  '23503',
+  null,
+  'Account deletion remains blocked until physical backup cleanup completes'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Add streaming blob encryption, durable transfer jobs, signed Storage flows, and a quota-backed server ledger with Pro-gated API routes.

<!-- GitButler Footer Boundary Top -->
---
This is **part 7 of 14 in a stack** made with GitButler:
- <kbd>&nbsp;14&nbsp;</kbd> #6104
- <kbd>&nbsp;13&nbsp;</kbd> #6103
- <kbd>&nbsp;12&nbsp;</kbd> #6102
- <kbd>&nbsp;11&nbsp;</kbd> #6101
- <kbd>&nbsp;10&nbsp;</kbd> #6100
- <kbd>&nbsp;9&nbsp;</kbd> #6099
- <kbd>&nbsp;8&nbsp;</kbd> #6109
- <kbd>&nbsp;7&nbsp;</kbd> #6108 👈 
- <kbd>&nbsp;6&nbsp;</kbd> #6098
- <kbd>&nbsp;5&nbsp;</kbd> #6093
- <kbd>&nbsp;4&nbsp;</kbd> #6092
- <kbd>&nbsp;3&nbsp;</kbd> #6091
- <kbd>&nbsp;2&nbsp;</kbd> #6090
- <kbd>&nbsp;1&nbsp;</kbd> #6089
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Large new surface area spanning Pro auth, encrypted backup lifecycle, service-role Supabase RPC/storage, and quota-backed object state—mistakes could leak capabilities, corrupt backup heads, or allow cross-user object access.
> 
> **Overview**
> Adds **Pro-gated sync API routes** for encrypted attachment backups: reserve identity in a Supabase ledger, grant time-limited upload/download capabilities, verify uploaded ciphertext against storage metadata, finalize, promote current head with compare-and-swap, and mark deletes for async cleanup. New `SyncError` variants map quota, conflict, and permission failures to stable HTTP codes.
> 
> Introduces **streaming E2EE attachment blobs** (`ANABLB01`) with chunked seal/open, ciphertext sizing, and blind attachment/version refs for the server ledger, plus a **`attachment_transfer_jobs`** local table (and Drizzle schema) to queue upload/download/delete work with deduplication constraints.
> 
> **Supabase Storage** client gains bounded responses, safe path encoding, signed uploads, object info validation, and stricter signed-URL checks; **desktop cataloging** now preserves `storage_kind` / cloud keys when content hash is unchanged, always upserts `attachment_local_state` as `present`, and fails catalog if that third statement does not apply. **Client upload** uses TUS with `x-signature` grants and range reads from Rust-sealed ciphertext.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fb2c7a18eacd89e7b02b4e5de95949999de932cd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->