### PR TITLE
fix(desktop): preserve startup and warm-instance deep links

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ version = "3.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "519bd3116aeeb42d5372c29d982d16d0170d3d4a5ed85fc7dd91642ffff3c67c"
 dependencies = [
- "darling 0.23.0",
+ "darling 0.20.11",
  "ident_case",
  "prettyplease",
  "proc-macro2",
@@ -9174,7 +9174,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "system-configuration",
  "tokio",
  "tower-service",
@@ -14195,7 +14195,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.2",
  "rustls 0.23.38",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -14233,7 +14233,7 @@ dependencies = [
  "cfg_aliases 0.2.1",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2 0.5.10",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -16262,7 +16262,7 @@ version = "3.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32824fab5e16e6c4d86dc1ba84489390419a39f97699852b66480bb87d297ed8"
 dependencies = [
- "dirs 6.0.0",
+ "dirs 4.0.0",
 ]
 
 [[package]]
@@ -18284,9 +18284,9 @@ dependencies = [
 
 [[package]]
 name = "tauri-plugin-deep-link"
-version = "2.4.7"
+version = "2.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94deb2e2e4641514ac496db2cddcfc850d6fc9d51ea17b82292a0490bd20ba5b"
+checksum = "70ee75bc5627f77bfdf40c913255ebc258117b10ebe2b2239a1a1cf40b0b58aa"
 dependencies = [
  "dunce",
  "plist",
@@ -19091,6 +19091,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tauri",
+ "tauri-plugin-deep-link",
  "thiserror 2.0.18",
  "tracing",
  "windows-sys 0.60.2",

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -71,7 +71,7 @@ tauri-plugin-sfx = { workspace = true }
 tauri-plugin-shell = { workspace = true }
 tauri-plugin-shortcut = { workspace = true }
 tauri-plugin-sidecar2 = { workspace = true }
-tauri-plugin-single-instance = { workspace = true }
+tauri-plugin-single-instance = { workspace = true, features = ["deep-link"] }
 tauri-plugin-store = { workspace = true }
 tauri-plugin-store2 = { workspace = true }
 tauri-plugin-tantivy = { workspace = true }

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -38,7 +38,6 @@
     "bedrock:default",
     "updater:default",
     "updater2:default",
-    "deep-link:default",
     "deeplink2:default",
     "store:default",
     "store2:default",

--- a/apps/desktop/src/shared/deeplink.test.ts
+++ b/apps/desktop/src/shared/deeplink.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it, vi } from "vitest";
+
+import { subscribeThenDrainDeepLinks } from "./deeplink";
+
+describe("desktop deep links", () => {
+  it("subscribes before draining cold-start callbacks", async () => {
+    const order: string[] = [];
+    const handle = vi.fn(() => {
+      order.push("handle");
+    });
+    const deepLink = { to: "/billing/refresh", search: {} } as const;
+
+    const unlisten = await subscribeThenDrainDeepLinks({
+      listen: async () => {
+        order.push("listen");
+        return () => {};
+      },
+      takePendingDeepLinks: async () => {
+        order.push("take");
+        return { status: "ok", data: [deepLink] };
+      },
+      handle,
+    });
+
+    expect(order).toEqual(["listen", "take", "handle"]);
+    expect(handle).toHaveBeenCalledWith(deepLink);
+    expect(unlisten).toEqual(expect.any(Function));
+  });
+});

--- a/apps/desktop/src/shared/deeplink.ts
+++ b/apps/desktop/src/shared/deeplink.ts
@@ -1,0 +1,30 @@
+import type { DeepLink } from "@hypr/plugin-deeplink2";
+
+type CommandResult<T> =
+  | { status: "ok"; data: T }
+  | { status: "error"; error: string };
+
+export async function subscribeThenDrainDeepLinks({
+  listen,
+  takePendingDeepLinks,
+  handle,
+}: {
+  listen: (handler: (deepLink: DeepLink) => void) => Promise<() => void>;
+  takePendingDeepLinks: () => Promise<CommandResult<DeepLink[]>>;
+  handle: (deepLink: DeepLink) => void;
+}) {
+  const unlisten = await listen(handle);
+
+  let result: CommandResult<DeepLink[]>;
+  try {
+    result = await takePendingDeepLinks();
+  } catch {
+    return unlisten;
+  }
+  if (result.status === "ok") {
+    for (const deepLink of result.data) {
+      handle(deepLink);
+    }
+  }
+  return unlisten;
+}

--- a/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
+++ b/apps/desktop/src/shared/hooks/useDeeplinkHandler.ts
@@ -3,6 +3,7 @@ import { isTauri } from "@tauri-apps/api/core";
 import { useScheduleTaskRunCallback } from "tinytick/ui-react";
 
 import {
+  type DeepLink,
   commands as deeplink2Commands,
   events as deeplink2Events,
 } from "@hypr/plugin-deeplink2";
@@ -14,6 +15,7 @@ import {
   createShareOpenProcessor,
   subscribeThenDrainShareOpens,
 } from "~/shared-notes/deeplink";
+import { subscribeThenDrainDeepLinks } from "~/shared/deeplink";
 import { useLatestRef } from "~/shared/hooks/useLatestRef";
 import { useMountEffect } from "~/shared/hooks/useMountEffect";
 import { useTabs } from "~/store/zustand/tabs";
@@ -44,21 +46,7 @@ export function useDeeplinkHandler() {
       });
       scheduleCalendarSyncRef.current();
     };
-    const shareOpenProcessor = createShareOpenProcessor({
-      takePendingShareOpen: deeplink2Commands.takePendingShareOpen,
-      getAuth: () => authRef.current,
-      openNew: (tab) => openNewRef.current(tab),
-    });
-    const shareOpenSubscription = subscribeThenDrainShareOpens({
-      listen: (handler) =>
-        deeplink2Events.shareOpenPendingEvent.listen(({ payload }) => {
-          handler(payload.pending_id);
-        }),
-      listPendingShareOpens: deeplink2Commands.listPendingShareOpens,
-      handle: shareOpenProcessor.handle,
-    });
-
-    const unlisten = deeplink2Events.deepLinkEvent.listen(({ payload }) => {
+    const handleDeepLink = (payload: DeepLink) => {
       if (payload.to === "/auth/callback") {
         const { access_token, refresh_token } = payload.search;
         if (access_token && refresh_token) {
@@ -95,6 +83,27 @@ export function useDeeplinkHandler() {
           });
         }
       }
+    };
+    const deepLinkSubscription = subscribeThenDrainDeepLinks({
+      listen: (handler) =>
+        deeplink2Events.deepLinkEvent.listen(({ payload }) => {
+          handler(payload);
+        }),
+      takePendingDeepLinks: deeplink2Commands.takePendingDeepLinks,
+      handle: handleDeepLink,
+    });
+    const shareOpenProcessor = createShareOpenProcessor({
+      takePendingShareOpen: deeplink2Commands.takePendingShareOpen,
+      getAuth: () => authRef.current,
+      openNew: (tab) => openNewRef.current(tab),
+    });
+    const shareOpenSubscription = subscribeThenDrainShareOpens({
+      listen: (handler) =>
+        deeplink2Events.shareOpenPendingEvent.listen(({ payload }) => {
+          handler(payload.pending_id);
+        }),
+      listPendingShareOpens: deeplink2Commands.listPendingShareOpens,
+      handle: shareOpenProcessor.handle,
     });
 
     return () => {
@@ -102,8 +111,8 @@ export function useDeeplinkHandler() {
       for (const timeoutId of timeoutIds) {
         window.clearTimeout(timeoutId);
       }
+      void deepLinkSubscription.then((fn) => fn()).catch(() => {});
       void shareOpenSubscription.then((fn) => fn()).catch(() => {});
-      void unlisten.then((fn) => fn()).catch(() => {});
     };
   });
 }

--- a/plugins/deeplink2/build.rs
+++ b/plugins/deeplink2/build.rs
@@ -2,6 +2,7 @@ const COMMANDS: &[&str] = &[
     "list_pending_share_opens",
     "start_callback_server",
     "stop_callback_server",
+    "take_pending_deep_links",
     "take_pending_share_open",
 ];
 

--- a/plugins/deeplink2/js/bindings.gen.ts
+++ b/plugins/deeplink2/js/bindings.gen.ts
@@ -22,6 +22,14 @@ async stopCallbackServer() : Promise<Result<null, string>> {
     else return { status: "error", error: e  as any };
 }
 },
+async takePendingDeepLinks() : Promise<Result<DeepLink[], string>> {
+    try {
+    return { status: "ok", data: await TAURI_INVOKE("plugin:deeplink2|take_pending_deep_links") };
+} catch (e) {
+    if(e instanceof Error) throw e;
+    else return { status: "error", error: e  as any };
+}
+},
 async listPendingShareOpens() : Promise<Result<string[], string>> {
     try {
     return { status: "ok", data: await TAURI_INVOKE("plugin:deeplink2|list_pending_share_opens") };

--- a/plugins/deeplink2/permissions/autogenerated/commands/take_pending_deep_links.toml
+++ b/plugins/deeplink2/permissions/autogenerated/commands/take_pending_deep_links.toml
@@ -1,0 +1,13 @@
+# Automatically generated - DO NOT EDIT!
+
+"$schema" = "../../schemas/schema.json"
+
+[[permission]]
+identifier = "allow-take-pending-deep-links"
+description = "Enables the take_pending_deep_links command without any pre-configured scope."
+commands.allow = ["take_pending_deep_links"]
+
+[[permission]]
+identifier = "deny-take-pending-deep-links"
+description = "Denies the take_pending_deep_links command without any pre-configured scope."
+commands.deny = ["take_pending_deep_links"]

--- a/plugins/deeplink2/permissions/autogenerated/reference.md
+++ b/plugins/deeplink2/permissions/autogenerated/reference.md
@@ -7,6 +7,7 @@ Default permissions for the plugin
 - `allow-list-pending-share-opens`
 - `allow-start-callback-server`
 - `allow-stop-callback-server`
+- `allow-take-pending-deep-links`
 - `allow-take-pending-share-open`
 
 ## Permission Table
@@ -92,6 +93,32 @@ Enables the stop_callback_server command without any pre-configured scope.
 <td>
 
 Denies the stop_callback_server command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`deeplink2:allow-take-pending-deep-links`
+
+</td>
+<td>
+
+Enables the take_pending_deep_links command without any pre-configured scope.
+
+</td>
+</tr>
+
+<tr>
+<td>
+
+`deeplink2:deny-take-pending-deep-links`
+
+</td>
+<td>
+
+Denies the take_pending_deep_links command without any pre-configured scope.
 
 </td>
 </tr>

--- a/plugins/deeplink2/permissions/default.toml
+++ b/plugins/deeplink2/permissions/default.toml
@@ -4,5 +4,6 @@ permissions = [
   "allow-list-pending-share-opens",
   "allow-start-callback-server",
   "allow-stop-callback-server",
+  "allow-take-pending-deep-links",
   "allow-take-pending-share-open",
 ]

--- a/plugins/deeplink2/permissions/schemas/schema.json
+++ b/plugins/deeplink2/permissions/schemas/schema.json
@@ -331,6 +331,18 @@
           "markdownDescription": "Denies the stop_callback_server command without any pre-configured scope."
         },
         {
+          "description": "Enables the take_pending_deep_links command without any pre-configured scope.",
+          "type": "string",
+          "const": "allow-take-pending-deep-links",
+          "markdownDescription": "Enables the take_pending_deep_links command without any pre-configured scope."
+        },
+        {
+          "description": "Denies the take_pending_deep_links command without any pre-configured scope.",
+          "type": "string",
+          "const": "deny-take-pending-deep-links",
+          "markdownDescription": "Denies the take_pending_deep_links command without any pre-configured scope."
+        },
+        {
           "description": "Enables the take_pending_share_open command without any pre-configured scope.",
           "type": "string",
           "const": "allow-take-pending-share-open",
@@ -343,10 +355,10 @@
           "markdownDescription": "Denies the take_pending_share_open command without any pre-configured scope."
         },
         {
-          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-pending-share-opens`\n- `allow-start-callback-server`\n- `allow-stop-callback-server`\n- `allow-take-pending-share-open`",
+          "description": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-pending-share-opens`\n- `allow-start-callback-server`\n- `allow-stop-callback-server`\n- `allow-take-pending-deep-links`\n- `allow-take-pending-share-open`",
           "type": "string",
           "const": "default",
-          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-pending-share-opens`\n- `allow-start-callback-server`\n- `allow-stop-callback-server`\n- `allow-take-pending-share-open`"
+          "markdownDescription": "Default permissions for the plugin\n#### This default permission set includes:\n\n- `allow-list-pending-share-opens`\n- `allow-start-callback-server`\n- `allow-stop-callback-server`\n- `allow-take-pending-deep-links`\n- `allow-take-pending-share-open`"
         }
       ]
     }

--- a/plugins/deeplink2/src/commands.rs
+++ b/plugins/deeplink2/src/commands.rs
@@ -1,6 +1,7 @@
+use crate::pending_deep_link::PendingDeepLinkState;
 use crate::pending_share_open::PendingShareOpenState;
 use crate::server;
-use crate::types::ShareOpenRequest;
+use crate::types::{DeepLink, ShareOpenRequest};
 
 #[tauri::command]
 #[specta::specta]
@@ -17,6 +18,20 @@ pub async fn stop_callback_server<R: tauri::Runtime>(
     app: tauri::AppHandle<R>,
 ) -> Result<(), String> {
     server::stop(app).await
+}
+
+#[tauri::command]
+#[specta::specta]
+pub fn take_pending_deep_links(
+    state: tauri::State<'_, PendingDeepLinkState>,
+) -> Result<Vec<DeepLink>, String> {
+    let deep_links = state
+        .take_all()
+        .map_err(|_| "pending deep-link queue unavailable".to_string())?;
+    if !deep_links.is_empty() {
+        tracing::info!(count = deep_links.len(), "pending_deep_links_drained");
+    }
+    Ok(deep_links)
 }
 
 #[tauri::command]

--- a/plugins/deeplink2/src/lib.rs
+++ b/plugins/deeplink2/src/lib.rs
@@ -1,5 +1,6 @@
 mod commands;
 mod error;
+mod pending_deep_link;
 mod pending_share_open;
 pub mod server;
 mod types;
@@ -15,7 +16,7 @@ pub use types::{
 
 use std::str::FromStr;
 
-use tauri::Manager;
+use tauri::{AppHandle, Manager, Runtime};
 use tauri_plugin_deep_link::DeepLinkExt;
 use tauri_specta::Event;
 
@@ -39,6 +40,7 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
         .commands(tauri_specta::collect_commands![
             commands::start_callback_server::<tauri::Wry>,
             commands::stop_callback_server::<tauri::Wry>,
+            commands::take_pending_deep_links,
             commands::list_pending_share_opens,
             commands::take_pending_share_open,
         ])
@@ -50,6 +52,60 @@ fn make_specta_builder<R: tauri::Runtime>() -> tauri_specta::Builder<R> {
         .error_handling(tauri_specta::ErrorHandlingMode::Result)
 }
 
+#[derive(Clone, Copy)]
+enum Delivery {
+    Emit,
+    Queue,
+}
+
+fn process_url<R: Runtime>(app_handle: &AppHandle<R>, url: &url::Url, delivery: Delivery) {
+    let url_str = url.as_str();
+    let redacted = redact_url(url_str);
+    tracing::info!(url = %redacted, "deeplink_received");
+
+    match types::IncomingDeepLink::from_str(url_str) {
+        Ok(types::IncomingDeepLink::Existing(deep_link)) => {
+            tracing::info!(path = deep_link.path(), "deeplink_parsed");
+            match delivery {
+                Delivery::Emit => {
+                    if let Err(error) = DeepLinkEvent(deep_link).emit(app_handle) {
+                        tracing::error!(?error, "deeplink_event_emit_failed");
+                    }
+                }
+                Delivery::Queue => {
+                    if app_handle
+                        .state::<pending_deep_link::PendingDeepLinkState>()
+                        .push(deep_link)
+                        .is_err()
+                    {
+                        tracing::error!("pending_deep_link_queue_unavailable");
+                    }
+                }
+            }
+        }
+        Ok(types::IncomingDeepLink::ShareOpen(request)) => {
+            let state = app_handle.state::<pending_share_open::PendingShareOpenState>();
+            match state.push(request) {
+                Ok(pending_id) => {
+                    tracing::info!(path = "/share/open", "deeplink_parsed");
+                    if matches!(delivery, Delivery::Emit)
+                        && let Err(error) =
+                            (types::ShareOpenPendingEvent { pending_id }).emit(app_handle)
+                    {
+                        tracing::error!(?error, "deeplink_event_emit_failed");
+                    }
+                }
+                Err(()) => {
+                    tracing::error!("pending_share_open_queue_unavailable");
+                }
+            }
+        }
+        Err(error) => {
+            tracing::debug!(?error, url = %redacted, "deeplink_parse_failed");
+        }
+    }
+}
+
 pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
     let specta_builder = make_specta_builder();
 
@@ -58,46 +114,29 @@ pub fn init<R: tauri::Runtime>() -> tauri::plugin::TauriPlugin<R> {
         .setup(move |app, _api| {
             specta_builder.mount_events(app);
             app.manage(server::CallbackServerState::new());
+            app.manage(pending_deep_link::PendingDeepLinkState::default());
             app.manage(pending_share_open::PendingShareOpenState::default());
 
             let app_handle = app.clone();
+            let startup_app_handle = app_handle.clone();
 
             app.deep_link().on_open_url(move |event| {
                 for url in event.urls() {
-                    let url_str = url.as_str();
-                    let redacted = redact_url(url_str);
-                    tracing::info!(url = %redacted, "deeplink_received");
-
-                    match types::IncomingDeepLink::from_str(url_str) {
-                        Ok(types::IncomingDeepLink::Existing(deep_link)) => {
-                            tracing::info!(path = deep_link.path(), "deeplink_parsed");
-                            if let Err(e) = DeepLinkEvent(deep_link).emit(&app_handle) {
-                                tracing::error!(error = ?e, "deeplink_event_emit_failed");
-                            }
-                        }
-                        Ok(types::IncomingDeepLink::ShareOpen(request)) => {
-                            let state =
-                                app_handle.state::<pending_share_open::PendingShareOpenState>();
-                            match state.push(request) {
-                                Ok(pending_id) => {
-                                    tracing::info!(path = "/share/open", "deeplink_parsed");
-                                    if let Err(e) = (types::ShareOpenPendingEvent { pending_id })
-                                        .emit(&app_handle)
-                                    {
-                                        tracing::error!(error = ?e, "deeplink_event_emit_failed");
-                                    }
-                                }
-                                Err(()) => {
-                                    tracing::error!("pending_share_open_queue_unavailable");
-                                }
-                            }
-                        }
-                        Err(e) => {
-                            tracing::debug!(error = ?e, url = %redacted, "deeplink_parse_failed");
-                        }
-                    }
+                    process_url(&app_handle, &url, Delivery::Emit);
                 }
             });
+
+            match app.deep_link().get_current() {
+                Ok(Some(urls)) => {
+                    for url in urls {
+                        process_url(&startup_app_handle, &url, Delivery::Queue);
+                    }
+                }
+                Ok(None) => {}
+                Err(error) => {
+                    tracing::error!(?error, "deeplink_current_read_failed");
+                }
+            }
 
             Ok(())
         })

--- a/plugins/deeplink2/src/pending_deep_link.rs
+++ b/plugins/deeplink2/src/pending_deep_link.rs
@@ -1,0 +1,134 @@
+use std::collections::VecDeque;
+use std::sync::Mutex;
+use std::time::{Duration, Instant};
+
+use crate::types::DeepLink;
+
+const PENDING_DEEP_LINK_CAPACITY: usize = 32;
+const PENDING_DEEP_LINK_TTL: Duration = Duration::from_secs(2 * 60);
+
+struct Entry {
+    deep_link: DeepLink,
+    expires_at: Instant,
+}
+
+pub(crate) struct PendingDeepLinkState {
+    entries: Mutex<VecDeque<Entry>>,
+    capacity: usize,
+    ttl: Duration,
+}
+
+impl Default for PendingDeepLinkState {
+    fn default() -> Self {
+        Self {
+            entries: Mutex::new(VecDeque::new()),
+            capacity: PENDING_DEEP_LINK_CAPACITY,
+            ttl: PENDING_DEEP_LINK_TTL,
+        }
+    }
+}
+
+impl PendingDeepLinkState {
+    pub(crate) fn push(&self, deep_link: DeepLink) -> Result<(), ()> {
+        self.push_at(deep_link, Instant::now())
+    }
+
+    pub(crate) fn take_all(&self) -> Result<Vec<DeepLink>, ()> {
+        self.take_all_at(Instant::now())
+    }
+
+    fn push_at(&self, deep_link: DeepLink, now: Instant) -> Result<(), ()> {
+        let mut entries = self.entries.lock().map_err(|_| ())?;
+        prune_expired(&mut entries, now);
+        while entries.len() >= self.capacity {
+            entries.pop_front();
+        }
+        entries.push_back(Entry {
+            deep_link,
+            expires_at: now + self.ttl,
+        });
+        Ok(())
+    }
+
+    fn take_all_at(&self, now: Instant) -> Result<Vec<DeepLink>, ()> {
+        let mut entries = self.entries.lock().map_err(|_| ())?;
+        prune_expired(&mut entries, now);
+        Ok(entries.drain(..).map(|entry| entry.deep_link).collect())
+    }
+
+    #[cfg(test)]
+    fn for_test(capacity: usize, ttl: Duration) -> Self {
+        Self {
+            entries: Mutex::new(VecDeque::new()),
+            capacity,
+            ttl,
+        }
+    }
+}
+
+fn prune_expired(entries: &mut VecDeque<Entry>, now: Instant) {
+    entries.retain(|entry| entry.expires_at > now);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{AuthCallbackSearch, BillingRefreshSearch};
+
+    fn deep_link() -> DeepLink {
+        DeepLink::BillingRefresh(BillingRefreshSearch {})
+    }
+
+    #[test]
+    fn drains_auth_tokens_once_without_debugging_them() {
+        let state = PendingDeepLinkState::for_test(2, Duration::from_secs(60));
+        let now = Instant::now();
+        let access_token = "fake-access-secret";
+        let refresh_token = "fake-refresh-secret";
+        state
+            .push_at(
+                DeepLink::AuthCallback(AuthCallbackSearch {
+                    access_token: access_token.to_string(),
+                    refresh_token: refresh_token.to_string(),
+                }),
+                now,
+            )
+            .unwrap();
+
+        let drained = state.take_all_at(now).unwrap();
+        assert!(matches!(
+            &drained[..],
+            [DeepLink::AuthCallback(search)]
+                if search.access_token == access_token && search.refresh_token == refresh_token
+        ));
+        let debug = format!("{drained:?}");
+        assert!(!debug.contains(access_token));
+        assert!(!debug.contains(refresh_token));
+        assert!(state.take_all_at(now).unwrap().is_empty());
+    }
+
+    #[test]
+    fn evicts_the_oldest_entry_at_capacity() {
+        let state = PendingDeepLinkState::for_test(2, Duration::from_secs(60));
+        let now = Instant::now();
+        state.push_at(deep_link(), now).unwrap();
+        state.push_at(deep_link(), now).unwrap();
+        state.push_at(deep_link(), now).unwrap();
+
+        assert_eq!(state.take_all_at(now).unwrap().len(), 2);
+    }
+
+    #[test]
+    fn drops_expired_entries() {
+        let state = PendingDeepLinkState::for_test(2, Duration::from_secs(5));
+        let now = Instant::now();
+        state.push_at(deep_link(), now).unwrap();
+
+        assert!(
+            state
+                .take_all_at(now + Duration::from_secs(5))
+                .unwrap()
+                .is_empty()
+        );
+    }
+}


### PR DESCRIPTION
Keep authentication and shared-note deep links reliable when Windows launches a new process, forwards a link to an existing instance, or receives a link before the renderer is ready.

## What changed

- Queue startup deep links in the native plugin and drain each link exactly once after the renderer subscribes.
- Forward warm-instance deep links through the single-instance path.
- Bound and expire the native queue, redact sensitive URL data from logs, and expose only the narrow take-pending command.
- Regenerate plugin bindings and permission metadata.

## Verification

- `cargo test -p tauri-plugin-deeplink2`: 12 passed.
- Desktop suite: 244 files / 1,746 tests passed.
- No unresolved review threads or requested changes at publication time.

