### PR TITLE
fix/e2ee-production-ready

### DIFF
--- a/.github/scripts/test_verify_cloudsync_e2ee.py
+++ b/.github/scripts/test_verify_cloudsync_e2ee.py
@@ -1,0 +1,55 @@
+import importlib.util
+import pathlib
+import unittest
+from unittest import mock
+
+
+MODULE_PATH = pathlib.Path(__file__).with_name("verify_cloudsync_e2ee.py")
+SPEC = importlib.util.spec_from_file_location("verify_cloudsync_e2ee", MODULE_PATH)
+assert SPEC and SPEC.loader
+verify = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(verify)
+
+
+class VerifyCloudSyncE2eeTests(unittest.TestCase):
+    def test_requires_the_legacy_plaintext_database_to_be_deleted(self) -> None:
+        with mock.patch.object(verify, "management_get", return_value={"id": "legacy"}):
+            with self.assertRaisesRegex(ValueError, "must be deleted"):
+                verify.verify_legacy_database_retired("legacy-id", "management-key")
+
+    def test_accepts_a_missing_legacy_plaintext_database(self) -> None:
+        with mock.patch.object(
+            verify,
+            "management_get",
+            side_effect=verify.ResourceNotFound("not found"),
+        ):
+            verify.verify_legacy_database_retired("legacy-id", "management-key")
+
+    def test_rejects_plaintext_tables_in_the_encrypted_database(self) -> None:
+        with mock.patch.object(
+            verify,
+            "run_sql",
+            return_value=[{"name": "sessions"}, {"name": "transcripts"}],
+        ):
+            with self.assertRaisesRegex(ValueError, "sessions, transcripts"):
+                verify.verify_no_plaintext_tables(
+                    "https://sqlite.example",
+                    "issuer-key",
+                    "encrypted-database",
+                )
+
+    def test_accepts_an_encrypted_database_without_plaintext_tables(self) -> None:
+        with mock.patch.object(verify, "run_sql", return_value=[]) as run_sql:
+            verify.verify_no_plaintext_tables(
+                "https://sqlite.example",
+                "issuer-key",
+                "encrypted-database",
+            )
+
+        query = run_sql.call_args.args[3]
+        for table in verify.LEGACY_PLAINTEXT_TABLES:
+            self.assertIn(f"'{table}'", query)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/.github/scripts/verify_cloudsync_e2ee.py
+++ b/.github/scripts/verify_cloudsync_e2ee.py
@@ -22,6 +22,16 @@ REQUIRED_SECRETS = (
     "SQLITECLOUD_PROJECT_URL",
     "SQLITECLOUD_TOKEN_ISSUER_API_KEY",
 )
+LEGACY_PLAINTEXT_TABLES = (
+    "action_items",
+    "events",
+    "humans",
+    "organizations",
+    "session_documents",
+    "session_participants",
+    "sessions",
+    "transcripts",
+)
 SENSITIVE_PARENT_ENV = {
     "ACTIONS_ID_TOKEN_REQUEST_TOKEN",
     "ACTIONS_RUNTIME_TOKEN",
@@ -38,6 +48,10 @@ class NoRedirectHandler(urllib.request.HTTPRedirectHandler):
 
 
 HTTP = urllib.request.build_opener(NoRedirectHandler())
+
+
+class ResourceNotFound(RuntimeError):
+    pass
 
 
 def load_secrets(path: str) -> dict[str, str]:
@@ -92,6 +106,8 @@ def request_json(
         with HTTP.open(request, timeout=30) as response:
             envelope = json.load(response)
     except urllib.error.HTTPError as error:
+        if error.code == 404:
+            raise ResourceNotFound(f"{label} returned HTTP 404") from error
         raise RuntimeError(f"{label} failed with HTTP {error.code}") from error
     except urllib.error.URLError as error:
         raise RuntimeError(f"{label} could not connect") from error
@@ -113,6 +129,44 @@ def management_get(path: str, management_key: str, label: str) -> object:
         label,
     )
     return response_data(envelope, label)
+
+
+def verify_legacy_database_retired(legacy_id: str, management_key: str) -> None:
+    encoded_legacy_id = urllib.parse.quote(legacy_id, safe="")
+    try:
+        management_get(
+            f"/v1/databases/{encoded_legacy_id}",
+            management_key,
+            "legacy database retirement check",
+        )
+    except ResourceNotFound:
+        return
+
+    raise ValueError(
+        "Legacy plaintext CloudSync database must be deleted before E2EE deployment"
+    )
+
+
+def verify_no_plaintext_tables(
+    project_url: str,
+    issuer_key: str,
+    database_name: str,
+) -> None:
+    quoted_names = ", ".join(f"'{name}'" for name in LEGACY_PLAINTEXT_TABLES)
+    rows = run_sql(
+        project_url,
+        issuer_key,
+        database_name,
+        "SELECT name FROM sqlite_schema "
+        f"WHERE type = 'table' AND name IN ({quoted_names}) ORDER BY name",
+        "E2EE plaintext table check",
+    )
+    plaintext_tables = [str(row.get("name", "")) for row in rows if row.get("name")]
+    if plaintext_tables:
+        raise ValueError(
+            "E2EE database contains legacy plaintext tables: "
+            + ", ".join(plaintext_tables)
+        )
 
 
 def run_sql(
@@ -144,30 +198,21 @@ def verify_remote_database(values: dict[str, str]) -> None:
 
     management_key = values["SQLITECLOUD_CLOUDSYNC_MANAGEMENT_API_KEY"]
     encoded_database_id = urllib.parse.quote(database_id, safe="")
-    encoded_legacy_id = urllib.parse.quote(legacy_id, safe="")
     database = management_get(
         f"/v1/databases/{encoded_database_id}",
         management_key,
         "E2EE database registration check",
     )
-    legacy_database = management_get(
-        f"/v1/databases/{encoded_legacy_id}",
-        management_key,
-        "legacy database registration check",
-    )
-    if not isinstance(database, dict) or not isinstance(legacy_database, dict):
+    if not isinstance(database, dict):
         raise ValueError("CloudSync database registration metadata is invalid")
 
     database_name = str(database.get("databaseName", "")).strip()
-    legacy_database_name = str(legacy_database.get("databaseName", "")).strip()
     project_id = str(database.get("projectId", "")).strip()
-    legacy_project_id = str(legacy_database.get("projectId", "")).strip()
-    if not all((database_name, legacy_database_name, project_id, legacy_project_id)):
+    if not all((database_name, project_id)):
         raise ValueError(
             "CloudSync database registration is missing its physical target"
         )
-    if (project_id, database_name) == (legacy_project_id, legacy_database_name):
-        raise ValueError("E2EE CloudSync database reuses the legacy physical database")
+    verify_legacy_database_retired(legacy_id, management_key)
 
     connection = management_get(
         f"/v1/databases/{encoded_database_id}/connection",
@@ -196,6 +241,7 @@ def verify_remote_database(values: dict[str, str]) -> None:
     project_url = values["SQLITECLOUD_PROJECT_URL"]
     validate_https_origin(project_url, "SQLITECLOUD_PROJECT_URL")
     issuer_key = values["SQLITECLOUD_TOKEN_ISSUER_API_KEY"]
+    verify_no_plaintext_tables(project_url, issuer_key, database_name)
     ddl_rows = run_sql(
         project_url,
         issuer_key,

--- a/.github/workflows/api_cd.yaml
+++ b/.github/workflows/api_cd.yaml
@@ -38,6 +38,8 @@ jobs:
         run: |
           set -euo pipefail
 
+          python3 .github/scripts/test_verify_cloudsync_e2ee.py
+
           cloudsync_secrets_json="$(mktemp)"
           trap 'rm -f "$cloudsync_secrets_json"' EXIT
 

--- a/.gitignore
+++ b/.gitignore
@@ -28,4 +28,5 @@ internal
 
 # Agent scratch / reference material (not for commit)
 .tmp/
-
+.codex-security-artifacts-*/
+.codex-security-work-ledger-*.jsonl

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18260,6 +18260,8 @@ dependencies = [
  "db-reactive",
  "e2ee",
  "fs-sync-core",
+ "futures-util",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "sha2 0.11.0",
@@ -18277,6 +18279,7 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+ "wiremock",
 ]
 
 [[package]]

--- a/apps/desktop/src/auth/cloudsync.test.ts
+++ b/apps/desktop/src/auth/cloudsync.test.ts
@@ -57,10 +57,17 @@ function session(accessToken = "supabase-token") {
   } as Session;
 }
 
-function credentialsResponse(workspaceId = "user-id") {
+function witness(accessToken = "supabase-token", workspaceId = "user-id") {
+  return {
+    endpoint: `https://api.test/sync/e2ee/witness/${workspaceId}`,
+    accessToken,
+  };
+}
+
+function credentialsResponse(workspaceId = "user-id", encryptionVersion = 2) {
   return new Response(
     JSON.stringify({
-      encryptionVersion: 1,
+      encryptionVersion,
       encryptionKeyId: E2EE_KEY_ID,
       databaseId: "database-id",
       token: "sqlite-token",
@@ -76,7 +83,7 @@ function credentialsResponse(workspaceId = "user-id") {
 
 function projectedCredentialsPayload() {
   return {
-    encryptionVersion: 1,
+    encryptionVersion: 2,
     encryptionKeyId: E2EE_KEY_ID,
     databaseId: "database-id",
     token: "sqlite-token",
@@ -232,6 +239,7 @@ describe("CloudSync auth lifecycle", () => {
       "database-id",
       "sqlite-token",
       "user-id",
+      witness(),
     );
     expect(startCloudsyncInitialSyncProgress).toHaveBeenCalledWith("user-id");
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
@@ -257,6 +265,7 @@ describe("CloudSync auth lifecycle", () => {
       "database-id",
       "sqlite-token",
       "user-id",
+      witness(),
       {
         accountUserId: "user-id",
         personalWorkspaceId: "user-id",
@@ -343,7 +352,7 @@ describe("CloudSync auth lifecycle", () => {
         Promise.resolve(
           new Response(
             JSON.stringify({
-              encryptionVersion: 1,
+              encryptionVersion: 2,
               encryptionKeyId: E2EE_KEY_ID,
               databaseId: "database-id",
               token: "sqlite-token",
@@ -355,6 +364,18 @@ describe("CloudSync auth lifecycle", () => {
           ),
         ),
       ),
+    );
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    await handleCloudsyncAuthChange("SIGNED_IN", session());
+
+    expect(configureCloudsyncToken).not.toHaveBeenCalled();
+  });
+
+  test("rejects credentials from the pre-witness encryption protocol", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(() => Promise.resolve(credentialsResponse("user-id", 1))),
     );
     vi.spyOn(console, "warn").mockImplementation(() => {});
 
@@ -716,6 +737,7 @@ describe("CloudSync auth lifecycle", () => {
       "database-id",
       "sqlite-token",
       "user-id",
+      witness(),
     );
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
   });
@@ -734,6 +756,7 @@ describe("CloudSync auth lifecycle", () => {
         "database-id",
         "sqlite-token",
         "user-id",
+        witness(),
       );
       expect(suspendCloudsync).toHaveBeenCalledTimes(1);
     },
@@ -855,6 +878,7 @@ describe("CloudSync auth lifecycle", () => {
       "database-id",
       "sqlite-token",
       "user-id",
+      witness(),
     );
     expect(suspendCloudsync).toHaveBeenCalledTimes(1);
   });

--- a/apps/desktop/src/auth/cloudsync.ts
+++ b/apps/desktop/src/auth/cloudsync.ts
@@ -31,7 +31,7 @@ export type CloudsyncAuthChangeResult = "ok" | "account_mismatch";
 type CloudsyncAccountMismatchHandler = () => Promise<void>;
 
 type CloudsyncCredentialCore = {
-  encryptionVersion: 1;
+  encryptionVersion: 2;
   encryptionKeyId: string;
   databaseId: string;
   token: string;
@@ -246,7 +246,7 @@ function isCredentials(value: unknown): value is CloudsyncCredentials {
 
   const candidate = value as Record<string, unknown>;
   const hasCoreCredentials =
-    candidate.encryptionVersion === 1 &&
+    candidate.encryptionVersion === 2 &&
     typeof candidate.encryptionKeyId === "string" &&
     /^[A-Za-z0-9_-]{22}$/.test(candidate.encryptionKeyId) &&
     typeof candidate.databaseId === "string" &&
@@ -619,6 +619,13 @@ async function activateCloudsync(
             credentials.token,
             accountUserId,
             {
+              endpoint: new URL(
+                `/sync/e2ee/witness/${credentials.personalWorkspaceId}`,
+                env.VITE_API_URL,
+              ).toString(),
+              accessToken: session.access_token,
+            },
+            {
               accountUserId: credentials.accountUserId,
               personalWorkspaceId: credentials.personalWorkspaceId,
               workspaces: credentials.workspaces,
@@ -628,6 +635,13 @@ async function activateCloudsync(
             credentials.databaseId,
             credentials.token,
             accountUserId,
+            {
+              endpoint: new URL(
+                `/sync/e2ee/witness/${credentials.workspaceId}`,
+                env.VITE_API_URL,
+              ).toString(),
+              accessToken: session.access_token,
+            },
           );
 
       if (configuration === "configured" && activeGeneration === generation) {

--- a/apps/desktop/src/settings/general/e2ee-setup.test.tsx
+++ b/apps/desktop/src/settings/general/e2ee-setup.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import {
+  act,
   cleanup,
   fireEvent,
   render,
@@ -12,6 +13,8 @@ const mocks = vi.hoisted(() => ({
   create: vi.fn(),
   import: vi.fn(),
   inspect: vi.fn(),
+  readClipboard: vi.fn(),
+  writeClipboard: vi.fn(),
 }));
 
 vi.mock("@hypr/plugin-db", () => ({
@@ -22,15 +25,35 @@ vi.mock("@hypr/plugin-db", () => ({
 
 import { E2eeSetupDialog } from "./e2ee-setup";
 
+const originalClipboard = Object.getOwnPropertyDescriptor(
+  navigator,
+  "clipboard",
+);
+
 describe("E2eeSetupDialog", () => {
   afterEach(() => {
     cleanup();
     vi.clearAllMocks();
     vi.unstubAllGlobals();
+    vi.useRealTimers();
+    if (originalClipboard) {
+      Object.defineProperty(navigator, "clipboard", originalClipboard);
+    } else {
+      Reflect.deleteProperty(navigator, "clipboard");
+    }
   });
 
   const renderDialog = (onReady = vi.fn()) => {
     mocks.inspect.mockResolvedValue({ keyId: "abcdefghijklmnopqrstuv" });
+    mocks.readClipboard.mockResolvedValue("");
+    mocks.writeClipboard.mockResolvedValue(undefined);
+    Object.defineProperty(navigator, "clipboard", {
+      configurable: true,
+      value: {
+        readText: mocks.readClipboard,
+        writeText: mocks.writeClipboard,
+      },
+    });
     vi.stubGlobal(
       "fetch",
       vi.fn(() =>
@@ -92,6 +115,48 @@ describe("E2eeSetupDialog", () => {
       ),
     );
     expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it("clears a copied recovery key after one minute when it is still on the clipboard", async () => {
+    const recoveryKey =
+      "anarlog-e2ee-v1:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+    mocks.create.mockResolvedValue(recoveryKey);
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Create a recovery key"));
+    expect(await screen.findByText(recoveryKey)).toBeTruthy();
+    mocks.readClipboard.mockResolvedValue(recoveryKey);
+    vi.useFakeTimers();
+
+    fireEvent.click(screen.getByText("Copy recovery key"));
+    await act(async () => {});
+    expect(mocks.writeClipboard).toHaveBeenCalledWith(recoveryKey);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(mocks.writeClipboard).toHaveBeenLastCalledWith("");
+  });
+
+  it("preserves clipboard content copied after the recovery key", async () => {
+    const recoveryKey =
+      "anarlog-e2ee-v1:abcdefghijklmnopqrstuvwxyz0123456789ABCDEFG";
+    mocks.create.mockResolvedValue(recoveryKey);
+    renderDialog();
+
+    fireEvent.click(screen.getByText("Create a recovery key"));
+    expect(await screen.findByText(recoveryKey)).toBeTruthy();
+    mocks.readClipboard.mockResolvedValue("new clipboard content");
+    vi.useFakeTimers();
+
+    fireEvent.click(screen.getByText("Copy recovery key"));
+    await act(async () => {});
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+
+    expect(mocks.writeClipboard).toHaveBeenCalledTimes(1);
+    expect(mocks.writeClipboard).toHaveBeenCalledWith(recoveryKey);
   });
 
   it("does not store a recovery key rejected by the account identity", async () => {

--- a/apps/desktop/src/settings/general/e2ee-setup.tsx
+++ b/apps/desktop/src/settings/general/e2ee-setup.tsx
@@ -2,7 +2,7 @@ import { Trans } from "@lingui/react/macro";
 import { useForm } from "@tanstack/react-form";
 import { useMutation } from "@tanstack/react-query";
 import { CopyIcon, KeyRoundIcon, Loader2Icon } from "lucide-react";
-import { useState } from "react";
+import { useRef, useState } from "react";
 
 import {
   createE2eeIdentity,
@@ -21,6 +21,18 @@ import {
 import { Input } from "@hypr/ui/components/ui/input";
 
 import { env } from "~/env";
+
+const RECOVERY_KEY_CLIPBOARD_TTL_MS = 60_000;
+
+async function clearRecoveryKeyClipboard(recoveryKey: string) {
+  try {
+    if ((await navigator.clipboard.readText()) === recoveryKey) {
+      await navigator.clipboard.writeText("");
+    }
+  } catch {
+    // Clipboard reads are not available on every platform.
+  }
+}
 
 async function claimE2eeIdentity(accessToken: string, keyId: string) {
   const response = await fetch(
@@ -63,6 +75,7 @@ export function E2eeSetupDialog({
 }) {
   const [mode, setMode] = useState<"choose" | "import">("choose");
   const [recoveryKey, setRecoveryKey] = useState<string | null>(null);
+  const clipboardClearTimer = useRef<number | null>(null);
   const createMutation = useMutation({
     mutationFn: () => createE2eeIdentity(accountUserId),
     onSuccess: setRecoveryKey,
@@ -75,11 +88,24 @@ export function E2eeSetupDialog({
     },
     onSuccess: onReady,
   });
+  const copyMutation = useMutation({
+    mutationFn: async (recoveryKey: string) => {
+      await navigator.clipboard.writeText(recoveryKey);
+      if (clipboardClearTimer.current !== null) {
+        window.clearTimeout(clipboardClearTimer.current);
+      }
+      clipboardClearTimer.current = window.setTimeout(() => {
+        clipboardClearTimer.current = null;
+        void clearRecoveryKeyClipboard(recoveryKey);
+      }, RECOVERY_KEY_CLIPBOARD_TTL_MS);
+    },
+  });
   const importForm = useForm({
     defaultValues: { recoveryKey: "" },
     onSubmit: ({ value }) => importMutation.mutate(value.recoveryKey.trim()),
   });
-  const error = createMutation.error ?? importMutation.error;
+  const error =
+    createMutation.error ?? importMutation.error ?? copyMutation.error;
   const pending = createMutation.isPending || importMutation.isPending;
 
   const setOpen = (nextOpen: boolean) => {
@@ -127,11 +153,15 @@ export function E2eeSetupDialog({
               <Button
                 variant="outline"
                 className="h-8 w-full rounded-full text-xs"
-                onClick={() => navigator.clipboard.writeText(recoveryKey)}
+                onClick={() => copyMutation.mutate(recoveryKey)}
+                disabled={copyMutation.isPending}
               >
                 <CopyIcon className="size-3.5" aria-hidden="true" />
                 <Trans>Copy recovery key</Trans>
               </Button>
+              <p className="text-muted-foreground text-center text-[11px] leading-4">
+                Clipboard copies clear after 60 seconds when supported.
+              </p>
             </div>
           ) : mode === "import" ? (
             <div className="space-y-3">

--- a/crates/api-sync/src/error.rs
+++ b/crates/api-sync/src/error.rs
@@ -17,6 +17,15 @@ pub enum SyncError {
     #[error("This account is protected by a different E2EE recovery key")]
     E2eeKeyMismatch,
 
+    #[error("E2EE freshness witness access is not permitted")]
+    E2eeWitnessForbidden,
+
+    #[error("E2EE freshness witness is not initialized")]
+    E2eeWitnessUninitialized,
+
+    #[error("E2EE freshness witness is unavailable")]
+    E2eeWitnessServiceUnavailable,
+
     #[error("Shared note publication is not permitted")]
     SnapshotPublicationForbidden,
 
@@ -76,6 +85,22 @@ impl IntoResponse for SyncError {
                 StatusCode::CONFLICT,
                 "e2ee_key_mismatch",
                 "This account is protected by a different E2EE recovery key".to_string(),
+            ),
+            Self::E2eeWitnessForbidden => (
+                StatusCode::FORBIDDEN,
+                "e2ee_witness_forbidden",
+                "E2EE freshness witness access is not permitted".to_string(),
+            ),
+            Self::E2eeWitnessUninitialized => (
+                StatusCode::CONFLICT,
+                "e2ee_witness_uninitialized",
+                "Open an existing trusted device before setting up encrypted sync on this device"
+                    .to_string(),
+            ),
+            Self::E2eeWitnessServiceUnavailable => (
+                StatusCode::BAD_GATEWAY,
+                "e2ee_witness_unavailable",
+                "E2EE freshness witness is unavailable".to_string(),
             ),
             Self::SnapshotPublicationForbidden => (
                 StatusCode::FORBIDDEN,

--- a/crates/api-sync/src/routes/e2ee_witness.rs
+++ b/crates/api-sync/src/routes/e2ee_witness.rs
@@ -1,0 +1,649 @@
+use axum::{
+    Extension, Json, Router,
+    extract::{DefaultBodyLimit, Path, Query, State},
+    http::{HeaderValue, header},
+    routing::get,
+};
+use hypr_api_auth::AuthContext;
+use reqwest::StatusCode as HttpStatusCode;
+use serde::{Deserialize, Serialize};
+use utoipa::OpenApi;
+use uuid::Uuid;
+
+use crate::error::{Result, SyncError};
+use crate::state::AppState;
+
+const MAX_EVENTS_PER_BATCH: usize = 16;
+const MAX_EVENT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_WITNESS_REQUEST_BYTES: usize = 64 * 1024 * 1024;
+const MAX_WITNESS_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+const WITNESS_PAGE_SIZE: i32 = 3;
+const WITNESS_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+#[derive(Clone, Debug, Deserialize, Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct E2eeWitnessEvent {
+    record_id: String,
+    payload_hash: String,
+    payload: String,
+}
+
+#[derive(Deserialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct PublishE2eeWitnessRequest {
+    initialize: bool,
+    events: Vec<E2eeWitnessEvent>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct PublishE2eeWitnessResponse {
+    initialized_at: String,
+    head_sequence: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct ReadE2eeWitnessQuery {
+    #[serde(default)]
+    after_sequence: u64,
+    through_sequence: Option<u64>,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct E2eeWitnessPageEvent {
+    sequence: u64,
+    record_id: String,
+    payload_hash: String,
+    payload: String,
+}
+
+#[derive(Serialize, utoipa::ToSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct E2eeWitnessPage {
+    initialized: bool,
+    initialized_at: Option<String>,
+    head_sequence: u64,
+    through_sequence: u64,
+    next_after_sequence: u64,
+    events: Vec<E2eeWitnessPageEvent>,
+}
+
+#[derive(Serialize)]
+struct PublishRpcRequest<'a> {
+    p_actor_user_id: &'a str,
+    p_workspace_id: &'a str,
+    p_initialize: bool,
+    p_events: &'a [PublishRpcEvent<'a>],
+}
+
+#[derive(Serialize)]
+struct PublishRpcEvent<'a> {
+    record_id: &'a str,
+    payload_hash: &'a str,
+    payload: &'a str,
+}
+
+#[derive(Serialize)]
+struct ReadRpcRequest<'a> {
+    p_actor_user_id: &'a str,
+    p_workspace_id: &'a str,
+    p_after_sequence: i64,
+    p_through_sequence: Option<i64>,
+    p_limit: i32,
+}
+
+#[derive(Deserialize)]
+struct PublishRpcRow {
+    initialized_at: String,
+    head_sequence: i64,
+}
+
+#[derive(Deserialize)]
+struct ReadRpcRow {
+    initialized_at: Option<String>,
+    head_sequence: i64,
+    through_sequence: i64,
+    event_sequence: Option<i64>,
+    record_id: Option<String>,
+    payload_hash: Option<String>,
+    payload: Option<String>,
+}
+
+#[derive(Deserialize)]
+struct PostgrestError {
+    code: String,
+}
+
+#[derive(OpenApi)]
+#[openapi(
+    paths(read_e2ee_witness, publish_e2ee_witness),
+    components(schemas(
+        E2eeWitnessEvent,
+        PublishE2eeWitnessRequest,
+        PublishE2eeWitnessResponse,
+        E2eeWitnessPageEvent,
+        E2eeWitnessPage
+    ))
+)]
+pub struct ApiDoc;
+
+pub fn openapi() -> utoipa::openapi::OpenApi {
+    ApiDoc::openapi()
+}
+
+pub fn router() -> Router<AppState> {
+    Router::new()
+        .route(
+            "/e2ee/witness/{workspace_id}",
+            get(read_e2ee_witness).post(publish_e2ee_witness),
+        )
+        .layer(DefaultBodyLimit::max(MAX_WITNESS_REQUEST_BYTES))
+}
+
+#[utoipa::path(
+    get,
+    path = "/e2ee/witness/{workspace_id}",
+    tag = "sync",
+    params(
+        ("workspace_id" = String, Path, description = "Personal workspace ID"),
+        ("afterSequence" = Option<u64>, Query, description = "Last applied witness sequence"),
+        ("throughSequence" = Option<u64>, Query, description = "Stable witness page boundary")
+    ),
+    responses(
+        (status = 200, description = "Append-only E2EE witness page", body = E2eeWitnessPage),
+        (status = 400, description = "Invalid witness cursor"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Witness workspace access denied"),
+        (status = 502, description = "Witness service unavailable")
+    )
+)]
+async fn read_e2ee_witness(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(workspace_id): Path<String>,
+    Query(query): Query<ReadE2eeWitnessQuery>,
+) -> Result<(
+    [(header::HeaderName, HeaderValue); 1],
+    Json<E2eeWitnessPage>,
+)> {
+    require_personal_workspace(&auth, &workspace_id)?;
+    let after_sequence = i64::try_from(query.after_sequence)
+        .map_err(|_| SyncError::BadRequest("E2EE witness cursor is invalid".to_string()))?;
+    let through_sequence = query
+        .through_sequence
+        .map(i64::try_from)
+        .transpose()
+        .map_err(|_| SyncError::BadRequest("E2EE witness cursor is invalid".to_string()))?;
+    let response = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/read_e2ee_freshness_page",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(WITNESS_TIMEOUT)
+        .json(&ReadRpcRequest {
+            p_actor_user_id: &auth.claims.sub,
+            p_workspace_id: &workspace_id,
+            p_after_sequence: after_sequence,
+            p_through_sequence: through_sequence,
+            p_limit: WITNESS_PAGE_SIZE,
+        })
+        .send()
+        .await
+        .map_err(|error| witness_transport_error(error, "read"))?;
+    let (status, bytes) = read_bounded_response(response, "read").await?;
+    if !status.is_success() {
+        return Err(map_postgrest_error(status, &bytes));
+    }
+    let rows = serde_json::from_slice::<Vec<ReadRpcRow>>(&bytes).map_err(|error| {
+        tracing::warn!(%error, "Supabase E2EE witness read response was invalid");
+        SyncError::E2eeWitnessServiceUnavailable
+    })?;
+    let page = validate_read_rows(rows, query.after_sequence, query.through_sequence)?;
+    Ok((
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+        Json(page),
+    ))
+}
+
+#[utoipa::path(
+    post,
+    path = "/e2ee/witness/{workspace_id}",
+    tag = "sync",
+    params(("workspace_id" = String, Path, description = "Personal workspace ID")),
+    request_body = PublishE2eeWitnessRequest,
+    responses(
+        (status = 200, description = "Ciphertext events appended", body = PublishE2eeWitnessResponse),
+        (status = 400, description = "Invalid witness event"),
+        (status = 401, description = "Authentication required"),
+        (status = 403, description = "Witness workspace access denied"),
+        (status = 409, description = "Legacy witness requires an established device"),
+        (status = 502, description = "Witness service unavailable")
+    )
+)]
+async fn publish_e2ee_witness(
+    Extension(auth): Extension<AuthContext>,
+    State(state): State<AppState>,
+    Path(workspace_id): Path<String>,
+    Json(request): Json<PublishE2eeWitnessRequest>,
+) -> Result<(
+    [(header::HeaderName, HeaderValue); 1],
+    Json<PublishE2eeWitnessResponse>,
+)> {
+    require_personal_workspace(&auth, &workspace_id)?;
+    validate_publish_request(&request)?;
+    let events = request
+        .events
+        .iter()
+        .map(|event| PublishRpcEvent {
+            record_id: &event.record_id,
+            payload_hash: &event.payload_hash,
+            payload: &event.payload,
+        })
+        .collect::<Vec<_>>();
+    let response = state
+        .client
+        .post(format!(
+            "{}/rest/v1/rpc/publish_e2ee_freshness_events",
+            state.config.supabase_url
+        ))
+        .header("apikey", &state.config.supabase_service_role_key)
+        .bearer_auth(&state.config.supabase_service_role_key)
+        .timeout(WITNESS_TIMEOUT)
+        .json(&PublishRpcRequest {
+            p_actor_user_id: &auth.claims.sub,
+            p_workspace_id: &workspace_id,
+            p_initialize: request.initialize,
+            p_events: &events,
+        })
+        .send()
+        .await
+        .map_err(|error| witness_transport_error(error, "publication"))?;
+    let (status, bytes) = read_bounded_response(response, "publication").await?;
+    if !status.is_success() {
+        return Err(map_postgrest_error(status, &bytes));
+    }
+    let mut rows = serde_json::from_slice::<Vec<PublishRpcRow>>(&bytes).map_err(|error| {
+        tracing::warn!(%error, "Supabase E2EE witness publication response was invalid");
+        SyncError::E2eeWitnessServiceUnavailable
+    })?;
+    if rows.len() != 1 {
+        tracing::warn!(
+            row_count = rows.len(),
+            "Supabase E2EE witness publication returned an invalid row count"
+        );
+        return Err(SyncError::E2eeWitnessServiceUnavailable);
+    }
+    let row = rows.pop().expect("row count was checked");
+    let initialized_at = chrono::DateTime::parse_from_rfc3339(&row.initialized_at)
+        .map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?
+        .to_rfc3339();
+    let head_sequence =
+        u64::try_from(row.head_sequence).map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?;
+    Ok((
+        [(header::CACHE_CONTROL, HeaderValue::from_static("no-store"))],
+        Json(PublishE2eeWitnessResponse {
+            initialized_at,
+            head_sequence,
+        }),
+    ))
+}
+
+fn require_personal_workspace(auth: &AuthContext, workspace_id: &str) -> Result<()> {
+    if !auth.claims.is_pro() {
+        return Err(SyncError::ProPlanRequired);
+    }
+    let workspace = Uuid::parse_str(workspace_id)
+        .map_err(|_| SyncError::BadRequest("E2EE witness workspace is invalid".to_string()))?;
+    if workspace.to_string() != workspace_id || auth.claims.sub != workspace_id {
+        return Err(SyncError::E2eeWitnessForbidden);
+    }
+    Ok(())
+}
+
+fn validate_publish_request(request: &PublishE2eeWitnessRequest) -> Result<()> {
+    if request.events.is_empty() || request.events.len() > MAX_EVENTS_PER_BATCH {
+        return Err(SyncError::BadRequest(
+            "E2EE witness event batch is invalid".to_string(),
+        ));
+    }
+    for event in &request.events {
+        if !is_blinded_id(&event.record_id)
+            || !is_blinded_id(&event.payload_hash)
+            || event.payload.is_empty()
+            || event.payload.len() > MAX_EVENT_BYTES
+        {
+            return Err(SyncError::BadRequest(
+                "E2EE witness event is invalid".to_string(),
+            ));
+        }
+    }
+    Ok(())
+}
+
+fn validate_read_rows(
+    rows: Vec<ReadRpcRow>,
+    requested_after: u64,
+    requested_through: Option<u64>,
+) -> Result<E2eeWitnessPage> {
+    let Some(first) = rows.first() else {
+        return Err(SyncError::E2eeWitnessServiceUnavailable);
+    };
+    let raw_head_sequence = first.head_sequence;
+    let raw_through_sequence = first.through_sequence;
+    let raw_initialized_at = first.initialized_at.clone();
+    let head_sequence =
+        u64::try_from(raw_head_sequence).map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?;
+    let through_sequence = u64::try_from(raw_through_sequence)
+        .map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?;
+    let initialized_at = raw_initialized_at
+        .as_deref()
+        .map(chrono::DateTime::parse_from_rfc3339)
+        .transpose()
+        .map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?
+        .map(|value| value.to_rfc3339());
+    if requested_after > through_sequence
+        || through_sequence > head_sequence
+        || requested_through.is_some_and(|value| value != through_sequence)
+        || (initialized_at.is_none() && (head_sequence != 0 || rows.len() != 1))
+    {
+        return Err(SyncError::E2eeWitnessServiceUnavailable);
+    }
+
+    let mut events = Vec::with_capacity(rows.len());
+    let mut previous = requested_after;
+    for row in rows {
+        if row.head_sequence != raw_head_sequence
+            || row.through_sequence != raw_through_sequence
+            || row.initialized_at != raw_initialized_at
+        {
+            return Err(SyncError::E2eeWitnessServiceUnavailable);
+        }
+        let Some(sequence) = row.event_sequence else {
+            if row.record_id.is_some() || row.payload_hash.is_some() || row.payload.is_some() {
+                return Err(SyncError::E2eeWitnessServiceUnavailable);
+            }
+            continue;
+        };
+        let sequence =
+            u64::try_from(sequence).map_err(|_| SyncError::E2eeWitnessServiceUnavailable)?;
+        let (Some(record_id), Some(payload_digest), Some(payload)) =
+            (row.record_id, row.payload_hash, row.payload)
+        else {
+            return Err(SyncError::E2eeWitnessServiceUnavailable);
+        };
+        if sequence <= previous
+            || sequence > through_sequence
+            || !is_blinded_id(&record_id)
+            || !is_blinded_id(&payload_digest)
+            || payload.is_empty()
+            || payload.len() > MAX_EVENT_BYTES
+        {
+            return Err(SyncError::E2eeWitnessServiceUnavailable);
+        }
+        previous = sequence;
+        events.push(E2eeWitnessPageEvent {
+            sequence,
+            record_id,
+            payload_hash: payload_digest,
+            payload,
+        });
+    }
+
+    Ok(E2eeWitnessPage {
+        initialized: initialized_at.is_some(),
+        initialized_at,
+        head_sequence,
+        through_sequence,
+        next_after_sequence: previous,
+        events,
+    })
+}
+
+async fn read_bounded_response(
+    mut response: reqwest::Response,
+    operation: &'static str,
+) -> Result<(HttpStatusCode, Vec<u8>)> {
+    let status = response.status();
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_WITNESS_RESPONSE_BYTES as u64)
+    {
+        tracing::warn!(%status, operation, "Supabase E2EE witness response was too large");
+        return Err(SyncError::E2eeWitnessServiceUnavailable);
+    }
+    let mut bytes = Vec::new();
+    while let Some(chunk) = response.chunk().await.map_err(|error| {
+        tracing::warn!(%error, operation, "Supabase E2EE witness response could not be read");
+        SyncError::E2eeWitnessServiceUnavailable
+    })? {
+        if bytes.len().saturating_add(chunk.len()) > MAX_WITNESS_RESPONSE_BYTES {
+            tracing::warn!(%status, operation, "Supabase E2EE witness response was too large");
+            return Err(SyncError::E2eeWitnessServiceUnavailable);
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok((status, bytes))
+}
+
+fn witness_transport_error(error: reqwest::Error, operation: &'static str) -> SyncError {
+    tracing::warn!(%error, operation, "Supabase E2EE witness request failed");
+    SyncError::E2eeWitnessServiceUnavailable
+}
+
+fn map_postgrest_error(status: HttpStatusCode, bytes: &[u8]) -> SyncError {
+    let code = serde_json::from_slice::<PostgrestError>(bytes)
+        .ok()
+        .map(|error| error.code);
+    tracing::warn!(%status, ?code, "Supabase E2EE witness request was rejected");
+    match (status, code.as_deref()) {
+        (HttpStatusCode::UNAUTHORIZED | HttpStatusCode::FORBIDDEN, _) | (_, Some("42501")) => {
+            SyncError::E2eeWitnessForbidden
+        }
+        (_, Some("22023")) => SyncError::BadRequest("E2EE witness request is invalid".to_string()),
+        (_, Some("55000")) => SyncError::E2eeWitnessUninitialized,
+        _ => SyncError::E2eeWitnessServiceUnavailable,
+    }
+}
+
+fn is_blinded_id(value: &str) -> bool {
+    value.len() == 43
+        && value
+            .bytes()
+            .all(|byte| byte.is_ascii_alphanumeric() || matches!(byte, b'-' | b'_'))
+}
+
+#[cfg(test)]
+mod tests {
+    use axum::{
+        body::{Body, to_bytes},
+        http::{Method, Request, StatusCode},
+    };
+    use hypr_api_auth::Claims;
+    use serde_json::{Value, json};
+    use tower::ServiceExt;
+    use wiremock::{
+        Mock, MockServer, ResponseTemplate,
+        matchers::{body_partial_json, header as request_header, method, path},
+    };
+
+    use super::*;
+    use crate::SyncConfig;
+
+    const OWNER: &str = "11111111-1111-4111-8111-111111111111";
+    const OTHER: &str = "22222222-2222-4222-8222-222222222222";
+    const RECORD_ID: &str = "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA";
+    const PAYLOAD_HASH: &str = "bSKYhMEmi7CrMtjaMV0P5S-RRyKL2DCje8n7KKlUlA0";
+
+    fn test_router(server: &MockServer) -> Router {
+        router()
+            .with_state(AppState::new(SyncConfig {
+                project_url: server.uri(),
+                token_issuer_api_key: "issuer-key".to_string(),
+                database_id: "database-id".to_string(),
+                token_ttl_seconds: 60,
+                supabase_url: server.uri(),
+                supabase_anon_key: "anon-key".to_string(),
+                supabase_service_role_key: "service-role-key".to_string(),
+            }))
+            .layer(Extension(AuthContext {
+                token: "user-token".to_string(),
+                claims: Claims {
+                    sub: OWNER.to_string(),
+                    email: None,
+                    entitlements: ["hyprnote_pro".to_string()].into_iter().collect(),
+                    subscription_status: None,
+                    trial_end: None,
+                    has_payment_method: None,
+                },
+            }))
+    }
+
+    fn request(method: Method, path: &str, body: Option<Value>) -> Request<Body> {
+        let mut request = Request::builder().method(method).uri(path);
+        if body.is_some() {
+            request = request.header(header::CONTENT_TYPE, "application/json");
+        }
+        request
+            .body(body.map_or_else(Body::empty, |body| {
+                Body::from(serde_json::to_vec(&body).unwrap())
+            }))
+            .unwrap()
+    }
+
+    async fn response_json(response: axum::response::Response) -> Value {
+        let bytes = to_bytes(response.into_body(), 1024 * 1024).await.unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    #[tokio::test]
+    async fn reads_a_stable_witness_page_through_the_service_role() {
+        let server = MockServer::start().await;
+        let payload = "opaque";
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/read_e2ee_freshness_page"))
+            .and(request_header("apikey", "service-role-key"))
+            .and(request_header("authorization", "Bearer service-role-key"))
+            .and(body_partial_json(json!({
+                "p_actor_user_id": OWNER,
+                "p_workspace_id": OWNER,
+                "p_after_sequence": 0,
+                "p_limit": 3
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": "2026-07-17T00:00:00Z",
+                "head_sequence": 1,
+                "through_sequence": 1,
+                "event_sequence": 1,
+                "record_id": RECORD_ID,
+                "payload_hash": PAYLOAD_HASH,
+                "payload": payload
+            }])))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server)
+            .oneshot(request(
+                Method::GET,
+                &format!("/e2ee/witness/{OWNER}?afterSequence=0"),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body["headSequence"], 1);
+        assert_eq!(body["events"][0]["recordId"], RECORD_ID);
+    }
+
+    #[tokio::test]
+    async fn publishes_snake_case_rpc_events() {
+        let server = MockServer::start().await;
+        let payload = "opaque";
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/publish_e2ee_freshness_events"))
+            .and(body_partial_json(json!({
+                "p_actor_user_id": OWNER,
+                "p_workspace_id": OWNER,
+                "p_initialize": false,
+                "p_events": [{
+                    "record_id": RECORD_ID,
+                    "payload_hash": PAYLOAD_HASH,
+                    "payload": payload
+                }]
+            })))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!([{
+                "initialized_at": "2026-07-17T00:00:00Z",
+                "head_sequence": 1
+            }])))
+            .mount(&server)
+            .await;
+
+        let response = test_router(&server)
+            .oneshot(request(
+                Method::POST,
+                &format!("/e2ee/witness/{OWNER}"),
+                Some(json!({
+                    "initialize": false,
+                    "events": [{
+                        "recordId": RECORD_ID,
+                        "payloadHash": PAYLOAD_HASH,
+                        "payload": payload
+                    }]
+                })),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response_json(response).await["headSequence"], 1);
+    }
+
+    #[tokio::test]
+    async fn rejects_cross_workspace_access_before_calling_supabase() {
+        let server = MockServer::start().await;
+        let response = test_router(&server)
+            .oneshot(request(
+                Method::GET,
+                &format!("/e2ee/witness/{OTHER}"),
+                None,
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::FORBIDDEN);
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn maps_uninitialized_legacy_witnesses_to_conflict() {
+        let server = MockServer::start().await;
+        let payload = "opaque";
+        Mock::given(method("POST"))
+            .and(path("/rest/v1/rpc/publish_e2ee_freshness_events"))
+            .respond_with(
+                ResponseTemplate::new(500)
+                    .set_body_json(json!({ "code": "55000", "message": "uninitialized" })),
+            )
+            .mount(&server)
+            .await;
+        let response = test_router(&server)
+            .oneshot(request(
+                Method::POST,
+                &format!("/e2ee/witness/{OWNER}"),
+                Some(json!({
+                    "initialize": false,
+                    "events": [{
+                        "recordId": RECORD_ID,
+                        "payloadHash": PAYLOAD_HASH,
+                        "payload": payload
+                    }]
+                })),
+            ))
+            .await
+            .unwrap();
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+    }
+}

--- a/crates/db-app/migrations/20260717192000_e2ee_replica_order.sql
+++ b/crates/db-app/migrations/20260717192000_e2ee_replica_order.sql
@@ -1,0 +1,23 @@
+ALTER TABLE e2ee_local_state
+ADD COLUMN writer_id TEXT NOT NULL DEFAULT '';
+
+ALTER TABLE e2ee_local_state
+ADD COLUMN payload TEXT NOT NULL DEFAULT '';
+
+UPDATE e2ee_local_state
+SET payload = COALESCE(
+  (
+    SELECT e2ee_records.payload
+    FROM e2ee_records
+    WHERE e2ee_records.id = e2ee_local_state.record_id
+      AND e2ee_records.workspace_id = e2ee_local_state.workspace_id
+  ),
+  ''
+);
+
+CREATE TABLE IF NOT EXISTS e2ee_local_device (
+  id         TEXT PRIMARY KEY NOT NULL,
+  writer_id  TEXT NOT NULL DEFAULT '',
+  created_at TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  CHECK (id = 'local')
+) STRICT;

--- a/crates/db-app/migrations/20260717193000_e2ee_freshness_witness.sql
+++ b/crates/db-app/migrations/20260717193000_e2ee_freshness_witness.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS e2ee_witness_state (
+  workspace_id   TEXT PRIMARY KEY NOT NULL,
+  last_sequence INTEGER NOT NULL DEFAULT 0,
+  updated_at     TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  CHECK (last_sequence >= 0)
+) STRICT;
+
+CREATE TABLE IF NOT EXISTS e2ee_witness_records (
+  workspace_id TEXT NOT NULL,
+  record_id    TEXT NOT NULL,
+  revision     INTEGER NOT NULL DEFAULT 0,
+  writer_id    TEXT NOT NULL DEFAULT '',
+  payload_hash TEXT NOT NULL DEFAULT '',
+  payload      TEXT NOT NULL DEFAULT '',
+  sequence     INTEGER NOT NULL DEFAULT 0,
+  updated_at   TEXT NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%fZ', 'now')),
+  PRIMARY KEY (workspace_id, record_id),
+  CHECK (revision >= 0),
+  CHECK (sequence >= 0)
+) STRICT;

--- a/crates/db-app/src/e2ee.rs
+++ b/crates/db-app/src/e2ee.rs
@@ -1,3 +1,4 @@
+use std::cmp::Ordering;
 use std::collections::{BTreeMap, HashMap, HashSet};
 
 use base64::Engine;
@@ -43,6 +44,27 @@ pub struct E2eeReplicaStats {
     pub encrypted_fields: u64,
     pub applied_fields: u64,
     pub skipped_local_changes: u64,
+    pub rejected_rollbacks: u64,
+    pub rejected_unwitnessed: u64,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct E2eeWitnessUpload {
+    pub record_id: String,
+    pub workspace_id: String,
+    pub revision: u64,
+    pub writer_id: String,
+    pub payload_hash: String,
+    pub payload: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct E2eeWitnessEvent {
+    pub sequence: u64,
+    pub record_id: String,
+    pub workspace_id: String,
+    pub payload_hash: String,
+    pub payload: String,
 }
 
 #[derive(Clone, sqlx::FromRow)]
@@ -53,8 +75,10 @@ struct LocalState {
     row_id: String,
     field_name: String,
     revision: i64,
+    writer_id: String,
     value_tag: String,
     payload_hash: String,
+    payload: String,
 }
 
 #[derive(sqlx::FromRow)]
@@ -68,7 +92,19 @@ struct DecryptedRecord {
     record_id: String,
     workspace_id: String,
     payload_hash: String,
+    payload: String,
     field: OpenedField,
+}
+
+#[derive(Clone, sqlx::FromRow)]
+struct WitnessRecord {
+    workspace_id: String,
+    record_id: String,
+    revision: i64,
+    writer_id: String,
+    payload_hash: String,
+    payload: String,
+    sequence: i64,
 }
 
 pub async fn encrypt_e2ee_replica_changes(
@@ -80,6 +116,7 @@ pub async fn encrypt_e2ee_replica_changes(
     }
 
     let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let writer_id = load_or_create_writer_id(&mut transaction).await?;
     let states = load_local_states(&mut transaction).await?;
     let mut active_manifests = HashSet::new();
     let mut stats = E2eeReplicaStats::default();
@@ -110,6 +147,7 @@ pub async fn encrypt_e2ee_replica_changes(
                 table,
                 &row_id,
                 ROW_MANIFEST_FIELD,
+                &writer_id,
                 false,
                 json!(true),
             )
@@ -132,6 +170,7 @@ pub async fn encrypt_e2ee_replica_changes(
                     table,
                     &row_id,
                     field,
+                    &writer_id,
                     false,
                     value,
                 )
@@ -167,6 +206,7 @@ pub async fn encrypt_e2ee_replica_changes(
             &state.table_name,
             &state.row_id,
             ROW_MANIFEST_FIELD,
+            &writer_id,
             true,
             Value::Null,
         )
@@ -184,6 +224,22 @@ pub async fn apply_e2ee_replica_changes(
     pool: &SqlitePool,
     keys: &HashMap<String, WorkspaceKey>,
 ) -> E2eeReplicaResult<E2eeReplicaStats> {
+    apply_e2ee_replica_changes_inner(pool, keys, false).await
+}
+
+pub async fn apply_e2ee_replica_changes_with_witness(
+    pool: &SqlitePool,
+    keys: &HashMap<String, WorkspaceKey>,
+) -> E2eeReplicaResult<E2eeReplicaStats> {
+    repair_e2ee_replica_from_witness(pool, keys).await?;
+    apply_e2ee_replica_changes_inner(pool, keys, true).await
+}
+
+async fn apply_e2ee_replica_changes_inner(
+    pool: &SqlitePool,
+    keys: &HashMap<String, WorkspaceKey>,
+    require_witness: bool,
+) -> E2eeReplicaResult<E2eeReplicaStats> {
     if keys.is_empty() {
         return Ok(E2eeReplicaStats::default());
     }
@@ -194,13 +250,34 @@ pub async fn apply_e2ee_replica_changes(
     )
     .fetch_all(&mut *transaction)
     .await?;
+    let witnessed_payloads = if require_witness {
+        sqlx::query_as::<_, (String, String, String)>(
+            "SELECT workspace_id, record_id, payload
+             FROM e2ee_witness_records",
+        )
+        .fetch_all(&mut *transaction)
+        .await?
+        .into_iter()
+        .map(|(workspace_id, record_id, payload)| ((workspace_id, record_id), payload))
+        .collect::<HashMap<_, _>>()
+    } else {
+        HashMap::new()
+    };
     let mut states = load_local_states(&mut transaction).await?;
     let mut groups = BTreeMap::<(String, String, String), Vec<DecryptedRecord>>::new();
+    let mut stats = E2eeReplicaStats::default();
 
     for record in records {
         let Some(key) = keys.get(&record.workspace_id) else {
             continue;
         };
+        if require_witness
+            && witnessed_payloads.get(&(record.workspace_id.clone(), record.id.clone()))
+                != Some(&record.payload)
+        {
+            stats.rejected_unwitnessed += 1;
+            continue;
+        }
         let field = key.open_field(&record.workspace_id, &record.id, &record.payload)?;
         if !E2EE_DOMAIN_TABLES.contains(&field.table.as_str()) {
             return Err(E2eeReplicaError::InvalidField);
@@ -216,11 +293,11 @@ pub async fn apply_e2ee_replica_changes(
                 record_id: record.id,
                 workspace_id: record.workspace_id,
                 payload_hash: hypr_e2ee::payload_hash(&record.payload),
+                payload: record.payload,
                 field,
             });
     }
 
-    let mut stats = E2eeReplicaStats::default();
     let mut column_cache = HashMap::<String, HashSet<String>>::new();
     for ((workspace_id, table, row_id), mut records) in groups {
         let key = &keys[&workspace_id];
@@ -232,6 +309,25 @@ pub async fn apply_e2ee_replica_changes(
                 columns
             }
         };
+        let mut stale_manifest = false;
+        let mut accepted_records = Vec::with_capacity(records.len());
+        for record in records {
+            let is_stale = match states.get(&record.record_id) {
+                Some(state) => record_version_order(state, &record)? == Ordering::Less,
+                None => false,
+            };
+            if is_stale {
+                restore_local_payload(&mut transaction, &states[&record.record_id]).await?;
+                stale_manifest |= record.field.field == ROW_MANIFEST_FIELD;
+                stats.rejected_rollbacks += 1;
+                continue;
+            }
+            accepted_records.push(record);
+        }
+        records = accepted_records;
+        if stale_manifest {
+            continue;
+        }
         let Some(manifest_index) = records
             .iter()
             .position(|record| record.field.field == ROW_MANIFEST_FIELD)
@@ -240,7 +336,6 @@ pub async fn apply_e2ee_replica_changes(
         };
         let manifest = records.swap_remove(manifest_index);
         let manifest_state = states.get(&manifest.record_id).cloned();
-        reject_rollback(manifest_state.as_ref(), &manifest.field)?;
         let manifest_unchanged = manifest_state
             .as_ref()
             .is_some_and(|state| state.payload_hash == manifest.payload_hash);
@@ -274,8 +369,10 @@ pub async fn apply_e2ee_replica_changes(
                     field_name: ROW_MANIFEST_FIELD.to_string(),
                     revision: i64::try_from(manifest.field.revision)
                         .map_err(|_| E2eeReplicaError::InvalidRow)?,
+                    writer_id: manifest.field.writer_id,
                     value_tag,
                     payload_hash: manifest.payload_hash,
+                    payload: manifest.payload,
                 };
                 upsert_local_state(&mut transaction, &state).await?;
                 stats.applied_fields += 1;
@@ -294,8 +391,10 @@ pub async fn apply_e2ee_replica_changes(
                 field_name: ROW_MANIFEST_FIELD.to_string(),
                 revision: i64::try_from(manifest.field.revision)
                     .map_err(|_| E2eeReplicaError::InvalidRow)?,
+                writer_id: manifest.field.writer_id,
                 value_tag,
                 payload_hash: manifest.payload_hash,
+                payload: manifest.payload,
             };
             upsert_local_state(&mut transaction, &state).await?;
             states.insert(state.record_id.clone(), state);
@@ -320,8 +419,6 @@ pub async fn apply_e2ee_replica_changes(
             {
                 continue;
             }
-            reject_rollback(states.get(&record.record_id), &record.field)?;
-
             if let Some(state) = states.get(&record.record_id) {
                 let Some(current) =
                     read_field(&mut transaction, &table, &workspace_id, &row_id, field_name)
@@ -355,8 +452,10 @@ pub async fn apply_e2ee_replica_changes(
                 field_name: field_name.to_string(),
                 revision: i64::try_from(record.field.revision)
                     .map_err(|_| E2eeReplicaError::InvalidRow)?,
+                writer_id: record.field.writer_id,
                 value_tag,
                 payload_hash: record.payload_hash,
+                payload: record.payload,
             };
             upsert_local_state(&mut transaction, &state).await?;
             states.insert(state.record_id.clone(), state);
@@ -368,6 +467,316 @@ pub async fn apply_e2ee_replica_changes(
     Ok(stats)
 }
 
+pub async fn e2ee_witness_cursor(pool: &SqlitePool, workspace_id: &str) -> E2eeReplicaResult<u64> {
+    let sequence: Option<i64> =
+        sqlx::query_scalar("SELECT last_sequence FROM e2ee_witness_state WHERE workspace_id = ?")
+            .bind(workspace_id)
+            .fetch_optional(pool)
+            .await?;
+    u64::try_from(sequence.unwrap_or(0)).map_err(|_| E2eeReplicaError::RollbackDetected)
+}
+
+pub async fn has_e2ee_local_state(
+    pool: &SqlitePool,
+    workspace_id: &str,
+) -> E2eeReplicaResult<bool> {
+    Ok(sqlx::query_scalar(
+        "SELECT EXISTS(
+           SELECT 1 FROM e2ee_local_state WHERE workspace_id = ?
+         )",
+    )
+    .bind(workspace_id)
+    .fetch_one(pool)
+    .await?)
+}
+
+pub async fn pending_e2ee_witness_uploads(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    key: &WorkspaceKey,
+) -> E2eeReplicaResult<Vec<E2eeWitnessUpload>> {
+    let states: Vec<LocalState> = sqlx::query_as(
+        "SELECT local.record_id, local.workspace_id, local.table_name, local.row_id,
+                local.field_name, local.revision, local.writer_id, local.value_tag,
+                local.payload_hash, local.payload
+         FROM e2ee_local_state AS local
+         LEFT JOIN e2ee_witness_records AS witness
+           ON witness.workspace_id = local.workspace_id
+          AND witness.record_id = local.record_id
+         WHERE local.workspace_id = ?
+           AND (
+             witness.record_id IS NULL
+             OR local.revision > witness.revision
+             OR (local.revision = witness.revision AND local.writer_id > witness.writer_id)
+             OR (
+               local.revision = witness.revision
+               AND local.writer_id = witness.writer_id
+               AND local.payload_hash > witness.payload_hash
+             )
+           )
+         ORDER BY local.record_id",
+    )
+    .bind(workspace_id)
+    .fetch_all(pool)
+    .await?;
+
+    states
+        .into_iter()
+        .map(|state| {
+            validate_witness_payload(
+                key,
+                &state.workspace_id,
+                &state.record_id,
+                &state.payload_hash,
+                &state.payload,
+                state.revision,
+                &state.writer_id,
+            )?;
+            Ok(E2eeWitnessUpload {
+                record_id: state.record_id,
+                workspace_id: state.workspace_id,
+                revision: u64::try_from(state.revision)
+                    .map_err(|_| E2eeReplicaError::InvalidRow)?,
+                writer_id: state.writer_id,
+                payload_hash: state.payload_hash,
+                payload: state.payload,
+            })
+        })
+        .collect()
+}
+
+pub async fn acknowledge_e2ee_witness_uploads(
+    pool: &SqlitePool,
+    key: &WorkspaceKey,
+    uploads: &[E2eeWitnessUpload],
+) -> E2eeReplicaResult<()> {
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    for upload in uploads {
+        let revision = i64::try_from(upload.revision).map_err(|_| E2eeReplicaError::InvalidRow)?;
+        validate_witness_payload(
+            key,
+            &upload.workspace_id,
+            &upload.record_id,
+            &upload.payload_hash,
+            &upload.payload,
+            revision,
+            &upload.writer_id,
+        )?;
+        upsert_witness_record(
+            &mut transaction,
+            &WitnessRecord {
+                workspace_id: upload.workspace_id.clone(),
+                record_id: upload.record_id.clone(),
+                revision,
+                writer_id: upload.writer_id.clone(),
+                payload_hash: upload.payload_hash.clone(),
+                payload: upload.payload.clone(),
+                sequence: 0,
+            },
+        )
+        .await?;
+    }
+    transaction.commit().await?;
+    Ok(())
+}
+
+pub async fn merge_e2ee_witness_events(
+    pool: &SqlitePool,
+    key: &WorkspaceKey,
+    workspace_id: &str,
+    events: &[E2eeWitnessEvent],
+) -> E2eeReplicaResult<()> {
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let mut previous_sequence = 0;
+    for event in events {
+        if event.workspace_id != workspace_id
+            || event.sequence == 0
+            || event.sequence <= previous_sequence
+        {
+            return Err(E2eeReplicaError::InvalidRow);
+        }
+        let sequence = i64::try_from(event.sequence).map_err(|_| E2eeReplicaError::InvalidRow)?;
+        let field = key.open_field(workspace_id, &event.record_id, &event.payload)?;
+        let revision = i64::try_from(field.revision).map_err(|_| E2eeReplicaError::InvalidRow)?;
+        validate_opened_witness_field(
+            &field,
+            &event.payload_hash,
+            &event.payload,
+            revision,
+            &field.writer_id,
+        )?;
+        upsert_witness_record(
+            &mut transaction,
+            &WitnessRecord {
+                workspace_id: workspace_id.to_string(),
+                record_id: event.record_id.clone(),
+                revision,
+                writer_id: field.writer_id,
+                payload_hash: event.payload_hash.clone(),
+                payload: event.payload.clone(),
+                sequence,
+            },
+        )
+        .await?;
+        previous_sequence = event.sequence;
+    }
+    transaction.commit().await?;
+    Ok(())
+}
+
+pub async fn advance_e2ee_witness_cursor(
+    pool: &SqlitePool,
+    workspace_id: &str,
+    through_sequence: u64,
+) -> E2eeReplicaResult<()> {
+    let through_sequence =
+        i64::try_from(through_sequence).map_err(|_| E2eeReplicaError::InvalidRow)?;
+    let current: Option<i64> =
+        sqlx::query_scalar("SELECT last_sequence FROM e2ee_witness_state WHERE workspace_id = ?")
+            .bind(workspace_id)
+            .fetch_optional(pool)
+            .await?;
+    if current.is_some_and(|current| through_sequence < current) {
+        return Err(E2eeReplicaError::RollbackDetected);
+    }
+    sqlx::query(
+        "INSERT INTO e2ee_witness_state (workspace_id, last_sequence)
+         VALUES (?, ?)
+         ON CONFLICT(workspace_id) DO UPDATE SET
+           last_sequence = excluded.last_sequence,
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         WHERE excluded.last_sequence >= e2ee_witness_state.last_sequence",
+    )
+    .bind(workspace_id)
+    .bind(through_sequence)
+    .execute(pool)
+    .await?;
+    Ok(())
+}
+
+async fn repair_e2ee_replica_from_witness(
+    pool: &SqlitePool,
+    keys: &HashMap<String, WorkspaceKey>,
+) -> E2eeReplicaResult<()> {
+    let mut transaction = pool.begin_with("BEGIN IMMEDIATE").await?;
+    let records: Vec<WitnessRecord> = sqlx::query_as(
+        "SELECT workspace_id, record_id, revision, writer_id, payload_hash, payload, sequence
+         FROM e2ee_witness_records
+         ORDER BY workspace_id, record_id",
+    )
+    .fetch_all(&mut *transaction)
+    .await?;
+    for record in records {
+        let Some(key) = keys.get(&record.workspace_id) else {
+            continue;
+        };
+        validate_witness_payload(
+            key,
+            &record.workspace_id,
+            &record.record_id,
+            &record.payload_hash,
+            &record.payload,
+            record.revision,
+            &record.writer_id,
+        )?;
+        let result = sqlx::query(
+            "INSERT INTO e2ee_records (id, workspace_id, payload)
+             VALUES (?, ?, ?)
+             ON CONFLICT(id) DO UPDATE SET
+               payload = excluded.payload,
+               updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+             WHERE e2ee_records.workspace_id = excluded.workspace_id",
+        )
+        .bind(&record.record_id)
+        .bind(&record.workspace_id)
+        .bind(&record.payload)
+        .execute(&mut *transaction)
+        .await?;
+        if result.rows_affected() != 1 {
+            return Err(E2eeReplicaError::RollbackDetected);
+        }
+    }
+    transaction.commit().await?;
+    Ok(())
+}
+
+async fn upsert_witness_record(
+    transaction: &mut Transaction<'_, Sqlite>,
+    record: &WitnessRecord,
+) -> E2eeReplicaResult<()> {
+    sqlx::query(
+        "INSERT INTO e2ee_witness_records (
+           workspace_id, record_id, revision, writer_id, payload_hash, payload, sequence
+         ) VALUES (?, ?, ?, ?, ?, ?, ?)
+         ON CONFLICT(workspace_id, record_id) DO UPDATE SET
+           revision = excluded.revision,
+           writer_id = excluded.writer_id,
+           payload_hash = excluded.payload_hash,
+           payload = excluded.payload,
+           sequence = MAX(e2ee_witness_records.sequence, excluded.sequence),
+           updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         WHERE excluded.revision > e2ee_witness_records.revision
+            OR (
+              excluded.revision = e2ee_witness_records.revision
+              AND excluded.writer_id > e2ee_witness_records.writer_id
+            )
+            OR (
+              excluded.revision = e2ee_witness_records.revision
+              AND excluded.writer_id = e2ee_witness_records.writer_id
+              AND excluded.payload_hash > e2ee_witness_records.payload_hash
+            )
+            OR (
+              excluded.revision = e2ee_witness_records.revision
+              AND excluded.writer_id = e2ee_witness_records.writer_id
+              AND excluded.payload_hash = e2ee_witness_records.payload_hash
+              AND excluded.sequence > e2ee_witness_records.sequence
+            )",
+    )
+    .bind(&record.workspace_id)
+    .bind(&record.record_id)
+    .bind(record.revision)
+    .bind(&record.writer_id)
+    .bind(&record.payload_hash)
+    .bind(&record.payload)
+    .bind(record.sequence)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+fn validate_witness_payload(
+    key: &WorkspaceKey,
+    workspace_id: &str,
+    record_id: &str,
+    payload_hash: &str,
+    payload: &str,
+    revision: i64,
+    writer_id: &str,
+) -> E2eeReplicaResult<()> {
+    if hypr_e2ee::payload_hash(payload) != payload_hash {
+        return Err(E2eeReplicaError::RollbackDetected);
+    }
+    let field = key.open_field(workspace_id, record_id, payload)?;
+    validate_opened_witness_field(&field, payload_hash, payload, revision, writer_id)
+}
+
+fn validate_opened_witness_field(
+    field: &OpenedField,
+    payload_hash: &str,
+    payload: &str,
+    revision: i64,
+    writer_id: &str,
+) -> E2eeReplicaResult<()> {
+    if !E2EE_DOMAIN_TABLES.contains(&field.table.as_str())
+        || i64::try_from(field.revision).ok() != Some(revision)
+        || field.writer_id != writer_id
+        || hypr_e2ee::payload_hash(payload) != payload_hash
+    {
+        return Err(E2eeReplicaError::RollbackDetected);
+    }
+    Ok(())
+}
+
 #[allow(clippy::too_many_arguments)]
 async fn encrypt_field_if_changed(
     transaction: &mut Transaction<'_, Sqlite>,
@@ -377,6 +786,7 @@ async fn encrypt_field_if_changed(
     table: &str,
     row_id: &str,
     field: &str,
+    writer_id: &str,
     deleted: bool,
     value: Value,
 ) -> E2eeReplicaResult<bool> {
@@ -394,7 +804,16 @@ async fn encrypt_field_if_changed(
         .map(|state| state.revision.saturating_add(1))
         .unwrap_or(1);
     let revision = u64::try_from(revision).map_err(|_| E2eeReplicaError::InvalidRow)?;
-    let sealed = key.seal_field(workspace_id, table, row_id, field, revision, deleted, value)?;
+    let sealed = key.seal_field(
+        workspace_id,
+        table,
+        row_id,
+        field,
+        writer_id,
+        revision,
+        deleted,
+        value,
+    )?;
     let payload_hash = hypr_e2ee::payload_hash(&sealed.payload);
     sqlx::query(
         "INSERT INTO e2ee_records (id, workspace_id, payload)
@@ -418,8 +837,10 @@ async fn encrypt_field_if_changed(
             row_id: row_id.to_string(),
             field_name: field.to_string(),
             revision: i64::try_from(revision).map_err(|_| E2eeReplicaError::InvalidRow)?,
+            writer_id: writer_id.to_string(),
             value_tag,
             payload_hash,
+            payload: sealed.payload,
         },
     )
     .await?;
@@ -430,7 +851,8 @@ async fn load_local_states(
     transaction: &mut Transaction<'_, Sqlite>,
 ) -> E2eeReplicaResult<HashMap<String, LocalState>> {
     let states: Vec<LocalState> = sqlx::query_as(
-        "SELECT record_id, workspace_id, table_name, row_id, field_name, revision, value_tag, payload_hash
+        "SELECT record_id, workspace_id, table_name, row_id, field_name, revision,
+                writer_id, value_tag, payload_hash, payload
          FROM e2ee_local_state",
     )
     .fetch_all(&mut **transaction)
@@ -447,16 +869,19 @@ async fn upsert_local_state(
 ) -> E2eeReplicaResult<()> {
     sqlx::query(
         "INSERT INTO e2ee_local_state (
-           record_id, workspace_id, table_name, row_id, field_name, revision, value_tag, payload_hash
-         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+           record_id, workspace_id, table_name, row_id, field_name, revision,
+           writer_id, value_tag, payload_hash, payload
+         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
          ON CONFLICT(record_id) DO UPDATE SET
            workspace_id = excluded.workspace_id,
            table_name = excluded.table_name,
            row_id = excluded.row_id,
            field_name = excluded.field_name,
            revision = excluded.revision,
+           writer_id = excluded.writer_id,
            value_tag = excluded.value_tag,
            payload_hash = excluded.payload_hash,
+           payload = excluded.payload,
            updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')",
     )
     .bind(&state.record_id)
@@ -465,8 +890,62 @@ async fn upsert_local_state(
     .bind(&state.row_id)
     .bind(&state.field_name)
     .bind(state.revision)
+    .bind(&state.writer_id)
     .bind(&state.value_tag)
     .bind(&state.payload_hash)
+    .bind(&state.payload)
+    .execute(&mut **transaction)
+    .await?;
+    Ok(())
+}
+
+async fn load_or_create_writer_id(
+    transaction: &mut Transaction<'_, Sqlite>,
+) -> E2eeReplicaResult<String> {
+    if let Some(writer_id) =
+        sqlx::query_scalar("SELECT writer_id FROM e2ee_local_device WHERE id = 'local'")
+            .fetch_optional(&mut **transaction)
+            .await?
+    {
+        return Ok(writer_id);
+    }
+
+    let writer_id = uuid::Uuid::new_v4().simple().to_string();
+    sqlx::query("INSERT INTO e2ee_local_device (id, writer_id) VALUES ('local', ?)")
+        .bind(&writer_id)
+        .execute(&mut **transaction)
+        .await?;
+    Ok(writer_id)
+}
+
+fn record_version_order(
+    state: &LocalState,
+    record: &DecryptedRecord,
+) -> E2eeReplicaResult<Ordering> {
+    let state_revision = u64::try_from(state.revision).map_err(|_| E2eeReplicaError::InvalidRow)?;
+    Ok(record
+        .field
+        .revision
+        .cmp(&state_revision)
+        .then_with(|| record.field.writer_id.cmp(&state.writer_id))
+        .then_with(|| record.payload_hash.cmp(&state.payload_hash)))
+}
+
+async fn restore_local_payload(
+    transaction: &mut Transaction<'_, Sqlite>,
+    state: &LocalState,
+) -> E2eeReplicaResult<()> {
+    if state.payload.is_empty() || hypr_e2ee::payload_hash(&state.payload) != state.payload_hash {
+        return Err(E2eeReplicaError::RollbackDetected);
+    }
+    sqlx::query(
+        "UPDATE e2ee_records
+         SET payload = ?, updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now')
+         WHERE id = ? AND workspace_id = ?",
+    )
+    .bind(&state.payload)
+    .bind(&state.record_id)
+    .bind(&state.workspace_id)
     .execute(&mut **transaction)
     .await?;
     Ok(())
@@ -655,14 +1134,6 @@ fn push_json_bind(query: &mut QueryBuilder<Sqlite>, value: &Value) -> E2eeReplic
         Value::Array(_) | Value::Object(_) => {
             return Err(E2eeReplicaError::UnsupportedValue);
         }
-    }
-    Ok(())
-}
-
-fn reject_rollback(state: Option<&LocalState>, field: &OpenedField) -> E2eeReplicaResult<()> {
-    let revision = i64::try_from(field.revision).map_err(|_| E2eeReplicaError::InvalidRow)?;
-    if state.is_some_and(|state| revision < state.revision) {
-        return Err(E2eeReplicaError::RollbackDetected);
     }
     Ok(())
 }
@@ -958,6 +1429,7 @@ mod tests {
                 "sessions",
                 "session-1",
                 ROW_MANIFEST_FIELD,
+                "00000000000000000000000000000001",
                 1,
                 false,
                 json!(true),
@@ -988,7 +1460,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn rejects_replayed_older_field_revisions() {
+    async fn rejects_and_repairs_replayed_older_field_revisions() {
         let db = test_db().await;
         let workspace_keys = keys("workspace-a");
         sqlx::query(
@@ -1017,19 +1489,316 @@ mod tests {
         encrypt_e2ee_replica_changes(db.pool(), &workspace_keys)
             .await
             .unwrap();
+        let current_payload: String =
+            sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+                .bind(&record_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
         apply_e2ee_replica_changes(db.pool(), &workspace_keys)
             .await
             .unwrap();
         sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = ?")
             .bind(old_payload)
-            .bind(record_id)
+            .bind(&record_id)
             .execute(db.pool())
             .await
             .unwrap();
 
-        let error = apply_e2ee_replica_changes(db.pool(), &workspace_keys)
+        let stats = apply_e2ee_replica_changes(db.pool(), &workspace_keys)
             .await
-            .unwrap_err();
-        assert!(matches!(error, E2eeReplicaError::RollbackDetected));
+            .unwrap();
+        let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let repaired_payload: String =
+            sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+                .bind(record_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(stats.rejected_rollbacks, 1);
+        assert_eq!(title, "Second");
+        assert_eq!(repaired_payload, current_payload);
+    }
+
+    #[tokio::test]
+    async fn equal_revision_payloads_converge_and_repair_the_replica() {
+        let db = test_db().await;
+        let workspace_keys = keys("workspace-a");
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session-1', 'workspace-a', 'user-a', 'Base')",
+        )
+        .execute(db.pool())
+        .await
+        .unwrap();
+        encrypt_e2ee_replica_changes(db.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let key = &workspace_keys["workspace-a"];
+        let first = key
+            .seal_field(
+                "workspace-a",
+                "sessions",
+                "session-1",
+                "title",
+                "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+                2,
+                false,
+                json!("Device A"),
+            )
+            .unwrap();
+        let second = key
+            .seal_field(
+                "workspace-a",
+                "sessions",
+                "session-1",
+                "title",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                2,
+                false,
+                json!("Device B"),
+            )
+            .unwrap();
+        let (winner, winner_title, replay) = (second, "Device B", first);
+
+        sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = ?")
+            .bind(&winner.payload)
+            .bind(&winner.record_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        apply_e2ee_replica_changes(db.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = ?")
+            .bind(&replay.payload)
+            .bind(&replay.record_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        apply_e2ee_replica_changes(db.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let canonical_payload: String =
+            sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+                .bind(&winner.record_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(title, winner_title);
+        assert_eq!(canonical_payload, winner.payload);
+
+        let third = key
+            .seal_field(
+                "workspace-a",
+                "sessions",
+                "session-1",
+                "title",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                3,
+                false,
+                json!("Clone A"),
+            )
+            .unwrap();
+        let fourth = key
+            .seal_field(
+                "workspace-a",
+                "sessions",
+                "session-1",
+                "title",
+                "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb",
+                3,
+                false,
+                json!("Clone B"),
+            )
+            .unwrap();
+        let (winner, winner_title, replay) =
+            if hypr_e2ee::payload_hash(&third.payload) > hypr_e2ee::payload_hash(&fourth.payload) {
+                (third, "Clone A", fourth)
+            } else {
+                (fourth, "Clone B", third)
+            };
+
+        sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = ?")
+            .bind(&winner.payload)
+            .bind(&winner.record_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        apply_e2ee_replica_changes(db.pool(), &workspace_keys)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE e2ee_records SET payload = ? WHERE id = ?")
+            .bind(&replay.payload)
+            .bind(&replay.record_id)
+            .execute(db.pool())
+            .await
+            .unwrap();
+        let stats = apply_e2ee_replica_changes(db.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(db.pool())
+            .await
+            .unwrap();
+        let canonical_payload: String =
+            sqlx::query_scalar("SELECT payload FROM e2ee_records WHERE id = ?")
+                .bind(&winner.record_id)
+                .fetch_one(db.pool())
+                .await
+                .unwrap();
+        assert_eq!(stats.rejected_rollbacks, 1);
+        assert_eq!(title, winner_title);
+        assert_eq!(canonical_payload, winner.payload);
+    }
+
+    #[tokio::test]
+    async fn writer_ids_are_stable_per_device_and_unique_across_devices() {
+        let first = test_db().await;
+        encrypt_e2ee_replica_changes(first.pool(), &keys("workspace-a"))
+            .await
+            .unwrap();
+        let first_writer: String =
+            sqlx::query_scalar("SELECT writer_id FROM e2ee_local_device WHERE id = 'local'")
+                .fetch_one(first.pool())
+                .await
+                .unwrap();
+        encrypt_e2ee_replica_changes(first.pool(), &keys("workspace-a"))
+            .await
+            .unwrap();
+        let repeated_writer: String =
+            sqlx::query_scalar("SELECT writer_id FROM e2ee_local_device WHERE id = 'local'")
+                .fetch_one(first.pool())
+                .await
+                .unwrap();
+
+        let second = test_db().await;
+        encrypt_e2ee_replica_changes(second.pool(), &keys("workspace-a"))
+            .await
+            .unwrap();
+        let second_writer: String =
+            sqlx::query_scalar("SELECT writer_id FROM e2ee_local_device WHERE id = 'local'")
+                .fetch_one(second.pool())
+                .await
+                .unwrap();
+
+        assert_eq!(first_writer, repeated_writer);
+        assert_ne!(first_writer, second_writer);
+        assert_eq!(first_writer.len(), 32);
+        assert_eq!(second_writer.len(), 32);
+    }
+
+    #[tokio::test]
+    async fn fresh_device_does_not_materialize_an_unwitnessed_snapshot() {
+        let workspace_keys = keys("workspace-a");
+        let source = test_db().await;
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session-1', 'workspace-a', 'user-a', 'Archived value')",
+        )
+        .execute(source.pool())
+        .await
+        .unwrap();
+        encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let fresh = test_db().await;
+        copy_replica(source.pool(), fresh.pool()).await;
+        let stats = apply_e2ee_replica_changes_with_witness(fresh.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let materialized: i64 =
+            sqlx::query_scalar("SELECT COUNT(*) FROM sessions WHERE id = 'session-1'")
+                .fetch_one(fresh.pool())
+                .await
+                .unwrap();
+        assert_eq!(materialized, 0);
+        assert!(stats.rejected_unwitnessed > 0);
+    }
+
+    #[tokio::test]
+    async fn witnessed_snapshot_materializes_and_repairs_the_replica() {
+        let workspace_keys = keys("workspace-a");
+        let source = test_db().await;
+        sqlx::query(
+            "INSERT INTO sessions (id, workspace_id, owner_user_id, title)
+             VALUES ('session-1', 'workspace-a', 'user-a', 'Witnessed value')",
+        )
+        .execute(source.pool())
+        .await
+        .unwrap();
+        encrypt_e2ee_replica_changes(source.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let encrypted: Vec<(String, String)> = sqlx::query_as(
+            "SELECT id, payload FROM e2ee_records WHERE workspace_id = 'workspace-a' ORDER BY id",
+        )
+        .fetch_all(source.pool())
+        .await
+        .unwrap();
+        let events = encrypted
+            .iter()
+            .enumerate()
+            .map(|(index, (record_id, payload))| E2eeWitnessEvent {
+                sequence: u64::try_from(index + 1).unwrap(),
+                record_id: record_id.clone(),
+                workspace_id: "workspace-a".to_string(),
+                payload_hash: hypr_e2ee::payload_hash(payload),
+                payload: payload.clone(),
+            })
+            .collect::<Vec<_>>();
+
+        let fresh = test_db().await;
+        copy_replica(source.pool(), fresh.pool()).await;
+        merge_e2ee_witness_events(
+            fresh.pool(),
+            &workspace_keys["workspace-a"],
+            "workspace-a",
+            &events,
+        )
+        .await
+        .unwrap();
+        advance_e2ee_witness_cursor(fresh.pool(), "workspace-a", events.last().unwrap().sequence)
+            .await
+            .unwrap();
+        apply_e2ee_replica_changes_with_witness(fresh.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let title: String = sqlx::query_scalar("SELECT title FROM sessions WHERE id = 'session-1'")
+            .fetch_one(fresh.pool())
+            .await
+            .unwrap();
+        assert_eq!(title, "Witnessed value");
+
+        sqlx::query("DELETE FROM e2ee_records")
+            .execute(fresh.pool())
+            .await
+            .unwrap();
+        apply_e2ee_replica_changes_with_witness(fresh.pool(), &workspace_keys)
+            .await
+            .unwrap();
+
+        let repaired: i64 = sqlx::query_scalar(
+            "SELECT COUNT(*) FROM e2ee_records WHERE workspace_id = 'workspace-a'",
+        )
+        .fetch_one(fresh.pool())
+        .await
+        .unwrap();
+        assert_eq!(repaired, i64::try_from(events.len()).unwrap());
     }
 }

--- a/crates/e2ee/src/lib.rs
+++ b/crates/e2ee/src/lib.rs
@@ -36,6 +36,8 @@ pub enum Error {
     InvalidPayload,
     #[error("the encrypted payload was created with an unavailable key")]
     UnknownKey,
+    #[error("the E2EE writer ID is invalid")]
+    InvalidWriterId,
     #[error("the encrypted payload failed authentication")]
     AuthenticationFailed,
     #[error("cryptographic randomness is unavailable")]
@@ -155,15 +157,20 @@ impl WorkspaceKey {
         table: &str,
         row_id: &str,
         field: &str,
+        writer_id: &str,
         revision: u64,
         deleted: bool,
         value: Value,
     ) -> Result<SealedField> {
+        if !is_valid_writer_id(writer_id) {
+            return Err(Error::InvalidWriterId);
+        }
         let record_id = self.blind_field_id(table, row_id, field);
         let plaintext = serde_json::to_vec(&ProtectedField {
             table,
             row_id,
             field,
+            writer_id,
             revision,
             deleted,
             value,
@@ -231,6 +238,9 @@ impl WorkspaceKey {
             .map_err(|_| Error::AuthenticationFailed)?;
         let field: OwnedProtectedField =
             serde_json::from_slice(&plaintext).map_err(|_| Error::InvalidPayload)?;
+        if !field.writer_id.is_empty() && !is_valid_writer_id(&field.writer_id) {
+            return Err(Error::InvalidPayload);
+        }
         if self.blind_field_id(&field.table, &field.row_id, &field.field) != record_id {
             return Err(Error::AuthenticationFailed);
         }
@@ -239,6 +249,7 @@ impl WorkspaceKey {
             table: field.table,
             row_id: field.row_id,
             field: field.field,
+            writer_id: field.writer_id,
             revision: field.revision,
             deleted: field.deleted,
             value: field.value,
@@ -257,6 +268,7 @@ pub struct OpenedField {
     pub table: String,
     pub row_id: String,
     pub field: String,
+    pub writer_id: String,
     pub revision: u64,
     pub deleted: bool,
     pub value: Value,
@@ -271,6 +283,7 @@ struct ProtectedField<'a> {
     table: &'a str,
     row_id: &'a str,
     field: &'a str,
+    writer_id: &'a str,
     revision: u64,
     deleted: bool,
     value: Value,
@@ -281,6 +294,8 @@ struct OwnedProtectedField {
     table: String,
     row_id: String,
     field: String,
+    #[serde(default)]
+    writer_id: String,
     revision: u64,
     deleted: bool,
     value: Value,
@@ -292,6 +307,13 @@ struct Envelope {
     key_id: String,
     nonce: String,
     ciphertext: String,
+}
+
+fn is_valid_writer_id(writer_id: &str) -> bool {
+    writer_id.len() == 32
+        && writer_id
+            .bytes()
+            .all(|byte| byte.is_ascii_digit() || matches!(byte, b'a'..=b'f'))
 }
 
 fn update_context(mac: &mut Hmac<Sha256>, domain: &[u8], table: &str, row_id: &str, field: &str) {
@@ -362,6 +384,7 @@ mod tests {
                 "session_documents",
                 "document-1",
                 "body",
+                "00000000000000000000000000000001",
                 1,
                 false,
                 json!({ "type": "doc", "content": [] }),
@@ -371,6 +394,8 @@ mod tests {
         assert!(!sealed.payload.contains("session_documents"));
         assert!(!sealed.payload.contains("document-1"));
         assert!(!sealed.payload.contains("content"));
+        let envelope: Value = serde_json::from_str(&sealed.payload).unwrap();
+        assert_eq!(envelope["version"], 1);
         let opened = key
             .open_field("workspace-a", &sealed.record_id, &sealed.payload)
             .unwrap();
@@ -378,8 +403,38 @@ mod tests {
         assert_eq!(opened.table, "session_documents");
         assert_eq!(opened.row_id, "document-1");
         assert_eq!(opened.field, "body");
+        assert_eq!(opened.writer_id, "00000000000000000000000000000001");
         assert_eq!(opened.revision, 1);
         assert_eq!(opened.value, json!({ "type": "doc", "content": [] }));
+    }
+
+    #[test]
+    fn rejects_invalid_writer_ids_and_decodes_legacy_fields() {
+        let key = recovery_key().workspace_key("workspace-a").unwrap();
+        let error = key
+            .seal_field(
+                "workspace-a",
+                "sessions",
+                "session-1",
+                "title",
+                "short",
+                1,
+                false,
+                json!("Planning"),
+            )
+            .unwrap_err();
+        assert!(matches!(error, Error::InvalidWriterId));
+
+        let legacy: OwnedProtectedField = serde_json::from_value(json!({
+            "table": "sessions",
+            "row_id": "session-1",
+            "field": "title",
+            "revision": 1,
+            "deleted": false,
+            "value": "Planning"
+        }))
+        .unwrap();
+        assert!(legacy.writer_id.is_empty());
     }
 
     #[test]
@@ -391,6 +446,7 @@ mod tests {
                 "sessions",
                 "session-1",
                 "title",
+                "00000000000000000000000000000001",
                 1,
                 false,
                 json!("Planning"),

--- a/plugins/db/Cargo.toml
+++ b/plugins/db/Cargo.toml
@@ -19,6 +19,8 @@ hypr-fs-sync-core = { workspace = true }
 hypr-storage = { workspace = true }
 hypr-tauri-utils = { workspace = true }
 
+futures-util = { workspace = true }
+reqwest = { workspace = true, features = ["json", "query", "stream"] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 sha2 = { workspace = true }
@@ -38,6 +40,7 @@ anyhow = { workspace = true }
 serde_json = { workspace = true }
 tempfile = { workspace = true }
 tokio = { workspace = true, features = ["macros", "rt", "sync", "time"] }
+wiremock = { workspace = true }
 
 [build-dependencies]
 tauri-plugin = { workspace = true, features = ["build"] }

--- a/plugins/db/js/bindings.gen.ts
+++ b/plugins/db/js/bindings.gen.ts
@@ -158,9 +158,9 @@ async bindCloudsyncAccount(accountUserId: string) : Promise<Result<boolean, stri
     else return { status: "error", error: e  as any };
 }
 },
-async configureCloudsyncToken(databaseId: string, token: string, workspaceId: string, workspaceProjection: CloudsyncWorkspaceProjection | null) : Promise<Result<CloudsyncTokenConfigurationResult, string>> {
+async configureCloudsyncToken(databaseId: string, token: string, workspaceId: string, workspaceProjection: CloudsyncWorkspaceProjection | null, e2eeWitness: CloudsyncE2eeWitness) : Promise<Result<CloudsyncTokenConfigurationResult, string>> {
     try {
-    return { status: "ok", data: await TAURI_INVOKE("plugin:db|configure_cloudsync_token", { databaseId, token, workspaceId, workspaceProjection }) };
+    return { status: "ok", data: await TAURI_INVOKE("plugin:db|configure_cloudsync_token", { databaseId, token, workspaceId, workspaceProjection, e2eeWitness }) };
 } catch (e) {
     if(e instanceof Error) throw e;
     else return { status: "error", error: e  as any };
@@ -219,6 +219,7 @@ async syncCloudsyncNow() : Promise<Result<JsonValue, string>> {
 /** user-defined types **/
 
 export type ActionItem = { id: string; assignee_human_id: string; status: string; text: string; due_at: string; completed_at: string | null }
+export type CloudsyncE2eeWitness = { endpoint: string; accessToken: string }
 export type CloudsyncTokenConfigurationResult = "configured" | "account_mismatch"
 export type CloudsyncWorkspaceProjection = { accountUserId: string; personalWorkspaceId: string; workspaces: CloudsyncWorkspaceProjectionEntry[] }
 export type CloudsyncWorkspaceProjectionEntry = { id: string; ownerUserId: string; kind: string; name: string; membershipId: string; role: string; membershipCreatedAt: string; membershipUpdatedAt: string; createdAt: string; updatedAt: string }

--- a/plugins/db/js/index.ts
+++ b/plugins/db/js/index.ts
@@ -4,6 +4,7 @@ import type {
   GetMeetingInput,
   GetMeetingTranscriptInput as GeneratedGetMeetingTranscriptInput,
   GetRecurringMeetingHistoryInput as GeneratedGetRecurringMeetingHistoryInput,
+  CloudsyncE2eeWitness,
   CloudsyncTokenConfigurationResult,
   CloudsyncWorkspaceProjection,
   E2eeIdentityStatus,
@@ -19,6 +20,7 @@ import type {
 } from "./bindings.gen";
 
 export type {
+  CloudsyncE2eeWitness,
   CloudsyncTokenConfigurationResult,
   CloudsyncWorkspaceProjection,
   E2eeIdentityStatus,
@@ -205,12 +207,14 @@ export async function configureCloudsyncToken(
   databaseId: string,
   token: string,
   workspaceId: string,
+  e2eeWitness: CloudsyncE2eeWitness,
   workspaceProjection?: CloudsyncWorkspaceProjection,
 ): Promise<CloudsyncTokenConfigurationResult> {
   return invoke("plugin:db|configure_cloudsync_token", {
     databaseId,
     token,
     workspaceId,
+    e2eeWitness,
     workspaceProjection: workspaceProjection ?? null,
   });
 }

--- a/plugins/db/src/commands.rs
+++ b/plugins/db/src/commands.rs
@@ -272,6 +272,7 @@ pub(crate) async fn configure_cloudsync_token<R: tauri::Runtime>(
     token: String,
     workspace_id: String,
     workspace_projection: Option<crate::CloudsyncWorkspaceProjection>,
+    e2ee_witness: crate::CloudsyncE2eeWitness,
 ) -> Result<crate::CloudsyncTokenConfigurationResult, String> {
     let personal_workspace_id = workspace_projection
         .as_ref()
@@ -292,6 +293,7 @@ pub(crate) async fn configure_cloudsync_token<R: tauri::Runtime>(
             token,
             workspace_id,
             workspace_projection.map(Into::into),
+            e2ee_witness,
         )
         .await
         .map_err(|error| error.to_string())

--- a/plugins/db/src/e2ee_witness.rs
+++ b/plugins/db/src/e2ee_witness.rs
@@ -1,0 +1,348 @@
+use std::io;
+
+use futures_util::StreamExt;
+use serde::{Deserialize, Serialize};
+
+const MAX_EVENTS_PER_BATCH: usize = 16;
+const MAX_EVENT_BYTES: usize = 16 * 1024 * 1024;
+const MAX_BATCH_BYTES: usize = 48 * 1024 * 1024;
+const MAX_RESPONSE_BYTES: usize = 64 * 1024 * 1024;
+const REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(20);
+
+#[derive(Clone)]
+pub(crate) struct E2eeWitnessClient {
+    client: reqwest::Client,
+    endpoint: reqwest::Url,
+    access_token: String,
+    workspace_id: String,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PublishRequest<'a> {
+    initialize: bool,
+    events: Vec<PublishEvent<'a>>,
+}
+
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct PublishEvent<'a> {
+    record_id: &'a str,
+    payload_hash: &'a str,
+    payload: &'a str,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct PublishResponse {
+    initialized_at: String,
+    head_sequence: u64,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ReadPage {
+    initialized: bool,
+    initialized_at: Option<String>,
+    head_sequence: u64,
+    through_sequence: u64,
+    next_after_sequence: u64,
+    events: Vec<ReadEvent>,
+}
+
+#[derive(Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct ReadEvent {
+    sequence: u64,
+    record_id: String,
+    payload_hash: String,
+    payload: String,
+}
+
+impl E2eeWitnessClient {
+    pub(crate) fn new(config: crate::CloudsyncE2eeWitness, workspace_id: &str) -> io::Result<Self> {
+        let endpoint = reqwest::Url::parse(&config.endpoint)
+            .map_err(|_| invalid_data("E2EE witness endpoint is invalid"))?;
+        if !matches!(endpoint.scheme(), "https" | "http")
+            || endpoint.query().is_some()
+            || endpoint.fragment().is_some()
+            || endpoint.path_segments().and_then(Iterator::last) != Some(workspace_id)
+            || config.access_token.is_empty()
+        {
+            return Err(invalid_data("E2EE witness configuration is invalid"));
+        }
+        let client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .timeout(REQUEST_TIMEOUT)
+            .build()
+            .map_err(|error| io::Error::other(format!("E2EE witness client failed: {error}")))?;
+        Ok(Self {
+            client,
+            endpoint,
+            access_token: config.access_token,
+            workspace_id: workspace_id.to_string(),
+        })
+    }
+
+    pub(crate) fn workspace_id(&self) -> &str {
+        &self.workspace_id
+    }
+
+    pub(crate) async fn initialize(
+        &self,
+        pool: &sqlx::SqlitePool,
+        key: &hypr_e2ee::WorkspaceKey,
+    ) -> io::Result<()> {
+        let cursor = witness_cursor(pool, &self.workspace_id).await?;
+        let status = self.read_page(cursor, None).await?;
+        self.validate_page(&status, cursor, None)?;
+        if status.head_sequence < cursor {
+            return Err(rollback_error());
+        }
+
+        if status.initialized {
+            self.publish_pending(pool, key, false).await?;
+        } else {
+            if !hypr_db_app::has_e2ee_local_state(pool, &self.workspace_id)
+                .await
+                .map_err(replica_error)?
+            {
+                return Err(io::Error::other(
+                    "E2EE freshness witness must be initialized from an existing trusted device",
+                ));
+            }
+            self.publish_pending(pool, key, true).await?;
+        }
+
+        self.refresh(pool, key).await
+    }
+
+    pub(crate) async fn publish_and_refresh(
+        &self,
+        pool: &sqlx::SqlitePool,
+        key: &hypr_e2ee::WorkspaceKey,
+    ) -> io::Result<()> {
+        self.publish_pending(pool, key, false).await?;
+        self.refresh(pool, key).await
+    }
+
+    pub(crate) async fn refresh(
+        &self,
+        pool: &sqlx::SqlitePool,
+        key: &hypr_e2ee::WorkspaceKey,
+    ) -> io::Result<()> {
+        let cursor = witness_cursor(pool, &self.workspace_id).await?;
+        let mut page = self.read_page(cursor, None).await?;
+        self.validate_page(&page, cursor, None)?;
+        if !page.initialized {
+            return Err(io::Error::other(
+                "E2EE freshness witness is not initialized",
+            ));
+        }
+        if page.head_sequence < cursor {
+            return Err(rollback_error());
+        }
+
+        let through = page.through_sequence;
+        loop {
+            let events = page
+                .events
+                .into_iter()
+                .map(|event| hypr_db_app::E2eeWitnessEvent {
+                    sequence: event.sequence,
+                    record_id: event.record_id,
+                    workspace_id: self.workspace_id.clone(),
+                    payload_hash: event.payload_hash,
+                    payload: event.payload,
+                })
+                .collect::<Vec<_>>();
+            hypr_db_app::merge_e2ee_witness_events(pool, key, &self.workspace_id, &events)
+                .await
+                .map_err(replica_error)?;
+            let after = page.next_after_sequence;
+            if after == through {
+                break;
+            }
+            if after >= through {
+                return Err(invalid_data("E2EE witness page cursor is invalid"));
+            }
+            page = self.read_page(after, Some(through)).await?;
+            self.validate_page(&page, after, Some(through))?;
+        }
+
+        hypr_db_app::advance_e2ee_witness_cursor(pool, &self.workspace_id, through)
+            .await
+            .map_err(replica_error)
+    }
+
+    async fn publish_pending(
+        &self,
+        pool: &sqlx::SqlitePool,
+        key: &hypr_e2ee::WorkspaceKey,
+        initialize: bool,
+    ) -> io::Result<()> {
+        let uploads = hypr_db_app::pending_e2ee_witness_uploads(pool, &self.workspace_id, key)
+            .await
+            .map_err(replica_error)?;
+        if initialize && uploads.is_empty() {
+            return Err(io::Error::other(
+                "E2EE freshness initialization requires established encrypted state",
+            ));
+        }
+        let cursor = witness_cursor(pool, &self.workspace_id).await?;
+        let mut start = 0;
+        while start < uploads.len() {
+            let mut end = start;
+            let mut batch_bytes = 0usize;
+            while end < uploads.len() && end - start < MAX_EVENTS_PER_BATCH {
+                let event_bytes = uploads[end]
+                    .payload
+                    .len()
+                    .saturating_add(uploads[end].record_id.len())
+                    .saturating_add(uploads[end].payload_hash.len())
+                    .saturating_add(256);
+                if uploads[end].payload.len() > MAX_EVENT_BYTES {
+                    return Err(invalid_data("E2EE witness event is too large"));
+                }
+                if end > start && batch_bytes.saturating_add(event_bytes) > MAX_BATCH_BYTES {
+                    break;
+                }
+                batch_bytes = batch_bytes.saturating_add(event_bytes);
+                end += 1;
+            }
+            let batch = &uploads[start..end];
+            let response = self
+                .client
+                .post(self.endpoint.clone())
+                .bearer_auth(&self.access_token)
+                .json(&PublishRequest {
+                    initialize: initialize && start == 0,
+                    events: batch
+                        .iter()
+                        .map(|upload| PublishEvent {
+                            record_id: &upload.record_id,
+                            payload_hash: &upload.payload_hash,
+                            payload: &upload.payload,
+                        })
+                        .collect(),
+                })
+                .send()
+                .await
+                .map_err(transport_error)?;
+            let status = response.status();
+            let bytes = read_bounded(response).await?;
+            if !status.is_success() {
+                return Err(io::Error::other(format!(
+                    "E2EE witness publication was rejected with status {status}"
+                )));
+            }
+            let response: PublishResponse = serde_json::from_slice(&bytes)
+                .map_err(|_| invalid_data("E2EE witness publication response is invalid"))?;
+            if response.initialized_at.is_empty() || response.head_sequence < cursor {
+                return Err(rollback_error());
+            }
+            hypr_db_app::acknowledge_e2ee_witness_uploads(pool, key, batch)
+                .await
+                .map_err(replica_error)?;
+            start = end;
+        }
+        Ok(())
+    }
+
+    async fn read_page(&self, after: u64, through: Option<u64>) -> io::Result<ReadPage> {
+        let mut request = self
+            .client
+            .get(self.endpoint.clone())
+            .bearer_auth(&self.access_token)
+            .query(&[("afterSequence", after)]);
+        if let Some(through) = through {
+            request = request.query(&[("throughSequence", through)]);
+        }
+        let response = request.send().await.map_err(transport_error)?;
+        let status = response.status();
+        let bytes = read_bounded(response).await?;
+        if !status.is_success() {
+            return Err(io::Error::other(format!(
+                "E2EE witness read was rejected with status {status}"
+            )));
+        }
+        serde_json::from_slice(&bytes)
+            .map_err(|_| invalid_data("E2EE witness read response is invalid"))
+    }
+
+    fn validate_page(
+        &self,
+        page: &ReadPage,
+        requested_after: u64,
+        requested_through: Option<u64>,
+    ) -> io::Result<()> {
+        if page.initialized != page.initialized_at.is_some()
+            || page.through_sequence > page.head_sequence
+            || requested_after > page.through_sequence
+            || requested_through.is_some_and(|through| through != page.through_sequence)
+            || page.next_after_sequence < requested_after
+            || page.next_after_sequence > page.through_sequence
+            || (page.events.is_empty() && page.next_after_sequence != requested_after)
+            || (page.events.is_empty() && requested_after != page.through_sequence)
+            || page
+                .events
+                .last()
+                .is_some_and(|event| event.sequence != page.next_after_sequence)
+        {
+            return Err(invalid_data("E2EE witness page is invalid"));
+        }
+        let mut previous = requested_after;
+        for event in &page.events {
+            if event.sequence <= previous
+                || event.sequence > page.through_sequence
+                || event.payload.is_empty()
+                || event.payload.len() > MAX_EVENT_BYTES
+            {
+                return Err(invalid_data("E2EE witness event is invalid"));
+            }
+            previous = event.sequence;
+        }
+        Ok(())
+    }
+}
+
+async fn witness_cursor(pool: &sqlx::SqlitePool, workspace_id: &str) -> io::Result<u64> {
+    hypr_db_app::e2ee_witness_cursor(pool, workspace_id)
+        .await
+        .map_err(replica_error)
+}
+
+async fn read_bounded(response: reqwest::Response) -> io::Result<Vec<u8>> {
+    if response
+        .content_length()
+        .is_some_and(|length| length > MAX_RESPONSE_BYTES as u64)
+    {
+        return Err(invalid_data("E2EE witness response is too large"));
+    }
+    let mut stream = response.bytes_stream();
+    let mut bytes = Vec::new();
+    while let Some(chunk) = stream.next().await {
+        let chunk = chunk.map_err(transport_error)?;
+        if bytes.len().saturating_add(chunk.len()) > MAX_RESPONSE_BYTES {
+            return Err(invalid_data("E2EE witness response is too large"));
+        }
+        bytes.extend_from_slice(&chunk);
+    }
+    Ok(bytes)
+}
+
+fn replica_error(error: hypr_db_app::E2eeReplicaError) -> io::Error {
+    io::Error::other(format!("E2EE witness state failed: {error}"))
+}
+
+fn transport_error(error: reqwest::Error) -> io::Error {
+    io::Error::other(format!("E2EE witness request failed: {error}"))
+}
+
+fn invalid_data(message: &'static str) -> io::Error {
+    io::Error::new(io::ErrorKind::InvalidData, message)
+}
+
+fn rollback_error() -> io::Error {
+    io::Error::other("E2EE freshness witness rollback was detected")
+}

--- a/plugins/db/src/lib.rs
+++ b/plugins/db/src/lib.rs
@@ -1,4 +1,5 @@
 mod commands;
+mod e2ee_witness;
 mod error;
 mod import;
 mod runtime;
@@ -161,6 +162,13 @@ pub struct CloudsyncWorkspaceProjectionEntry {
     pub updated_at: String,
 }
 
+#[derive(Clone, serde::Deserialize, specta::Type, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CloudsyncE2eeWitness {
+    pub endpoint: String,
+    pub access_token: String,
+}
+
 impl From<CloudsyncWorkspaceProjection> for hypr_db_app::CloudsyncWorkspaceProjection {
     fn from(projection: CloudsyncWorkspaceProjection) -> Self {
         Self {
@@ -274,6 +282,7 @@ mod test {
     use hypr_db_reactive::QueryEventSink;
     use serde_json::json;
     use tauri::ipc::{Channel, InvokeResponseBody};
+    use wiremock::{Mock, MockServer, Request, Respond, ResponseTemplate, matchers::path};
 
     use super::*;
 
@@ -368,6 +377,91 @@ mod test {
             .set_e2ee_recovery_key("user-a", &recovery_key)
             .unwrap();
         (dir, runtime)
+    }
+
+    #[derive(Clone, Default)]
+    struct WitnessResponder {
+        events: Arc<Mutex<Vec<serde_json::Value>>>,
+    }
+
+    impl Respond for WitnessResponder {
+        fn respond(&self, request: &Request) -> ResponseTemplate {
+            if request.method == wiremock::http::Method::POST {
+                let body: serde_json::Value = request.body_json().unwrap();
+                let mut events = self.events.lock().unwrap();
+                for event in body["events"].as_array().unwrap() {
+                    let duplicate = events.iter().any(|existing| {
+                        existing["recordId"] == event["recordId"]
+                            && existing["payloadHash"] == event["payloadHash"]
+                    });
+                    if !duplicate {
+                        let mut event = event.clone();
+                        event["sequence"] = json!(events.len() + 1);
+                        events.push(event);
+                    }
+                }
+                return ResponseTemplate::new(200).set_body_json(json!({
+                    "initializedAt": "2026-07-17T00:00:00Z",
+                    "headSequence": events.len(),
+                }));
+            }
+
+            let query = request
+                .url
+                .query_pairs()
+                .collect::<std::collections::HashMap<_, _>>();
+            let after = query
+                .get("afterSequence")
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(0);
+            let events = self.events.lock().unwrap();
+            let head = u64::try_from(events.len()).unwrap();
+            let through = query
+                .get("throughSequence")
+                .and_then(|value| value.parse::<u64>().ok())
+                .unwrap_or(head);
+            let page = events
+                .iter()
+                .filter(|event| {
+                    event["sequence"].as_u64().unwrap() > after
+                        && event["sequence"].as_u64().unwrap() <= through
+                })
+                .take(3)
+                .cloned()
+                .collect::<Vec<_>>();
+            let next = page
+                .last()
+                .and_then(|event| event["sequence"].as_u64())
+                .unwrap_or(after);
+            ResponseTemplate::new(200).set_body_json(json!({
+                "initialized": true,
+                "initializedAt": "2026-07-17T00:00:00Z",
+                "headSequence": head,
+                "throughSequence": through,
+                "nextAfterSequence": next,
+                "events": page,
+            }))
+        }
+    }
+
+    async fn setup_witness(workspace_id: &str) -> (MockServer, CloudsyncE2eeWitness) {
+        let server = MockServer::start().await;
+        Mock::given(path(format!("/sync/e2ee/witness/{workspace_id}")))
+            .respond_with(WitnessResponder::default())
+            .mount(&server)
+            .await;
+        let config = CloudsyncE2eeWitness {
+            endpoint: format!("{}/sync/e2ee/witness/{workspace_id}", server.uri()),
+            access_token: "access-token".to_string(),
+        };
+        (server, config)
+    }
+
+    fn unreachable_witness(workspace_id: &str) -> CloudsyncE2eeWitness {
+        CloudsyncE2eeWitness {
+            endpoint: format!("http://127.0.0.1:9/sync/e2ee/witness/{workspace_id}"),
+            access_token: "access-token".to_string(),
+        }
     }
 
     async fn setup_unmigrated_runtime() -> (tempfile::TempDir, Arc<runtime::PluginDbRuntime>) {
@@ -648,6 +742,7 @@ mod test {
                 "managed-database-id".to_string(),
                 "token".to_string(),
                 "user-a".to_string(),
+                unreachable_witness("user-a"),
             )
             .await
             .unwrap_err();
@@ -762,6 +857,7 @@ mod test {
                 "managed-database-id".to_string(),
                 "token".to_string(),
                 "user-a".to_string(),
+                unreachable_witness("user-a"),
             )
             .await
             .unwrap_err();
@@ -814,6 +910,7 @@ mod test {
                     personal_workspace_id: "user-a".to_string(),
                     workspaces: vec![],
                 }),
+                unreachable_witness("user-a"),
             )
             .await
             .unwrap_err();
@@ -843,6 +940,7 @@ mod test {
     #[tokio::test]
     async fn token_configuration_claims_workspace_and_can_be_suspended() {
         let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
+        let (_witness_server, witness) = setup_witness("user-a").await;
         let local_workspace = hypr_db_app::ensure_cloudsync_workspace_binding(runtime.pool())
             .await
             .unwrap();
@@ -869,6 +967,7 @@ mod test {
                     "managed-database-id".to_string(),
                     "token".to_string(),
                     "user-a".to_string(),
+                    witness,
                 )
                 .await
                 .unwrap(),
@@ -897,6 +996,7 @@ mod test {
     #[tokio::test]
     async fn token_configuration_projects_server_workspaces_after_account_claim() {
         let (_dir, runtime) = setup_enabled_cloudsync_runtime().await;
+        let (_witness_server, witness) = setup_witness("user-a").await;
         assert!(
             runtime
                 .bind_cloudsync_account("user-a".to_string())
@@ -942,6 +1042,7 @@ mod test {
                     "token".to_string(),
                     "user-a".to_string(),
                     Some(projection),
+                    witness,
                 )
                 .await
                 .unwrap(),
@@ -1051,6 +1152,7 @@ mod test {
                         updated_at: "2026-07-16T00:00:00Z".to_string(),
                     }],
                 }),
+                unreachable_witness("user-a"),
             )
             .await
             .unwrap_err();
@@ -1092,6 +1194,7 @@ mod test {
                 "managed-database-id".to_string(),
                 "token".to_string(),
                 "user-a".to_string(),
+                unreachable_witness("user-a"),
             )
             .await
             .unwrap();
@@ -1126,6 +1229,7 @@ mod test {
                 "managed-database-id".to_string(),
                 "token".to_string(),
                 "user-a".to_string(),
+                unreachable_witness("user-a"),
             )
             .await
             .unwrap();

--- a/plugins/db/src/runtime.rs
+++ b/plugins/db/src/runtime.rs
@@ -15,6 +15,7 @@ const CLOUDSYNC_WRITE_FILTER: &str =
 #[derive(Default)]
 struct E2eeSyncHook {
     keys: std::sync::RwLock<HashMap<String, hypr_e2ee::WorkspaceKey>>,
+    witness: std::sync::RwLock<Option<crate::e2ee_witness::E2eeWitnessClient>>,
 }
 
 impl E2eeSyncHook {
@@ -38,10 +39,19 @@ impl E2eeSyncHook {
 
     fn clear(&self) {
         self.keys.write().unwrap().clear();
+        *self.witness.write().unwrap() = None;
     }
 
     fn snapshot(&self) -> HashMap<String, hypr_e2ee::WorkspaceKey> {
         self.keys.read().unwrap().clone()
+    }
+
+    fn set_witness(&self, witness: crate::e2ee_witness::E2eeWitnessClient) {
+        *self.witness.write().unwrap() = Some(witness);
+    }
+
+    fn witness(&self) -> Option<crate::e2ee_witness::E2eeWitnessClient> {
+        self.witness.read().unwrap().clone()
     }
 
     async fn prepare_local_snapshot(
@@ -60,7 +70,13 @@ impl hypr_db_core::CloudsyncSyncHook for E2eeSyncHook {
         pool: &'a sqlx::SqlitePool,
     ) -> hypr_db_core::CloudsyncHookFuture<'a> {
         let keys = self.snapshot();
+        let witness = self.witness();
         Box::pin(async move {
+            let witness = witness
+                .ok_or_else(|| std::io::Error::other("E2EE freshness witness is not configured"))?;
+            let key = keys.get(witness.workspace_id()).ok_or_else(|| {
+                std::io::Error::other("E2EE freshness witness identity is not configured")
+            })?;
             let stats = hypr_db_app::encrypt_e2ee_replica_changes(pool, &keys)
                 .await
                 .map_err(|error| {
@@ -69,6 +85,17 @@ impl hypr_db_core::CloudsyncSyncHook for E2eeSyncHook {
             tracing::debug!(
                 encrypted_fields = stats.encrypted_fields,
                 "prepared encrypted CloudSync replica"
+            );
+            witness.publish_and_refresh(pool, key).await?;
+            let stats = hypr_db_app::apply_e2ee_replica_changes_with_witness(pool, &keys)
+                .await
+                .map_err(|error| {
+                    std::io::Error::other(format!("E2EE pre-sync witness apply failed: {error}"))
+                })?;
+            tracing::debug!(
+                applied_fields = stats.applied_fields,
+                rejected_unwitnessed = stats.rejected_unwitnessed,
+                "applied trusted E2EE witness before CloudSync"
             );
             Ok(())
         })
@@ -79,8 +106,15 @@ impl hypr_db_core::CloudsyncSyncHook for E2eeSyncHook {
         pool: &'a sqlx::SqlitePool,
     ) -> hypr_db_core::CloudsyncHookFuture<'a> {
         let keys = self.snapshot();
+        let witness = self.witness();
         Box::pin(async move {
-            let stats = hypr_db_app::apply_e2ee_replica_changes(pool, &keys)
+            let witness = witness
+                .ok_or_else(|| std::io::Error::other("E2EE freshness witness is not configured"))?;
+            let key = keys.get(witness.workspace_id()).ok_or_else(|| {
+                std::io::Error::other("E2EE freshness witness identity is not configured")
+            })?;
+            witness.refresh(pool, key).await?;
+            let stats = hypr_db_app::apply_e2ee_replica_changes_with_witness(pool, &keys)
                 .await
                 .map_err(|error| {
                     std::io::Error::other(format!("E2EE post-sync decryption failed: {error}"))
@@ -88,6 +122,8 @@ impl hypr_db_core::CloudsyncSyncHook for E2eeSyncHook {
             tracing::debug!(
                 applied_fields = stats.applied_fields,
                 skipped_local_changes = stats.skipped_local_changes,
+                rejected_rollbacks = stats.rejected_rollbacks,
+                rejected_unwitnessed = stats.rejected_unwitnessed,
                 "applied encrypted CloudSync replica"
             );
             Ok(())
@@ -270,9 +306,16 @@ impl PluginDbRuntime {
         database_id: String,
         token: String,
         account_user_id: String,
+        e2ee_witness: crate::CloudsyncE2eeWitness,
     ) -> Result<crate::CloudsyncTokenConfigurationResult> {
-        self.configure_cloudsync_token_with_projection(database_id, token, account_user_id, None)
-            .await
+        self.configure_cloudsync_token_with_projection(
+            database_id,
+            token,
+            account_user_id,
+            None,
+            e2ee_witness,
+        )
+        .await
     }
 
     pub async fn configure_cloudsync_token_with_projection(
@@ -281,6 +324,36 @@ impl PluginDbRuntime {
         token: String,
         account_user_id: String,
         workspace_projection: Option<hypr_db_app::CloudsyncWorkspaceProjection>,
+        e2ee_witness: crate::CloudsyncE2eeWitness,
+    ) -> Result<crate::CloudsyncTokenConfigurationResult> {
+        let result = self
+            .configure_cloudsync_token_with_projection_inner(
+                database_id,
+                token,
+                account_user_id,
+                workspace_projection,
+                e2ee_witness,
+            )
+            .await;
+        if result.is_err()
+            || matches!(
+                &result,
+                Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch)
+            )
+        {
+            let _ = self.db.cloudsync_suspend().await;
+            self.e2ee_sync_hook.clear();
+        }
+        result
+    }
+
+    async fn configure_cloudsync_token_with_projection_inner(
+        &self,
+        database_id: String,
+        token: String,
+        account_user_id: String,
+        workspace_projection: Option<hypr_db_app::CloudsyncWorkspaceProjection>,
+        e2ee_witness: crate::CloudsyncE2eeWitness,
     ) -> Result<crate::CloudsyncTokenConfigurationResult> {
         let _reconciliation_guard = if workspace_projection.is_some() {
             Some(self.synced_write_barrier.write().await)
@@ -314,7 +387,10 @@ impl PluginDbRuntime {
             return Err(crate::Error::E2eeIdentityRequired);
         }
 
-        if !self.claim_cloudsync_workspace(account_user_id).await? {
+        if !self
+            .claim_cloudsync_workspace(account_user_id.clone())
+            .await?
+        {
             return Ok(crate::CloudsyncTokenConfigurationResult::AccountMismatch);
         }
 
@@ -322,6 +398,14 @@ impl PluginDbRuntime {
             self.db.cloudsync_suspend().await?;
         }
         self.prepare_e2ee_cutover().await?;
+        let witness =
+            crate::e2ee_witness::E2eeWitnessClient::new(e2ee_witness, personal_workspace_id)?;
+        let key = self
+            .e2ee_sync_hook
+            .workspace_key(personal_workspace_id)
+            .ok_or(crate::Error::E2eeIdentityRequired)?;
+        witness.initialize(self.db.pool(), &key).await?;
+        self.e2ee_sync_hook.set_witness(witness);
 
         let write_filter_version_current = match workspace_projection.as_ref() {
             Some(_) => hypr_db_app::cloudsync_write_filter_version_current(self.db.pool()).await?,
@@ -639,6 +723,7 @@ impl PluginDbRuntime {
     pub async fn logout_cloudsync(&self, discard_unsent_changes: bool) -> Result<()> {
         let _write_guard = self.synced_write_barrier.write().await;
         self.db.cloudsync_logout(discard_unsent_changes).await?;
+        self.e2ee_sync_hook.clear();
         Ok(())
     }
 }

--- a/plugins/store2/src/commands.rs
+++ b/plugins/store2/src/commands.rs
@@ -1,11 +1,31 @@
 use crate::Store2PluginExt;
 
 const SECURE_STORE_SUFFIX: &str = "secure-store";
+const NATIVE_SECRET_ACCOUNT_PREFIXES: &[&str] = &["e2ee:"];
 #[cfg(target_os = "macos")]
 const MACOS_KEYCHAIN_ACCESS_ERROR_PREFIX: &str = "macOS couldn't access your login Keychain.";
 
 #[cfg(target_os = "macos")]
 const ERR_SEC_AUTH_FAILED: i32 = -25293;
+
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum SecretCaller {
+    Native,
+    Renderer,
+}
+
+fn validate_secret_coordinate(caller: SecretCaller, scope: &str, key: &str) -> Result<(), String> {
+    let account = format!("{scope}:{key}");
+    if caller == SecretCaller::Renderer
+        && NATIVE_SECRET_ACCOUNT_PREFIXES
+            .iter()
+            .any(|prefix| account.starts_with(prefix))
+    {
+        return Err("secure-store account is reserved for native use".to_string());
+    }
+
+    Ok(())
+}
 
 fn secure_store_service(identifier: &str) -> String {
     let identifier = match identifier {
@@ -252,7 +272,7 @@ pub(crate) async fn get_secret<R: tauri::Runtime>(
     scope: String,
     key: String,
 ) -> Result<Option<String>, String> {
-    read_secret(app, scope, key).await
+    read_secret_for(SecretCaller::Renderer, app, scope, key).await
 }
 
 pub async fn read_secret<R: tauri::Runtime>(
@@ -260,6 +280,16 @@ pub async fn read_secret<R: tauri::Runtime>(
     scope: String,
     key: String,
 ) -> Result<Option<String>, String> {
+    read_secret_for(SecretCaller::Native, app, scope, key).await
+}
+
+async fn read_secret_for<R: tauri::Runtime>(
+    caller: SecretCaller,
+    app: tauri::AppHandle<R>,
+    scope: String,
+    key: String,
+) -> Result<Option<String>, String> {
+    validate_secret_coordinate(caller, &scope, &key)?;
     tauri::async_runtime::spawn_blocking(move || {
         let entry = secret_entry(&app, &scope, &key)?;
         match entry.get_password() {
@@ -294,7 +324,7 @@ pub(crate) async fn set_secret<R: tauri::Runtime>(
     key: String,
     value: String,
 ) -> Result<(), String> {
-    write_secret(app, scope, key, value).await
+    write_secret_for(SecretCaller::Renderer, app, scope, key, value).await
 }
 
 pub async fn write_secret<R: tauri::Runtime>(
@@ -303,6 +333,17 @@ pub async fn write_secret<R: tauri::Runtime>(
     key: String,
     value: String,
 ) -> Result<(), String> {
+    write_secret_for(SecretCaller::Native, app, scope, key, value).await
+}
+
+async fn write_secret_for<R: tauri::Runtime>(
+    caller: SecretCaller,
+    app: tauri::AppHandle<R>,
+    scope: String,
+    key: String,
+    value: String,
+) -> Result<(), String> {
+    validate_secret_coordinate(caller, &scope, &key)?;
     tauri::async_runtime::spawn_blocking(move || {
         let entry = secret_entry(&app, &scope, &key)?;
         entry.set_password(&value).map_err(secure_store_error)?;
@@ -322,6 +363,16 @@ pub(crate) async fn delete_secret<R: tauri::Runtime>(
     scope: String,
     key: String,
 ) -> Result<(), String> {
+    delete_secret_for(SecretCaller::Renderer, app, scope, key).await
+}
+
+async fn delete_secret_for<R: tauri::Runtime>(
+    caller: SecretCaller,
+    app: tauri::AppHandle<R>,
+    scope: String,
+    key: String,
+) -> Result<(), String> {
+    validate_secret_coordinate(caller, &scope, &key)?;
     tauri::async_runtime::spawn_blocking(move || {
         for legacy_entry in legacy_secret_entries(&app, &scope, &key)? {
             match legacy_entry.delete_credential() {
@@ -404,6 +455,61 @@ mod tests {
     #[test]
     fn skips_duplicate_legacy_secret_locations() {
         assert!(legacy_secret_locations("com.example.app", "provider", "deepgram").is_empty());
+    }
+
+    #[test]
+    fn isolates_native_secret_accounts_from_renderer_commands() {
+        assert!(validate_secret_coordinate(SecretCaller::Renderer, "provider", "deepgram").is_ok());
+        assert!(
+            validate_secret_coordinate(
+                SecretCaller::Renderer,
+                "e2ee",
+                "account:user-a:recovery-v1"
+            )
+            .is_err()
+        );
+        assert!(
+            validate_secret_coordinate(
+                SecretCaller::Renderer,
+                "e2ee:account",
+                "user-a:recovery-v1"
+            )
+            .is_err()
+        );
+        assert!(
+            validate_secret_coordinate(SecretCaller::Native, "e2ee", "account:user-a:recovery-v1")
+                .is_ok()
+        );
+    }
+
+    #[tokio::test]
+    async fn renderer_secret_commands_reject_native_accounts_before_keychain_access() {
+        let app = tauri::test::mock_builder()
+            .build(tauri::test::mock_context(tauri::test::noop_assets()))
+            .unwrap();
+        let app = app.handle().clone();
+        let scope = "e2ee".to_string();
+        let key = "account:user-a:recovery-v1".to_string();
+        let expected = "secure-store account is reserved for native use";
+
+        assert_eq!(
+            get_secret(app.clone(), scope.clone(), key.clone())
+                .await
+                .unwrap_err(),
+            expected
+        );
+        assert_eq!(
+            set_secret(
+                app.clone(),
+                scope.clone(),
+                key.clone(),
+                "replacement".to_string()
+            )
+            .await
+            .unwrap_err(),
+            expected
+        );
+        assert_eq!(delete_secret(app, scope, key).await.unwrap_err(), expected);
     }
 
     #[cfg(target_os = "macos")]

--- a/supabase/migrations/20260717130133_e2ee_freshness_witness.sql
+++ b/supabase/migrations/20260717130133_e2ee_freshness_witness.sql
@@ -1,0 +1,268 @@
+ALTER TABLE public.workspaces
+  ADD COLUMN e2ee_freshness_initialized_at timestamptz;
+
+CREATE TABLE public.e2ee_freshness_events (
+  sequence bigint GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+  workspace_id uuid NOT NULL REFERENCES public.workspaces(id) ON DELETE CASCADE,
+  record_id text NOT NULL,
+  payload_hash text NOT NULL,
+  payload text NOT NULL,
+  created_by uuid NOT NULL,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT e2ee_freshness_events_record_id_check CHECK (
+    record_id ~ '^[A-Za-z0-9_-]{43}$'
+  ),
+  CONSTRAINT e2ee_freshness_events_payload_hash_check CHECK (
+    payload_hash ~ '^[A-Za-z0-9_-]{43}$'
+  ),
+  CONSTRAINT e2ee_freshness_events_payload_size_check CHECK (
+    octet_length(payload) BETWEEN 1 AND 16777216
+  ),
+  CONSTRAINT e2ee_freshness_events_payload_key UNIQUE (
+    workspace_id,
+    record_id,
+    payload_hash
+  )
+);
+
+CREATE INDEX e2ee_freshness_events_workspace_sequence_idx
+  ON public.e2ee_freshness_events(workspace_id, sequence);
+
+ALTER TABLE public.e2ee_freshness_events ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE public.e2ee_freshness_events
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON SEQUENCE public.e2ee_freshness_events_sequence_seq
+  FROM PUBLIC, anon, authenticated;
+GRANT SELECT, INSERT ON TABLE public.e2ee_freshness_events TO service_role;
+GRANT USAGE, SELECT ON SEQUENCE public.e2ee_freshness_events_sequence_seq TO service_role;
+
+CREATE OR REPLACE FUNCTION public.claim_personal_workspace_e2ee_key(
+  p_actor_user_id uuid,
+  p_key_id text
+)
+RETURNS TABLE (key_id text)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = ''
+AS $$
+BEGIN
+  IF p_actor_user_id IS NULL
+    OR p_key_id IS NULL
+    OR p_key_id !~ '^[A-Za-z0-9_-]{22}$'
+  THEN
+    RAISE EXCEPTION 'E2EE key identity is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  UPDATE public.workspaces AS workspace
+  SET e2ee_key_id = p_key_id,
+      e2ee_freshness_initialized_at = now(),
+      updated_at = now()
+  WHERE workspace.id = p_actor_user_id
+    AND workspace.owner_user_id = p_actor_user_id
+    AND workspace.kind = 'personal'
+    AND workspace.deleted_at IS NULL
+    AND workspace.e2ee_key_id IS NULL;
+
+  RETURN QUERY
+  SELECT workspace.e2ee_key_id
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_actor_user_id
+    AND workspace.owner_user_id = p_actor_user_id
+    AND workspace.kind = 'personal'
+    AND workspace.deleted_at IS NULL;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.publish_e2ee_freshness_events(
+  p_actor_user_id uuid,
+  p_workspace_id uuid,
+  p_initialize boolean,
+  p_events jsonb
+)
+RETURNS TABLE (
+  initialized_at timestamptz,
+  head_sequence bigint
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_initialized_at timestamptz;
+  v_events jsonb := COALESCE(p_events, '[]'::jsonb);
+BEGIN
+  IF p_actor_user_id IS NULL OR p_workspace_id IS NULL OR p_initialize IS NULL THEN
+    RAISE EXCEPTION 'E2EE freshness request is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT workspace.e2ee_freshness_initialized_at
+  INTO v_initialized_at
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id
+    AND workspace.id = p_actor_user_id
+    AND workspace.owner_user_id = p_actor_user_id
+    AND workspace.kind = 'personal'
+    AND workspace.deleted_at IS NULL
+    AND workspace.e2ee_key_id IS NOT NULL
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'E2EE freshness publication is not permitted' USING ERRCODE = '42501';
+  END IF;
+
+  IF jsonb_typeof(v_events) <> 'array' OR jsonb_array_length(v_events) > 64 THEN
+    RAISE EXCEPTION 'E2EE freshness event batch is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF EXISTS (
+    SELECT 1
+    FROM jsonb_array_elements(v_events) AS event(value)
+    WHERE jsonb_typeof(event.value) <> 'object'
+      OR COALESCE(event.value->>'record_id', '') !~ '^[A-Za-z0-9_-]{43}$'
+      OR COALESCE(event.value->>'payload_hash', '') !~ '^[A-Za-z0-9_-]{43}$'
+      OR octet_length(COALESCE(event.value->>'payload', '')) NOT BETWEEN 1 AND 16777216
+      OR event.value->>'payload_hash' <> rtrim(
+        translate(
+          encode(extensions.digest(event.value->>'payload', 'sha256'), 'base64'),
+          '+/',
+          '-_'
+        ),
+        '='
+      )
+  ) THEN
+    RAISE EXCEPTION 'E2EE freshness event is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  IF v_initialized_at IS NULL AND NOT p_initialize THEN
+    RAISE EXCEPTION 'E2EE freshness witness is not initialized' USING ERRCODE = '55000';
+  END IF;
+
+  IF v_initialized_at IS NULL AND jsonb_array_length(v_events) = 0 THEN
+    RAISE EXCEPTION 'E2EE freshness initialization requires established state'
+      USING ERRCODE = '55000';
+  END IF;
+
+  INSERT INTO public.e2ee_freshness_events (
+    workspace_id,
+    record_id,
+    payload_hash,
+    payload,
+    created_by
+  )
+  SELECT
+    p_workspace_id,
+    event.value->>'record_id',
+    event.value->>'payload_hash',
+    event.value->>'payload',
+    p_actor_user_id
+  FROM jsonb_array_elements(v_events) AS event(value)
+  ON CONFLICT (workspace_id, record_id, payload_hash) DO NOTHING;
+
+  IF v_initialized_at IS NULL THEN
+    UPDATE public.workspaces AS workspace
+    SET e2ee_freshness_initialized_at = now(),
+        updated_at = now()
+    WHERE workspace.id = p_workspace_id
+    RETURNING workspace.e2ee_freshness_initialized_at
+    INTO v_initialized_at;
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    v_initialized_at,
+    COALESCE(MAX(event.sequence), 0)::bigint
+  FROM public.e2ee_freshness_events AS event
+  WHERE event.workspace_id = p_workspace_id;
+END;
+$$;
+
+CREATE OR REPLACE FUNCTION public.read_e2ee_freshness_page(
+  p_actor_user_id uuid,
+  p_workspace_id uuid,
+  p_after_sequence bigint,
+  p_through_sequence bigint,
+  p_limit integer
+)
+RETURNS TABLE (
+  initialized_at timestamptz,
+  head_sequence bigint,
+  through_sequence bigint,
+  event_sequence bigint,
+  record_id text,
+  payload_hash text,
+  payload text
+)
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = ''
+AS $$
+DECLARE
+  v_initialized_at timestamptz;
+  v_head_sequence bigint;
+  v_through_sequence bigint;
+BEGIN
+  IF p_actor_user_id IS NULL
+    OR p_workspace_id IS NULL
+    OR p_after_sequence IS NULL
+    OR p_after_sequence < 0
+    OR p_limit IS NULL
+    OR p_limit NOT BETWEEN 1 AND 64
+  THEN
+    RAISE EXCEPTION 'E2EE freshness page is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  SELECT workspace.e2ee_freshness_initialized_at
+  INTO v_initialized_at
+  FROM public.workspaces AS workspace
+  WHERE workspace.id = p_workspace_id
+    AND workspace.id = p_actor_user_id
+    AND workspace.owner_user_id = p_actor_user_id
+    AND workspace.kind = 'personal'
+    AND workspace.deleted_at IS NULL
+    AND workspace.e2ee_key_id IS NOT NULL;
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION 'E2EE freshness read is not permitted' USING ERRCODE = '42501';
+  END IF;
+
+  SELECT COALESCE(MAX(event.sequence), 0)::bigint
+  INTO v_head_sequence
+  FROM public.e2ee_freshness_events AS event
+  WHERE event.workspace_id = p_workspace_id;
+
+  v_through_sequence := COALESCE(p_through_sequence, v_head_sequence);
+  IF v_through_sequence < p_after_sequence OR v_through_sequence > v_head_sequence THEN
+    RAISE EXCEPTION 'E2EE freshness page is invalid' USING ERRCODE = '22023';
+  END IF;
+
+  RETURN QUERY
+  SELECT
+    v_initialized_at,
+    v_head_sequence,
+    v_through_sequence,
+    event.sequence,
+    event.record_id,
+    event.payload_hash,
+    event.payload
+  FROM (SELECT 1) AS singleton
+  LEFT JOIN LATERAL (
+    SELECT candidate.sequence, candidate.record_id, candidate.payload_hash, candidate.payload
+    FROM public.e2ee_freshness_events AS candidate
+    WHERE candidate.workspace_id = p_workspace_id
+      AND candidate.sequence > p_after_sequence
+      AND candidate.sequence <= v_through_sequence
+    ORDER BY candidate.sequence
+    LIMIT p_limit
+  ) AS event ON true;
+END;
+$$;
+
+REVOKE ALL ON FUNCTION public.publish_e2ee_freshness_events(uuid, uuid, boolean, jsonb)
+  FROM PUBLIC, anon, authenticated;
+REVOKE ALL ON FUNCTION public.read_e2ee_freshness_page(uuid, uuid, bigint, bigint, integer)
+  FROM PUBLIC, anon, authenticated;
+GRANT EXECUTE ON FUNCTION public.publish_e2ee_freshness_events(uuid, uuid, boolean, jsonb)
+  TO service_role;
+GRANT EXECUTE ON FUNCTION public.read_e2ee_freshness_page(uuid, uuid, bigint, bigint, integer)
+  TO service_role;

--- a/supabase/tests/021-e2ee-freshness-witness.sql
+++ b/supabase/tests/021-e2ee-freshness-witness.sql
@@ -1,0 +1,269 @@
+begin;
+select plan(15);
+
+select tests.create_supabase_user('witness_owner', 'witness-owner@example.com');
+select tests.create_supabase_user('witness_other', 'witness-other@example.com');
+
+select ok(
+  not has_table_privilege('authenticated', 'public.e2ee_freshness_events', 'SELECT')
+    and not has_table_privilege('authenticated', 'public.e2ee_freshness_events', 'INSERT')
+    and not has_table_privilege('authenticated', 'public.e2ee_freshness_events', 'UPDATE')
+    and not has_table_privilege('authenticated', 'public.e2ee_freshness_events', 'DELETE'),
+  'Authenticated clients cannot access the witness table directly'
+);
+
+select ok(
+  has_table_privilege('service_role', 'public.e2ee_freshness_events', 'SELECT')
+    and has_table_privilege('service_role', 'public.e2ee_freshness_events', 'INSERT')
+    and not has_table_privilege('service_role', 'public.e2ee_freshness_events', 'UPDATE')
+    and not has_table_privilege('service_role', 'public.e2ee_freshness_events', 'DELETE'),
+  'Service code can append and read witness events but cannot rewrite history'
+);
+
+select ok(
+  not has_function_privilege(
+    'authenticated',
+    'public.publish_e2ee_freshness_events(uuid, uuid, boolean, jsonb)',
+    'EXECUTE'
+  )
+    and not has_function_privilege(
+      'authenticated',
+      'public.read_e2ee_freshness_page(uuid, uuid, bigint, bigint, integer)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.publish_e2ee_freshness_events(uuid, uuid, boolean, jsonb)',
+      'EXECUTE'
+    )
+    and has_function_privilege(
+      'service_role',
+      'public.read_e2ee_freshness_page(uuid, uuid, bigint, bigint, integer)',
+      'EXECUTE'
+    ),
+  'Only trusted service code can use witness functions'
+);
+
+select tests.authenticate_as_service_role();
+
+select is(
+  (
+    select key_id
+    from public.claim_personal_workspace_e2ee_key(
+      tests.get_supabase_uid('witness_owner'),
+      'abcdefghijklmnopqrstuv'
+    )
+  ),
+  'abcdefghijklmnopqrstuv',
+  'Claiming a new recovery-key identity succeeds'
+);
+
+select isnt(
+  (
+    select e2ee_freshness_initialized_at
+    from public.workspaces
+    where id = tests.get_supabase_uid('witness_owner')
+  ),
+  null,
+  'A newly claimed identity starts with an authoritative empty witness'
+);
+
+select results_eq(
+  format(
+    $$
+      select head_sequence, event_sequence
+      from public.read_e2ee_freshness_page(%L, %L, 0, null, 64)
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_owner')
+  ),
+  $$values (0::bigint, null::bigint)$$,
+  'An empty initialized witness returns a stable zero head'
+);
+
+create temporary table witness_event as
+select
+  repeat('r', 43)::text as record_id,
+  '{"version":1,"ciphertext":"opaque"}'::text as payload;
+
+alter table witness_event add column payload_hash text;
+update witness_event
+set payload_hash = rtrim(
+  translate(encode(extensions.digest(payload, 'sha256'), 'base64'), '+/', '-_'),
+  '='
+);
+
+select isnt(
+  (
+    select head_sequence
+    from public.publish_e2ee_freshness_events(
+      tests.get_supabase_uid('witness_owner'),
+      tests.get_supabase_uid('witness_owner'),
+      false,
+      (
+        select jsonb_build_array(jsonb_build_object(
+          'record_id', record_id,
+          'payload_hash', payload_hash,
+          'payload', payload
+        ))
+        from witness_event
+      )
+    )
+  ),
+  0::bigint,
+  'Publishing the first opaque ciphertext advances the append-only head'
+);
+
+create temporary table witness_head as
+select max(sequence)::bigint as sequence
+from public.e2ee_freshness_events
+where workspace_id = tests.get_supabase_uid('witness_owner');
+
+select is(
+  (
+    select head_sequence
+    from public.publish_e2ee_freshness_events(
+      tests.get_supabase_uid('witness_owner'),
+      tests.get_supabase_uid('witness_owner'),
+      false,
+      (
+        select jsonb_build_array(jsonb_build_object(
+          'record_id', record_id,
+          'payload_hash', payload_hash,
+          'payload', payload
+        ))
+        from witness_event
+      )
+    )
+  ),
+  (select sequence from witness_head),
+  'Publishing the same ciphertext is idempotent'
+);
+
+select results_eq(
+  format(
+    $$
+      select head_sequence, through_sequence, event_sequence, record_id, payload_hash, payload
+      from public.read_e2ee_freshness_page(%L, %L, 0, null, 64)
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_owner')
+  ),
+  $$
+    select head.sequence, head.sequence, head.sequence, event.record_id, event.payload_hash,
+      event.payload
+    from witness_event as event
+    cross join witness_head as head
+  $$,
+  'Witness pages return the exact immutable ciphertext event'
+);
+
+select throws_ok(
+  format(
+    $$
+      select *
+      from public.publish_e2ee_freshness_events(
+        %L,
+        %L,
+        false,
+        '[{"record_id":"rrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrrr","payload_hash":"hhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhhh","payload":"tampered"}]'::jsonb
+      )
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_owner')
+  ),
+  '22023',
+  'E2EE freshness event is invalid',
+  'Payload hashes are verified before an event is appended'
+);
+
+select throws_ok(
+  format(
+    $$
+      select *
+      from public.publish_e2ee_freshness_events(%L, %L, null, '[]'::jsonb)
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_owner')
+  ),
+  '22023',
+  'E2EE freshness request is invalid',
+  'Witness initialization intent must be explicit'
+);
+
+update public.workspaces
+set e2ee_key_id = 'zyxwvutsrqponmlkjihgfe',
+    e2ee_freshness_initialized_at = null
+where id = tests.get_supabase_uid('witness_other');
+
+select throws_ok(
+  format(
+    $$
+      select *
+      from public.publish_e2ee_freshness_events(%L, %L, false, '[]'::jsonb)
+    $$,
+    tests.get_supabase_uid('witness_other'),
+    tests.get_supabase_uid('witness_other')
+  ),
+  '55000',
+  'E2EE freshness witness is not initialized',
+  'Legacy identities cannot bootstrap from untrusted cloud state'
+);
+
+select lives_ok(
+  format(
+    $$
+      select *
+      from public.publish_e2ee_freshness_events(
+        %L,
+        %L,
+        true,
+        (
+          select jsonb_build_array(jsonb_build_object(
+            'record_id', record_id,
+            'payload_hash', payload_hash,
+            'payload', payload
+          ))
+          from witness_event
+        )
+      )
+    $$,
+    tests.get_supabase_uid('witness_other'),
+    tests.get_supabase_uid('witness_other')
+  ),
+  'An established client can explicitly initialize a legacy witness'
+);
+
+select throws_ok(
+  format(
+    $$
+      select *
+      from public.read_e2ee_freshness_page(%L, %L, 0, null, 64)
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_other')
+  ),
+  '42501',
+  'E2EE freshness read is not permitted',
+  'A service request cannot cross the actor workspace boundary'
+);
+
+select tests.clear_authentication();
+select tests.authenticate_as('witness_owner');
+
+select throws_ok(
+  format(
+    $$
+      select *
+      from public.read_e2ee_freshness_page(%L, %L, 0, null, 64)
+    $$,
+    tests.get_supabase_uid('witness_owner'),
+    tests.get_supabase_uid('witness_owner')
+  ),
+  '42501',
+  null,
+  'Authenticated clients cannot invoke witness reads directly'
+);
+
+select * from finish();
+rollback;


### PR DESCRIPTION


<!-- GitButler Footer Boundary Top -->
---
This is **part 5 of 11 in a stack** made with GitButler:
- <kbd>&nbsp;11&nbsp;</kbd> #6126
- <kbd>&nbsp;10&nbsp;</kbd> #6104
- <kbd>&nbsp;9&nbsp;</kbd> #6103
- <kbd>&nbsp;8&nbsp;</kbd> #6102
- <kbd>&nbsp;7&nbsp;</kbd> #6101
- <kbd>&nbsp;6&nbsp;</kbd> #6100
- <kbd>&nbsp;5&nbsp;</kbd> #6125 👈 
- <kbd>&nbsp;4&nbsp;</kbd> #6124
- <kbd>&nbsp;3&nbsp;</kbd> #6123
- <kbd>&nbsp;2&nbsp;</kbd> #6122
- <kbd>&nbsp;1&nbsp;</kbd> #6121
<!-- GitButler Footer Boundary Bottom -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes encrypted sync trust model, credential validation, and multi-layer crypto/replica logic on the critical CloudSync path; misconfiguration could block sync or affect data convergence.
> 
> **Overview**
> Introduces an **append-only E2EE freshness witness** so encrypted CloudSync only materializes ciphertext that has been published through a trusted server log, instead of trusting raw replica snapshots alone.
> 
> **Server & storage:** New `/sync/e2ee/witness/{workspace_id}` read/publish endpoints proxy Supabase RPCs with validation and bounded responses; a migration adds `e2ee_freshness_events`, workspace initialization metadata, and service-role-only access with pgTAP coverage.
> 
> **Desktop & plugin:** CloudSync credentials move to **`encryptionVersion: 2`** and require a witness `{ endpoint, accessToken }` when calling `configureCloudsyncToken`. The db plugin runs witness init/publish/refresh around sync, applies **`apply_e2ee_replica_changes_with_witness`**, and stores local witness state. Sealed fields gain per-device **`writer_id`** with revision/writer/hash tie-breaking and rollback repair.
> 
> **Deploy safety:** API CD runs unit tests plus stricter verification—legacy plaintext CloudSync DB must be gone and the E2EE DB must not contain legacy plaintext tables.
> 
> **UX & hardening:** Recovery-key copy clears the clipboard after 60s when still unchanged; renderer secure-store commands cannot touch `e2ee:` accounts reserved for native use.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 168619837ee98dd80f34f85255ba0c0af3b82327. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->