### PR TITLE
fix(desktop): recover missing audio for re-transcription

### DIFF
--- a/apps/desktop/src/services/audio-retention.test.ts
+++ b/apps/desktop/src/services/audio-retention.test.ts
@@ -34,12 +34,19 @@ import {
 } from "./audio-retention";
 
 function mockCleanupRows(
-  sessions: Array<{ id: string; created_at: string; has_words: number }>,
+  sessions: Array<{
+    id: string;
+    created_at: string;
+    has_words: number;
+    is_uploaded?: number;
+  }>,
   logicallyDeleted: Array<{ session_id: string }> = [],
 ) {
   mocks.execute.mockImplementation((sql: string) =>
     Promise.resolve(
-      sql.includes("FROM session_attachments") ? logicallyDeleted : sessions,
+      sql.includes("SELECT DISTINCT attachment.session_id")
+        ? logicallyDeleted
+        : sessions,
     ),
   );
 }
@@ -157,6 +164,29 @@ describe("audio retention", () => {
     await expect(
       deleteProcessedAudioForRetention("none", "unprocessed"),
     ).resolves.toBe(false);
+    expect(mocks.deleteLocalSessionAudio).not.toHaveBeenCalled();
+  });
+
+  test("keeps explicitly uploaded audio regardless of retention", async () => {
+    mocks.execute.mockResolvedValueOnce([{ has_words: 1, is_uploaded: 1 }]);
+
+    await expect(
+      deleteProcessedAudioForRetention("none", "uploaded"),
+    ).resolves.toBe(false);
+    expect(mocks.deleteLocalSessionAudio).not.toHaveBeenCalled();
+
+    mockCleanupRows([
+      {
+        id: "uploaded",
+        created_at: "2026-01-01T00:00:00.000Z",
+        has_words: 1,
+        is_uploaded: 1,
+      },
+    ]);
+
+    await expect(
+      cleanupExpiredAudio("none", Date.parse("2026-05-13T00:00:00.000Z")),
+    ).resolves.toEqual([]);
     expect(mocks.deleteLocalSessionAudio).not.toHaveBeenCalled();
   });
 

--- a/apps/desktop/src/services/audio-retention.ts
+++ b/apps/desktop/src/services/audio-retention.ts
@@ -51,8 +51,11 @@ export function isSessionAudioIdle(sessionId: string) {
   );
 }
 
-async function sessionHasTranscriptWords(sessionId: string): Promise<boolean> {
-  const rows = await liveQueryClient.execute<{ has_words: number }>(
+async function getSessionAudioRetentionState(sessionId: string) {
+  const rows = await liveQueryClient.execute<{
+    has_words: number;
+    is_uploaded: number;
+  }>(
     `
       SELECT EXISTS(
         SELECT 1
@@ -61,11 +64,26 @@ async function sessionHasTranscriptWords(sessionId: string): Promise<boolean> {
           AND deleted_at IS NULL
           AND json_valid(words_json)
           AND json_array_length(words_json) > 0
-      ) AS has_words
+      ) AS has_words,
+      EXISTS(
+        SELECT 1
+        FROM session_attachments
+        WHERE session_id = ?
+          AND source_type = 'session_audio'
+          AND source_id = 'primary'
+          AND deleted_at IS NULL
+          AND json_extract(
+            CASE
+              WHEN json_valid(metadata_json) THEN metadata_json
+              ELSE '{}'
+            END,
+            '$.audio_origin'
+          ) = 'uploaded'
+      ) AS is_uploaded
     `,
-    [sessionId],
+    [sessionId, sessionId],
   );
-  return rows[0]?.has_words === 1;
+  return rows[0] ?? { has_words: 0, is_uploaded: 0 };
 }
 
 export async function deleteProcessedAudioForRetention(
@@ -80,7 +98,8 @@ export async function deleteProcessedAudioForRetention(
     return false;
   }
 
-  if (!(await sessionHasTranscriptWords(sessionId))) {
+  const state = await getSessionAudioRetentionState(sessionId);
+  if (state.is_uploaded === 1 || state.has_words !== 1) {
     return false;
   }
 
@@ -111,6 +130,7 @@ export async function cleanupExpiredAudio(
     id: string;
     created_at: string;
     has_words: number;
+    is_uploaded: number;
   }>(`
     SELECT
       session.id,
@@ -122,13 +142,33 @@ export async function cleanupExpiredAudio(
           AND transcript.deleted_at IS NULL
           AND json_valid(transcript.words_json)
           AND json_array_length(transcript.words_json) > 0
-      ) AS has_words
+      ) AS has_words,
+      EXISTS(
+        SELECT 1
+        FROM session_attachments AS attachment
+        WHERE attachment.session_id = session.id
+          AND attachment.source_type = 'session_audio'
+          AND attachment.source_id = 'primary'
+          AND attachment.deleted_at IS NULL
+          AND json_extract(
+            CASE
+              WHEN json_valid(attachment.metadata_json)
+                THEN attachment.metadata_json
+              ELSE '{}'
+            END,
+            '$.audio_origin'
+          ) = 'uploaded'
+      ) AS is_uploaded
     FROM sessions AS session
     WHERE session.deleted_at IS NULL
     ORDER BY session.created_at, session.id
   `);
 
   for (const session of sessions) {
+    if (session.is_uploaded === 1) {
+      continue;
+    }
+
     if (!isSessionAudioIdle(session.id)) {
       continue;
     }

--- a/apps/desktop/src/session/attachments.test.ts
+++ b/apps/desktop/src/session/attachments.test.ts
@@ -213,7 +213,7 @@ describe("attachment catalog", () => {
   });
 
   it("catalogs primary audio with a stable logical identity and root-relative path", async () => {
-    await catalogLocalSessionAudio("session-1");
+    await catalogLocalSessionAudio("session-1", "recorded");
 
     expect(mocks.audioMetadata).toHaveBeenCalledWith("session-1");
     const statements = mocks.executeTransaction.mock.calls[0]![0];
@@ -230,6 +230,7 @@ describe("attachment catalog", () => {
       "audio/mpeg",
       84,
       "d".repeat(64),
+      "recorded",
       "session-1",
       "session-audio:session-1",
     ]);
@@ -249,7 +250,7 @@ describe("attachment catalog", () => {
       },
     });
 
-    await catalogLocalSessionAudio("session-1");
+    await catalogLocalSessionAudio("session-1", "uploaded");
 
     const update = mocks.executeTransaction.mock.calls[0]![0][1];
     expect(update.params).toEqual([
@@ -262,10 +263,12 @@ describe("attachment catalog", () => {
       "e".repeat(64),
       128,
       "e".repeat(64),
+      "uploaded",
       "session-audio:session-1",
       "session-1",
       "session-1",
     ]);
+    expect(update.sql).toContain("'$.audio_origin'");
   });
 
   it("keeps canonical metadata when retention deletes only local audio bytes", async () => {

--- a/apps/desktop/src/session/attachments.ts
+++ b/apps/desktop/src/session/attachments.ts
@@ -195,6 +195,7 @@ export async function catalogLocalNoteAttachment(input: {
 
 export async function catalogLocalSessionAudio(
   inputSessionId: string,
+  audioOrigin: "recorded" | "uploaded",
 ): Promise<void> {
   const sessionId = requireText(inputSessionId, "session ID", 512);
   await enqueueDatabaseWrite(`session:${sessionId}`, async () => {
@@ -255,6 +256,14 @@ export async function catalogLocalSessionAudio(
             sha256 = ?,
             source_type = 'session_audio',
             source_id = 'primary',
+            metadata_json = json_set(
+              CASE
+                WHEN json_valid(metadata_json) THEN metadata_json
+                ELSE '{}'
+              END,
+              '$.audio_origin',
+              ?
+            ),
             updated_at = strftime('%Y-%m-%dT%H:%M:%fZ', 'now'),
             deleted_at = NULL
           WHERE id = ?
@@ -276,6 +285,7 @@ export async function catalogLocalSessionAudio(
           result.data.sha256,
           result.data.sizeBytes,
           result.data.sha256,
+          audioOrigin,
           attachmentId,
           sessionId,
           sessionId,
@@ -311,7 +321,7 @@ export async function catalogLocalSessionAudio(
             '',
             'session_audio',
             'primary',
-            '{}'
+            json_object('audio_origin', ?)
           FROM sessions AS session
           WHERE session.id = ?
             AND session.deleted_at IS NULL
@@ -328,6 +338,7 @@ export async function catalogLocalSessionAudio(
           contentType,
           result.data.sizeBytes,
           result.data.sha256,
+          audioOrigin,
           sessionId,
           attachmentId,
         ],

--- a/apps/desktop/src/session/components/note-input/header.test.tsx
+++ b/apps/desktop/src/session/components/note-input/header.test.tsx
@@ -22,6 +22,7 @@ type CapturedMenuItem =
 const hoisted = vi.hoisted(() => ({
   enhance: vi.fn(),
   regenerateTranscript: vi.fn(),
+  uploadAudio: vi.fn(),
   startListening: vi.fn(),
   stopListening: vi.fn(),
   stopTranscription: vi.fn(),
@@ -192,6 +193,10 @@ vi.mock("~/session/queries", () => ({
 
 vi.mock("~/session/components/note-input/transcript/actions", () => ({
   useRegenerateTranscript: () => hoisted.regenerateTranscript,
+}));
+
+vi.mock("~/stt/useUploadFile", () => ({
+  useUploadFile: () => ({ uploadAudio: hoisted.uploadAudio }),
 }));
 
 vi.mock("~/session/components/note-input/transcript/export-data", () => ({
@@ -559,7 +564,7 @@ describe("Header", () => {
     expect(hoisted.transcriptRenderDataCalls).toBe(1);
   });
 
-  it("omits transcript recording actions when recording is missing", () => {
+  it("offers audio upload for re-transcription when recording is missing", () => {
     hoisted.audioExists = false;
     const editorTabs: EditorView[] = [
       { type: "enhanced", id: "note-1" },
@@ -580,7 +585,16 @@ describe("Header", () => {
 
     expect(
       menu.map((item) => ("text" in item ? item.text : "separator")),
-    ).toEqual(["Copy"]);
+    ).toEqual(["Copy", "Upload audio to re-transcribe"]);
+
+    menu
+      .find(
+        (item): item is Extract<CapturedMenuItem, { id: string }> =>
+          "id" in item && item.id === "regenerate-transcript-session-1",
+      )
+      ?.action();
+
+    expect(hoisted.uploadAudio).toHaveBeenCalledTimes(1);
   });
 
   it("replaces the current enhanced note when changing templates", async () => {

--- a/apps/desktop/src/session/components/note-input/header.tsx
+++ b/apps/desktop/src/session/components/note-input/header.tsx
@@ -51,6 +51,7 @@ import { createTaskId } from "~/store/zustand/ai-task/task-configs";
 import { type Tab, useTabs } from "~/store/zustand/tabs";
 import { type EditorView } from "~/store/zustand/tabs/schema";
 import { useListener } from "~/stt/contexts";
+import { useUploadFile } from "~/stt/useUploadFile";
 import {
   filterWebTemplatesAgainstUserTemplates,
   DEFAULT_TEMPLATE_ICON,
@@ -746,6 +747,7 @@ function HeaderViewTranscriptActive({
   };
 }) {
   const regenerate = useRegenerateTranscript(sessionId);
+  const { uploadAudio } = useUploadFile(sessionId);
   const { request: transcriptExportRequest } =
     useSessionTranscriptRenderData(sessionId);
   const { audioExists, deleteRecording, isDeletingRecording } =
@@ -789,14 +791,19 @@ function HeaderViewTranscriptActive({
       },
     ];
 
-    if (audioExists) {
-      items.push({
-        id: `regenerate-transcript-${sessionId}`,
-        text: "Re-transcribe",
-        action: () => {
+    items.push({
+      id: `regenerate-transcript-${sessionId}`,
+      text: audioExists ? "Re-transcribe" : "Upload audio to re-transcribe",
+      action: () => {
+        if (audioExists) {
           void regenerate();
-        },
-      });
+        } else {
+          uploadAudio();
+        }
+      },
+    });
+
+    if (audioExists) {
       items.push({
         id: `delete-recording-${sessionId}`,
         text: "Delete recording",
@@ -814,6 +821,7 @@ function HeaderViewTranscriptActive({
     isDeletingRecording,
     regenerate,
     sessionId,
+    uploadAudio,
   ]);
   const showContextMenu = useNativeContextMenu(contextMenu);
 

--- a/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.test.tsx
@@ -165,7 +165,7 @@ describe("OverflowButton", () => {
     expect(uploadTranscriptMock).toHaveBeenCalledTimes(1);
   });
 
-  it("hides upload actions when the session already has a transcript", () => {
+  it("offers audio upload for re-transcription when recording is missing", () => {
     render(
       <OverflowButton
         sessionId="session-1"
@@ -177,12 +177,19 @@ describe("OverflowButton", () => {
     expect(
       screen.queryByRole("button", { name: "Upload transcript" }),
     ).toBeNull();
+    fireEvent.click(
+      screen.getByRole("button", { name: "Upload audio to re-transcribe" }),
+    );
     expect(
       screen.getByRole("button", { name: "Resume listening" }),
     ).not.toBeNull();
+    expect(uploadAudioMock).toHaveBeenCalledTimes(1);
   });
 
   it("renders one separator when meeting actions are disabled", () => {
+    useHasTranscriptMock.mockReturnValue(false);
+    currentNoteContent.value = "Existing content";
+
     const { container } = render(
       <OverflowButton
         allowListening={false}

--- a/apps/desktop/src/session/components/outer-header/overflow/index.tsx
+++ b/apps/desktop/src/session/components/outer-header/overflow/index.tsx
@@ -66,7 +66,8 @@ export function OverflowButton({
     sessionMode === "active" || sessionMode === "finalizing";
   const isRetranscribing = sessionMode === "running_batch";
   const showListeningAction = allowListening;
-  const showRetranscribeAction = audioExists && !isMeetingInProgress;
+  const showRetranscribeAction =
+    (audioExists || hasTranscript) && !isMeetingInProgress;
   const showUploadActions =
     !audioExists &&
     !hasTranscript &&
@@ -94,7 +95,11 @@ export function OverflowButton({
   };
   const handleRetranscribe = () => {
     setOpen(false);
-    void regenerateTranscript();
+    if (audioExists) {
+      void regenerateTranscript();
+    } else {
+      uploadAudio();
+    }
   };
   const handleOpenFloatingPanel = () => {
     setOpen(false);
@@ -146,7 +151,11 @@ export function OverflowButton({
                 className="cursor-pointer"
               >
                 <RefreshCwIcon />
-                <span>Re-transcribe</span>
+                <span>
+                  {audioExists
+                    ? "Re-transcribe"
+                    : "Upload audio to re-transcribe"}
+                </span>
               </DropdownMenuItem>
             )}
             {showUploadActions && (

--- a/apps/desktop/src/stt/useStartListening.test.ts
+++ b/apps/desktop/src/stt/useStartListening.test.ts
@@ -379,7 +379,10 @@ describe("useStartListening", () => {
     });
 
     expect(runBatchMock).toHaveBeenCalledWith("/tmp/session.wav");
-    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith(
+      "session-1",
+      "recorded",
+    );
     expect(
       catalogLocalSessionAudioMock.mock.invocationCallOrder[0],
     ).toBeLessThan(runBatchMock.mock.invocationCallOrder[0]!);
@@ -449,7 +452,10 @@ describe("useStartListening", () => {
       });
     });
 
-    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith(
+      "session-1",
+      "recorded",
+    );
     expect(runBatchMock).not.toHaveBeenCalled();
     consoleError.mockRestore();
   });
@@ -483,7 +489,10 @@ describe("useStartListening", () => {
     releaseBlocker?.();
     await blocker;
     await act(async () => await stopped);
-    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith(
+      "session-1",
+      "recorded",
+    );
   });
 
   test("cleans up processed audio after live capture stops", async () => {

--- a/apps/desktop/src/stt/useStartListening.ts
+++ b/apps/desktop/src/stt/useStartListening.ts
@@ -308,7 +308,7 @@ export function useStartListening(sessionId: string) {
       if (details.audioPath) {
         try {
           await enqueueSessionAudioOperation(sessionId, () =>
-            catalogLocalSessionAudio(sessionId),
+            catalogLocalSessionAudio(sessionId, "recorded"),
           );
         } catch (error) {
           console.error("[listener] failed to catalog recorded audio", error);

--- a/apps/desktop/src/stt/useUploadFile.test.tsx
+++ b/apps/desktop/src/stt/useUploadFile.test.tsx
@@ -176,7 +176,10 @@ describe("useUploadFile", () => {
     expect(runBatchMock).toHaveBeenCalledWith(
       "/vault/sessions/session-1/audio.wav",
     );
-    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith("session-1");
+    expect(catalogLocalSessionAudioMock).toHaveBeenCalledWith(
+      "session-1",
+      "uploaded",
+    );
     expect(audioImportDataMock.mock.invocationCallOrder[0]).toBeLessThan(
       catalogLocalSessionAudioMock.mock.invocationCallOrder[0]!,
     );

--- a/apps/desktop/src/stt/useUploadFile.ts
+++ b/apps/desktop/src/stt/useUploadFile.ts
@@ -175,7 +175,7 @@ export function useUploadFile(sessionId: string) {
             throw new Error(result.error);
           }
           try {
-            await catalogLocalSessionAudio(sessionId);
+            await catalogLocalSessionAudio(sessionId, "uploaded");
           } catch (error) {
             console.error("[upload] failed to catalog imported audio", error);
           }


### PR DESCRIPTION
## Summary

- Offer an audio upload action when a transcript exists but its local recording is missing.
- Track whether session audio was recorded or explicitly uploaded and keep uploaded source audio outside automatic retention cleanup.
- Reuse the normal transcription flow after replacement audio is selected from either transcript action surface.
- Preserve attachment identity and metadata across re-cataloging.

## Validation

- Focused desktop suite: 6 files, 110 tests.
- Dprint check on all changed desktop files.
- Full synthesized desktop suite: 244 files, 1,746 tests.
