### PR TITLE
fix/e2ee-freshness-witness

### DIFF
--- a/crates/api-sync/src/routes/mod.rs
+++ b/crates/api-sync/src/routes/mod.rs
@@ -21,6 +21,7 @@ use crate::snapshot::{
 use crate::state::AppState;
 
 mod attachment_backups;
+mod e2ee_witness;
 mod shared_attachments;
 
 const WORKSPACE_PROJECTION_SELECT: &str = "id,user_id,role,created_at,updated_at,workspace:workspaces!inner(id,owner_user_id,kind,name,created_at,updated_at)";
@@ -30,7 +31,7 @@ const MAX_TOKEN_ATTRIBUTES_BYTES: usize = 8 * 1024;
 const SNAPSHOT_PUBLISH_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
 const MAX_SNAPSHOT_REQUEST_BYTES: usize = MAX_SNAPSHOT_BODY_BYTES + 16 * 1024;
 const MAX_SNAPSHOT_RESPONSE_BYTES: u64 = (MAX_SNAPSHOT_BODY_BYTES + 16 * 1024) as u64;
-const CLOUDSYNC_ENCRYPTION_VERSION: u8 = 1;
+const CLOUDSYNC_ENCRYPTION_VERSION: u8 = 2;
 const E2EE_KEY_ID_HEADER: &str = "x-anarlog-e2ee-key-id";
 
 #[derive(Serialize, utoipa::ToSchema)]
@@ -202,6 +203,7 @@ pub struct ApiDoc;
 pub fn openapi() -> utoipa::openapi::OpenApi {
     let mut openapi = ApiDoc::openapi();
     openapi.merge(attachment_backups::openapi());
+    openapi.merge(e2ee_witness::openapi());
     openapi.merge(shared_attachments::openapi());
     openapi
 }
@@ -210,6 +212,7 @@ pub fn router(state: AppState) -> Router {
     Router::new()
         .route("/token", post(create_credentials))
         .route("/e2ee/identity", put(claim_e2ee_identity))
+        .merge(e2ee_witness::router())
         .route(
             "/shares/{share_id}/snapshot",
             put(publish_session_share_snapshot)
@@ -892,7 +895,7 @@ mod tests {
         assert_eq!(response.headers()[header::CACHE_CONTROL], "no-store");
         let body = response_json(response).await;
         assert_eq!(body["databaseId"], "database-id");
-        assert_eq!(body["encryptionVersion"], 1);
+        assert_eq!(body["encryptionVersion"], 2);
         assert_eq!(body["encryptionKeyId"], TEST_KEY_ID);
         assert_eq!(body["token"], "sqlite-token");
         assert_eq!(body["workspaceId"], "user-123");

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -138,6 +138,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         sql: include_str!("../migrations/20260717140000_attachment_local_state.sql"),
     },
     hypr_db_migrate::MigrationStep {
+        id: "20260717193000_e2ee_freshness_witness",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260717193000_e2ee_freshness_witness.sql"),
+    },
+    hypr_db_migrate::MigrationStep {
         id: "20260717150000_attachment_transfer_jobs",
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260717150000_attachment_transfer_jobs.sql"),
@@ -377,6 +382,8 @@ mod tests {
                 "daily_notes",
                 "e2ee_local_state",
                 "e2ee_records",
+                "e2ee_witness_records",
+                "e2ee_witness_state",
                 "entity_mentions",
                 "events",
                 "humans",
@@ -756,6 +763,24 @@ mod tests {
         assert!(!cloudsync_alter_guard_required("workspaces"));
         assert!(!cloudsync_alter_guard_required("workspace_memberships"));
         assert!(!cloudsync_alter_guard_required("calendars"));
+    }
+
+    #[test]
+    fn e2ee_witness_state_is_local_only() {
+        let migration = APP_MIGRATION_STEPS
+            .iter()
+            .find(|step| step.id == "20260717193000_e2ee_freshness_witness")
+            .unwrap();
+
+        assert_eq!(migration.scope, hypr_db_migrate::MigrationScope::Plain);
+        for table_name in ["e2ee_witness_records", "e2ee_witness_state"] {
+            assert!(
+                !cloudsync_table_registry()
+                    .iter()
+                    .any(|table| table.table_name == table_name)
+            );
+            assert!(!cloudsync_alter_guard_required(table_name));
+        }
     }
 
     #[test]

--- a/crates/db-app/src/lib.rs
+++ b/crates/db-app/src/lib.rs
@@ -138,6 +138,11 @@ pub const APP_MIGRATION_STEPS: &[hypr_db_migrate::MigrationStep] = &[
         sql: include_str!("../migrations/20260717140000_attachment_local_state.sql"),
     },
     hypr_db_migrate::MigrationStep {
+        id: "20260717192000_e2ee_replica_order",
+        scope: hypr_db_migrate::MigrationScope::Plain,
+        sql: include_str!("../migrations/20260717192000_e2ee_replica_order.sql"),
+    },
+    hypr_db_migrate::MigrationStep {
         id: "20260717193000_e2ee_freshness_witness",
         scope: hypr_db_migrate::MigrationScope::Plain,
         sql: include_str!("../migrations/20260717193000_e2ee_freshness_witness.sql"),
@@ -380,6 +385,7 @@ mod tests {
                 "cloudsync_session_evictions",
                 "cloudsync_writable_workspaces",
                 "daily_notes",
+                "e2ee_local_device",
                 "e2ee_local_state",
                 "e2ee_records",
                 "e2ee_witness_records",
@@ -763,6 +769,60 @@ mod tests {
         assert!(!cloudsync_alter_guard_required("workspaces"));
         assert!(!cloudsync_alter_guard_required("workspace_memberships"));
         assert!(!cloudsync_alter_guard_required("calendars"));
+    }
+
+    #[tokio::test]
+    async fn e2ee_order_migration_backfills_the_canonical_payload_locally() {
+        let db = hypr_db_core::Db::connect_memory_plain().await.unwrap();
+        sqlx::raw_sql(include_str!(
+            "../migrations/20260717120000_e2ee_replica.sql"
+        ))
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO e2ee_records (id, workspace_id, payload)
+             VALUES ('record-1', 'workspace-a', 'ciphertext')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        sqlx::query(
+            "INSERT INTO e2ee_local_state (
+               record_id, workspace_id, table_name, row_id, field_name,
+               revision, value_tag, payload_hash
+             ) VALUES (
+               'record-1', 'workspace-a', 'sessions', 'session-1',
+               'title', 1, 'tag', 'hash'
+             )",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+
+        let migration = APP_MIGRATION_STEPS
+            .iter()
+            .find(|step| step.id == "20260717192000_e2ee_replica_order")
+            .unwrap();
+        assert_eq!(migration.scope, hypr_db_migrate::MigrationScope::Plain);
+        sqlx::raw_sql(migration.sql)
+            .execute(db.pool())
+            .await
+            .unwrap();
+
+        let state: (String, String) = sqlx::query_as(
+            "SELECT writer_id, payload FROM e2ee_local_state WHERE record_id = 'record-1'",
+        )
+        .fetch_one(db.pool())
+        .await
+        .unwrap();
+        assert_eq!(state, (String::new(), "ciphertext".to_string()));
+        assert!(
+            !cloudsync_table_registry()
+                .iter()
+                .any(|table| table.table_name == "e2ee_local_device")
+        );
+        assert!(!cloudsync_alter_guard_required("e2ee_local_device"));
     }
 
     #[test]


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 4 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #6126
- <kbd>&nbsp;10&nbsp;</kbd> #6104
- <kbd>&nbsp;9&nbsp;</kbd> #6103
- <kbd>&nbsp;8&nbsp;</kbd> #6102
- <kbd>&nbsp;7&nbsp;</kbd> #6101
- <kbd>&nbsp;6&nbsp;</kbd> #6100
- <kbd>&nbsp;5&nbsp;</kbd> #6125
- <kbd>&nbsp;4&nbsp;</kbd> #6124 👈 
- <kbd>&nbsp;3&nbsp;</kbd> #6123
- <kbd>&nbsp;2&nbsp;</kbd> #6122
- <kbd>&nbsp;1&nbsp;</kbd> #6121
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches E2EE sync contracts (encryption version bump and new witness endpoints) and local migration backfills; witness tables are intentionally not replicated, which clients must align with.
> 
> **Overview**
> Adds **E2EE freshness witness** support on the sync API by wiring a new `e2ee_witness` route module into the router and OpenAPI, alongside bumping **CloudSync encryption version from 1 to 2** in minted credentials (tests updated accordingly).
> 
> On the client DB side, registers two **plain (local-only)** migrations: **`e2ee_replica_order`** backfills canonical `writer_id` / `payload` on `e2ee_local_state` from replica ciphertext and introduces **`e2ee_local_device`** outside CloudSync; **`e2ee_freshness_witness`** adds **`e2ee_witness_records`** and **`e2ee_witness_state`**, also excluded from the CloudSync registry. New tests assert backfill behavior and that witness/device tables are not CloudSync-synced.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 42f4a46a2c4a4183be8532b89df4c02c34d6ce51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->