### PR TITLE
fix(attachments): bound shared storage resources

### DIFF
--- a/crates/api-subscription/src/cleanup_worker.rs
+++ b/crates/api-subscription/src/cleanup_worker.rs
@@ -24,9 +24,14 @@ const ATTACHMENT_LEASE_SECONDS: i32 = 300;
 const ACCOUNT_BATCH_SIZE: usize = 4;
 const ACCOUNT_LEASE_SECONDS: i32 = 900;
 const POLL_INTERVAL: Duration = Duration::from_secs(30);
+const FULL_BATCH_POLL_INTERVAL: Duration = Duration::from_secs(5);
 const MAX_ACCOUNT_PREFIX_OBJECTS: usize = 20_000;
 const MAX_CIPHERTEXT_SIZE_BYTES: i64 = 545_259_520;
 const STRIPE_DELETE_TIMEOUT: Duration = Duration::from_secs(30);
+
+fn full_batch_poll_delay(full_batch: bool) -> Option<Duration> {
+    full_batch.then_some(FULL_BATCH_POLL_INTERVAL)
+}
 
 #[derive(Clone)]
 pub struct CleanupWorker {
@@ -145,8 +150,8 @@ impl CleanupWorker {
                 _ = cancellation.cancelled() => break,
                 _ = interval.tick() => {
                     let full_batch = self.run_once(&cancellation).await;
-                    if full_batch {
-                        interval.reset_immediately();
+                    if let Some(delay) = full_batch_poll_delay(full_batch) {
+                        interval.reset_after(delay);
                     }
                 }
             }
@@ -739,6 +744,13 @@ mod tests {
     const SHARE: &str = "00000000-0000-4000-8000-000000000503";
     const WORKSPACE: &str = "00000000-0000-4000-8000-000000000504";
     const CUSTOMER: &str = "cus_cleanup501";
+
+    #[test]
+    fn full_batches_back_off_without_changing_idle_polling() {
+        assert_eq!(full_batch_poll_delay(true), Some(Duration::from_secs(5)));
+        assert_eq!(full_batch_poll_delay(false), None);
+        assert_eq!(POLL_INTERVAL, Duration::from_secs(30));
+    }
 
     fn worker(server: &MockServer) -> CleanupWorker {
         let mut worker = CleanupWorker::new(

--- a/supabase/migrations/20260717170003_session_share_attachment_owner_limits.sql
+++ b/supabase/migrations/20260717170003_session_share_attachment_owner_limits.sql
@@ -1,0 +1,210 @@
+CREATE OR REPLACE FUNCTION public.reserve_session_share_attachment(
+  p_share_id uuid,
+  p_actor_user_id uuid,
+  p_attachment_ref text,
+  p_version_ref text,
+  p_filename text,
+  p_content_type text,
+  p_size_bytes bigint
+)
+RETURNS TABLE (
+  attachment_id uuid,
+  object_key text,
+  object_state text,
+  filename text,
+  content_type text,
+  size_bytes bigint,
+  sha256 text,
+  reservation_expires_at timestamptz,
+  cleanup_not_before timestamptz,
+  was_created boolean
+)
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+DECLARE
+  v_now timestamptz;
+  v_share public.session_shares%ROWTYPE;
+  v_owner_user_id uuid;
+  v_object public.session_share_attachment_objects%ROWTYPE;
+  v_object_id uuid;
+  v_owner_bytes bigint;
+  v_owner_object_count bigint;
+  v_owner_active_reservations bigint;
+BEGIN
+  IF p_attachment_ref IS NULL
+    OR p_attachment_ref !~ '^[A-Za-z0-9_-]{43}$'
+    OR p_version_ref IS NULL
+    OR p_version_ref !~ '^[A-Za-z0-9_-]{43}$'
+    OR p_version_ref = p_attachment_ref
+    OR p_filename IS NULL
+    OR p_filename <> btrim(p_filename)
+    OR p_filename = ''
+    OR p_filename ~ '[\\/[:cntrl:]]'
+    OR octet_length(p_filename) > 1024
+    OR p_content_type IS NULL
+    OR p_content_type <> lower(btrim(p_content_type))
+    OR p_content_type !~ '^[a-z0-9][a-z0-9!#$&^_.+-]*/[a-z0-9][a-z0-9!#$&^_.+-]*$'
+    OR octet_length(p_content_type) > 255
+    OR p_size_bytes IS NULL
+    OR p_size_bytes NOT BETWEEN 1 AND 536870912
+  THEN
+    RAISE EXCEPTION 'invalid shared attachment metadata'
+      USING ERRCODE = '22023';
+  END IF;
+
+  v_share := private.require_session_share_attachment_manager(
+    p_share_id,
+    p_actor_user_id
+  );
+
+  SELECT workspace.owner_user_id
+  INTO STRICT v_owner_user_id
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = v_share.workspace_id
+    AND workspace.deleted_at IS NULL;
+
+  PERFORM pg_catalog.pg_advisory_xact_lock(
+    pg_catalog.hashtextextended(v_owner_user_id::text, 170003)
+  );
+  v_now := clock_timestamp();
+
+  SELECT attachment.*
+  INTO v_object
+  FROM public.session_share_attachment_objects AS attachment
+  WHERE attachment.share_id = v_share.id
+    AND attachment.version_ref = p_version_ref
+    AND attachment.state <> 'deleting'
+  FOR UPDATE;
+
+  IF FOUND THEN
+    IF v_object.owner_user_id <> v_owner_user_id
+      OR v_object.attachment_ref <> p_attachment_ref
+      OR v_object.filename <> p_filename
+      OR v_object.content_type <> p_content_type
+      OR v_object.size_bytes <> p_size_bytes
+    THEN
+      RAISE EXCEPTION 'shared attachment reservation conflicts'
+        USING ERRCODE = '40001';
+    END IF;
+
+    RETURN QUERY SELECT
+      v_object.id,
+      v_object.object_key,
+      v_object.state,
+      v_object.filename,
+      v_object.content_type,
+      v_object.size_bytes,
+      v_object.sha256,
+      v_object.reservation_expires_at,
+      v_object.cleanup_not_before,
+      false;
+    RETURN;
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM public.session_share_attachment_objects AS attachment
+    WHERE attachment.share_id = v_share.id
+      AND attachment.version_ref = p_version_ref
+      AND (
+        attachment.owner_user_id IS DISTINCT FROM v_owner_user_id
+        OR attachment.attachment_ref IS DISTINCT FROM p_attachment_ref
+        OR attachment.filename IS DISTINCT FROM p_filename
+        OR attachment.content_type IS DISTINCT FROM p_content_type
+        OR attachment.size_bytes IS DISTINCT FROM p_size_bytes
+      )
+  ) THEN
+    RAISE EXCEPTION 'shared attachment reservation conflicts'
+      USING ERRCODE = '40001';
+  END IF;
+
+  SELECT
+    COALESCE(sum(attachment.size_bytes), 0),
+    count(*),
+    count(*) FILTER (
+      WHERE attachment.state = 'reserved'
+        AND attachment.cleanup_not_before > v_now
+    )
+  INTO
+    v_owner_bytes,
+    v_owner_object_count,
+    v_owner_active_reservations
+  FROM public.session_share_attachment_objects AS attachment
+  WHERE attachment.owner_user_id = v_owner_user_id;
+
+  IF v_owner_object_count >= 10000 THEN
+    RAISE EXCEPTION 'shared attachment object limit exceeded'
+      USING ERRCODE = '54000';
+  END IF;
+
+  IF p_size_bytes > 5368709120 - v_owner_bytes THEN
+    RAISE EXCEPTION 'shared attachment storage quota exceeded'
+      USING ERRCODE = '54000';
+  END IF;
+
+  IF v_owner_active_reservations >= 5 THEN
+    RAISE EXCEPTION 'shared attachment reservation limit exceeded'
+      USING ERRCODE = '55000';
+  END IF;
+
+  IF (
+    SELECT count(*)
+    FROM public.session_share_attachment_objects AS attachment
+    WHERE attachment.share_id = v_share.id
+  ) >= 256
+    OR COALESCE((
+      SELECT sum(attachment.size_bytes)
+      FROM public.session_share_attachment_objects AS attachment
+      WHERE attachment.share_id = v_share.id
+    ), 0) + p_size_bytes > 2147483648
+  THEN
+    RAISE EXCEPTION 'shared attachment quota exhausted'
+      USING ERRCODE = '54000';
+  END IF;
+
+  v_object_id := gen_random_uuid();
+  INSERT INTO public.session_share_attachment_objects (
+    id,
+    share_id,
+    owner_user_id,
+    attachment_ref,
+    version_ref,
+    object_key,
+    filename,
+    content_type,
+    size_bytes,
+    reservation_expires_at,
+    cleanup_not_before,
+    created_at,
+    updated_at
+  ) VALUES (
+    v_object_id,
+    v_share.id,
+    v_owner_user_id,
+    p_attachment_ref,
+    p_version_ref,
+    v_owner_user_id::text || '/' || v_share.id::text || '/' || v_object_id::text || '.sna1',
+    p_filename,
+    p_content_type,
+    p_size_bytes,
+    v_now + interval '15 minutes',
+    v_now + interval '15 minutes',
+    v_now,
+    v_now
+  )
+  RETURNING * INTO v_object;
+
+  RETURN QUERY SELECT
+    v_object.id,
+    v_object.object_key,
+    v_object.state,
+    v_object.filename,
+    v_object.content_type,
+    v_object.size_bytes,
+    v_object.sha256,
+    v_object.reservation_expires_at,
+    v_object.cleanup_not_before,
+    true;
+END;
+$$;

--- a/supabase/tests/020-session-share-attachment-owner-limits.sql
+++ b/supabase/tests/020-session-share-attachment-owner-limits.sql
@@ -1,0 +1,530 @@
+begin;
+select plan(18);
+
+select tests.create_supabase_user(
+  'shared_attachment_active_limit',
+  'shared-attachment-active-limit@example.com'
+);
+select tests.create_supabase_user(
+  'shared_attachment_byte_limit',
+  'shared-attachment-byte-limit@example.com'
+);
+select tests.create_supabase_user(
+  'shared_attachment_row_limit',
+  'shared-attachment-row-limit@example.com'
+);
+
+update auth.users
+set email_confirmed_at = now()
+where id in (
+  tests.get_supabase_uid('shared_attachment_active_limit'),
+  tests.get_supabase_uid('shared_attachment_byte_limit'),
+  tests.get_supabase_uid('shared_attachment_row_limit')
+);
+
+select tests.authenticate_as_service_role();
+
+insert into public.session_shares (
+  id,
+  workspace_id,
+  session_id,
+  created_by_user_id
+)
+values
+  (
+    '00000000-0000-4000-8000-000000002001'::uuid,
+    tests.get_supabase_uid('shared_attachment_active_limit'),
+    'active-limit-1',
+    tests.get_supabase_uid('shared_attachment_active_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002002'::uuid,
+    tests.get_supabase_uid('shared_attachment_active_limit'),
+    'active-limit-2',
+    tests.get_supabase_uid('shared_attachment_active_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002003'::uuid,
+    tests.get_supabase_uid('shared_attachment_active_limit'),
+    'active-limit-3',
+    tests.get_supabase_uid('shared_attachment_active_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002101'::uuid,
+    tests.get_supabase_uid('shared_attachment_byte_limit'),
+    'byte-limit-1',
+    tests.get_supabase_uid('shared_attachment_byte_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002102'::uuid,
+    tests.get_supabase_uid('shared_attachment_byte_limit'),
+    'byte-limit-2',
+    tests.get_supabase_uid('shared_attachment_byte_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002103'::uuid,
+    tests.get_supabase_uid('shared_attachment_byte_limit'),
+    'byte-limit-3',
+    tests.get_supabase_uid('shared_attachment_byte_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002201'::uuid,
+    tests.get_supabase_uid('shared_attachment_row_limit'),
+    'row-limit-1',
+    tests.get_supabase_uid('shared_attachment_row_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002202'::uuid,
+    tests.get_supabase_uid('shared_attachment_row_limit'),
+    'row-limit-2',
+    tests.get_supabase_uid('shared_attachment_row_limit')
+  ),
+  (
+    '00000000-0000-4000-8000-000000002203'::uuid,
+    tests.get_supabase_uid('shared_attachment_row_limit'),
+    'row-limit-3',
+    tests.get_supabase_uid('shared_attachment_row_limit')
+  );
+
+with definition as (
+  select lower(pg_get_functiondef(
+    'public.reserve_session_share_attachment(uuid,uuid,text,text,text,text,bigint)'::regprocedure
+  )) as body
+)
+select ok(
+  body like '%pg_catalog.pg_advisory_xact_lock%'
+    and body like '%pg_catalog.hashtextextended(v_owner_user_id::text, 170003)%',
+  'Reservations serialize on a dedicated owner-scoped advisory lock'
+)
+from definition;
+
+with definition as (
+  select lower(pg_get_functiondef(
+    'public.reserve_session_share_attachment(uuid,uuid,text,text,text,text,bigint)'::regprocedure
+  )) as body
+)
+select ok(
+  strpos(body, 'pg_catalog.pg_advisory_xact_lock')
+      < strpos(body, 'v_now := clock_timestamp()')
+    and strpos(body, 'v_now := clock_timestamp()')
+      < strpos(body, 'coalesce(sum(attachment.size_bytes), 0)')
+    and strpos(body, 'return query select')
+      < strpos(body, 'coalesce(sum(attachment.size_bytes), 0)')
+    and strpos(body, 'coalesce(sum(attachment.size_bytes), 0)')
+      < strpos(body, 'insert into public.session_share_attachment_objects'),
+  'The lock and refreshed clock precede quotas while idempotence precedes quota enforcement'
+)
+from definition;
+
+select lives_ok(
+  $query$
+    select count(*)
+    from generate_series(1, 5) as input(sequence)
+    cross join lateral public.reserve_session_share_attachment(
+      case
+        when input.sequence <= 3
+          then '00000000-0000-4000-8000-000000002001'::uuid
+        else '00000000-0000-4000-8000-000000002002'::uuid
+      end,
+      tests.get_supabase_uid('shared_attachment_active_limit'),
+      lpad(input.sequence::text, 43, 'A'),
+      lpad(input.sequence::text, 43, 'B'),
+      'active-' || input.sequence::text || '.bin',
+      'application/octet-stream',
+      1
+    ) as reservation
+  $query$,
+  'Five active reservations can be spread across an owner''s shares'
+);
+
+select ok(
+  (
+    select count(*) = 5
+      and count(distinct attachment.share_id) = 2
+    from public.session_share_attachment_objects as attachment
+    where attachment.owner_user_id = tests.get_supabase_uid(
+      'shared_attachment_active_limit'
+    )
+      and attachment.state = 'reserved'
+      and attachment.cleanup_not_before > clock_timestamp()
+  ),
+  'The active reservation limit is owner-wide rather than share-local'
+);
+
+select results_eq(
+  $query$
+    select attachment_id, object_key, was_created
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002002'::uuid,
+      tests.get_supabase_uid('shared_attachment_active_limit'),
+      lpad('5', 43, 'A'),
+      lpad('5', 43, 'B'),
+      'active-5.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  $query$
+    select attachment.id, attachment.object_key, false
+    from public.session_share_attachment_objects as attachment
+    where attachment.share_id = '00000000-0000-4000-8000-000000002002'::uuid
+      and attachment.version_ref = lpad('5', 43, 'B')
+  $query$,
+  'An exact retry remains idempotent after the owner reaches the active limit'
+);
+
+select throws_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002003'::uuid,
+      tests.get_supabase_uid('shared_attachment_active_limit'),
+      lpad('6', 43, 'A'),
+      lpad('6', 43, 'B'),
+      'active-6.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  '55000',
+  'shared attachment reservation limit exceeded',
+  'A sixth active reservation is rejected on a different share'
+);
+
+update public.session_share_attachment_objects
+set
+  state = 'ready',
+  sha256 = repeat('a', 64),
+  finalized_at = clock_timestamp(),
+  updated_at = clock_timestamp()
+where share_id = '00000000-0000-4000-8000-000000002001'::uuid
+  and version_ref = lpad('1', 43, 'B');
+
+select lives_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002003'::uuid,
+      tests.get_supabase_uid('shared_attachment_active_limit'),
+      lpad('6', 43, 'A'),
+      lpad('6', 43, 'B'),
+      'active-6.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  'Finalizing one reservation releases one active owner slot'
+);
+
+select is(
+  (
+    select count(*)
+    from public.session_share_attachment_objects as attachment
+    where attachment.owner_user_id = tests.get_supabase_uid(
+      'shared_attachment_active_limit'
+    )
+      and attachment.state = 'reserved'
+      and attachment.cleanup_not_before > clock_timestamp()
+  ),
+  5::bigint,
+  'The replacement reservation fills the released owner slot'
+);
+
+with seed as materialized (
+  select input.sequence, gen_random_uuid() as attachment_id
+  from generate_series(1, 9) as input(sequence)
+)
+insert into public.session_share_attachment_objects (
+  id,
+  share_id,
+  owner_user_id,
+  attachment_ref,
+  version_ref,
+  object_key,
+  filename,
+  content_type,
+  size_bytes,
+  sha256,
+  state,
+  reservation_expires_at,
+  cleanup_not_before,
+  finalized_at,
+  deletion_requested_at,
+  created_at,
+  updated_at
+)
+select
+  seed.attachment_id,
+  '00000000-0000-4000-8000-000000002101'::uuid,
+  tests.get_supabase_uid('shared_attachment_byte_limit'),
+  lpad(seed.sequence::text, 43, 'C'),
+  lpad(seed.sequence::text, 43, 'D'),
+  tests.get_supabase_uid('shared_attachment_byte_limit')::text
+    || '/00000000-0000-4000-8000-000000002101/'
+    || seed.attachment_id::text || '.sna1',
+  'byte-' || seed.sequence::text || '.bin',
+  'application/octet-stream',
+  536870912,
+  case when seed.sequence between 4 and 6 then repeat('b', 64) end,
+  case
+    when seed.sequence <= 3 then 'reserved'
+    when seed.sequence <= 6 then 'ready'
+    else 'deleting'
+  end,
+  clock_timestamp() - interval '3 hours',
+  clock_timestamp() - interval '2 hours',
+  case
+    when seed.sequence between 4 and 6
+      then clock_timestamp() - interval '1 hour'
+  end,
+  case
+    when seed.sequence >= 7
+      then clock_timestamp() - interval '1 hour'
+  end,
+  clock_timestamp() - interval '4 hours',
+  clock_timestamp() - interval '1 hour'
+from seed;
+
+select ok(
+  (
+    select count(*) = 9
+      and count(distinct attachment.state) = 3
+      and sum(attachment.size_bytes) = 4831838208
+    from public.session_share_attachment_objects as attachment
+    where attachment.owner_user_id = tests.get_supabase_uid(
+      'shared_attachment_byte_limit'
+    )
+  ),
+  'Reserved, ready, and deleting rows all contribute to owner bytes'
+);
+
+select lives_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002102'::uuid,
+      tests.get_supabase_uid('shared_attachment_byte_limit'),
+      repeat('I', 43),
+      repeat('J', 43),
+      'byte-boundary.bin',
+      'application/octet-stream',
+      536870912
+    )
+  $query$,
+  'An owner can reserve exactly up to the five GiB byte boundary'
+);
+
+select is(
+  (
+    select sum(attachment.size_bytes)
+    from public.session_share_attachment_objects as attachment
+    where attachment.owner_user_id = tests.get_supabase_uid(
+      'shared_attachment_byte_limit'
+    )
+  ),
+  5368709120::numeric,
+  'Owner byte accounting reaches exactly five GiB across shares'
+);
+
+select throws_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002103'::uuid,
+      tests.get_supabase_uid('shared_attachment_byte_limit'),
+      repeat('K', 43),
+      repeat('L', 43),
+      'byte-overflow.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  '54000',
+  'shared attachment storage quota exceeded',
+  'One more byte is rejected on another share'
+);
+
+with seed as materialized (
+  select input.sequence, gen_random_uuid() as attachment_id
+  from generate_series(1, 9998) as input(sequence)
+)
+insert into public.session_share_attachment_objects (
+  id,
+  share_id,
+  owner_user_id,
+  attachment_ref,
+  version_ref,
+  object_key,
+  filename,
+  content_type,
+  size_bytes,
+  sha256,
+  state,
+  reservation_expires_at,
+  cleanup_not_before,
+  finalized_at,
+  deletion_requested_at,
+  created_at,
+  updated_at
+)
+select
+  seed.attachment_id,
+  '00000000-0000-4000-8000-000000002201'::uuid,
+  tests.get_supabase_uid('shared_attachment_row_limit'),
+  lpad(seed.sequence::text, 43, 'M'),
+  lpad(seed.sequence::text, 43, 'N'),
+  tests.get_supabase_uid('shared_attachment_row_limit')::text
+    || '/00000000-0000-4000-8000-000000002201/'
+    || seed.attachment_id::text || '.sna1',
+  'row-' || seed.sequence::text || '.bin',
+  'application/octet-stream',
+  1,
+  case when seed.sequence % 3 = 1 then repeat('c', 64) end,
+  case
+    when seed.sequence % 3 = 0 then 'reserved'
+    when seed.sequence % 3 = 1 then 'ready'
+    else 'deleting'
+  end,
+  clock_timestamp() - interval '3 hours',
+  clock_timestamp() - interval '2 hours',
+  case
+    when seed.sequence % 3 = 1
+      then clock_timestamp() - interval '1 hour'
+  end,
+  case
+    when seed.sequence % 3 = 2
+      then clock_timestamp() - interval '1 hour'
+  end,
+  clock_timestamp() - interval '4 hours',
+  clock_timestamp() - interval '1 hour'
+from seed;
+
+insert into public.session_share_attachment_objects (
+  id,
+  share_id,
+  owner_user_id,
+  attachment_ref,
+  version_ref,
+  object_key,
+  filename,
+  content_type,
+  size_bytes,
+  state,
+  reservation_expires_at,
+  cleanup_not_before,
+  deletion_requested_at,
+  gc_lease_id,
+  gc_lease_expires_at,
+  created_at,
+  updated_at
+)
+values (
+  '00000000-0000-4000-8000-000000002299'::uuid,
+  '00000000-0000-4000-8000-000000002201'::uuid,
+  tests.get_supabase_uid('shared_attachment_row_limit'),
+  repeat('O', 43),
+  repeat('P', 43),
+  tests.get_supabase_uid('shared_attachment_row_limit')::text
+    || '/00000000-0000-4000-8000-000000002201/'
+    || '00000000-0000-4000-8000-000000002299.sna1',
+  'row-gc.bin',
+  'application/octet-stream',
+  1,
+  'deleting',
+  clock_timestamp() - interval '3 hours',
+  clock_timestamp() - interval '2 hours',
+  clock_timestamp() - interval '1 hour',
+  '00000000-0000-4000-8000-000000002298'::uuid,
+  clock_timestamp() + interval '5 minutes',
+  clock_timestamp() - interval '4 hours',
+  clock_timestamp() - interval '1 hour'
+);
+
+select ok(
+  (
+    select count(*) = 9999
+      and count(distinct attachment.state) = 3
+    from public.session_share_attachment_objects as attachment
+    where attachment.owner_user_id = tests.get_supabase_uid(
+      'shared_attachment_row_limit'
+    )
+  ),
+  'All attachment states contribute to the owner row count'
+);
+
+select lives_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002202'::uuid,
+      tests.get_supabase_uid('shared_attachment_row_limit'),
+      repeat('Q', 43),
+      repeat('R', 43),
+      'row-boundary.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  'An owner can reserve the ten-thousandth ledger row on another share'
+);
+
+select throws_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002203'::uuid,
+      tests.get_supabase_uid('shared_attachment_row_limit'),
+      repeat('S', 43),
+      repeat('T', 43),
+      'row-overflow.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  '54000',
+  'shared attachment object limit exceeded',
+  'A deleting row still blocks the ten-thousand-and-first reservation'
+);
+
+select is(
+  public.finish_session_share_attachment_deletion(
+    '00000000-0000-4000-8000-000000002299'::uuid,
+    tests.get_supabase_uid('shared_attachment_row_limit')::text
+      || '/00000000-0000-4000-8000-000000002201/'
+      || '00000000-0000-4000-8000-000000002299.sna1',
+    '00000000-0000-4000-8000-000000002298'::uuid
+  ),
+  true,
+  'Physical GC completion removes the deleting ledger row'
+);
+
+select lives_ok(
+  $query$
+    select *
+    from public.reserve_session_share_attachment(
+      '00000000-0000-4000-8000-000000002203'::uuid,
+      tests.get_supabase_uid('shared_attachment_row_limit'),
+      repeat('S', 43),
+      repeat('T', 43),
+      'row-overflow.bin',
+      'application/octet-stream',
+      1
+    )
+  $query$,
+  'A new reservation succeeds only after physical GC frees the owner row'
+);
+
+select is(
+  (
+    select count(*)
+    from public.session_share_attachment_objects as attachment
+    where attachment.owner_user_id = tests.get_supabase_uid(
+      'shared_attachment_row_limit'
+    )
+  ),
+  10000::bigint,
+  'The owner returns to the exact ten-thousand-row boundary after GC'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION
Adds owner-wide limits to shared attachment reservations and prevents a saturated cleanup worker from tight-looping.

- serialize reservations by owner before checking aggregate quotas
- cap each owner at 10,000 ledger rows, 5 GiB, and 5 active reservations
- keep idempotent retries valid at the limits and retain per-share limits
- count reserved, ready, and deleting rows until physical garbage collection
- impose a 5-second floor after full cleanup batches while preserving the 30-second idle poll

Verification:
- 18/18 targeted pgTAP assertions
- 15/15 cleanup-worker tests
- cargo clippy -p api-subscription --lib --no-deps -- -D warnings
- targeted dprint check
- independent review: no P0-P2 findings

No production migration or deployment is performed by this PR.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes hot-path reservation logic and quota accounting in PostgreSQL; incorrect limits or locking could block legitimate uploads or allow overrun until deployed migration runs.
> 
> **Overview**
> Adds **owner-wide quotas** on `reserve_session_share_attachment` and tweaks the subscription **cleanup worker** so saturated batches do not spin.
> 
> The migration redefines reservation to take an **owner-scoped advisory lock**, refresh time, then handle **idempotent retries** before enforcing aggregates: **10,000** ledger rows, **5 GiB** total bytes, and **5** active reservations across all of an owner’s shares (reserved/ready/deleting rows count until physical GC). Existing **per-share** caps (256 objects / 2 GiB) remain. Exact retries still succeed at the limits.
> 
> In `cleanup_worker`, a full attachment/account batch no longer resets the poll timer immediately; it schedules the next tick after at least **5 seconds**, while idle polling stays **30 seconds**. pgTAP and a small Rust unit test cover the new behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e176db4fa1f10c2e50537ba7c6beffcfd99b3f68. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->